### PR TITLE
docs: add DEVELOPMENT.md development lifecycle guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 Guidance for coding agents (Codex, Rovo Dev). The canonical project doc —
 architecture, layout, commands, and data conventions — is **[README.md](README.md)**.
-Game rules are in **[GAME_RULE.md](GAME_RULE.md)**. Read both before making changes.
+Game rules are in **[GAME_RULE.md](GAME_RULE.md)**. The development lifecycle
+(plan → implement → validate, and which tests to run per workspace) is in
+**[DEVELOPMENT.md](DEVELOPMENT.md)**. Read all three before making changes.
 
 Directory-scoped notes extend this for their subtree:
 `web/AGENTS.md` (React app), `image_extraction/.agent.md` (PaddleOCR/venv).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,12 @@
 # CLAUDE.md
 
-The canonical project doc is `README.md`; game rules are in `GAME_RULE.md`.
-Both are imported below so they load automatically:
+The canonical project doc is `README.md`; game rules are in `GAME_RULE.md`;
+the development lifecycle (plan → implement → validate, and which tests to run
+per workspace) is in `DEVELOPMENT.md`. All three are imported below so they load
+automatically:
 
 @README.md
 
 @GAME_RULE.md
+
+@DEVELOPMENT.md

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,74 @@
+# Development Lifecycle
+
+How a change moves from an idea to a merged PR in this repo, and — because this
+is a multi-workspace monorepo — **which tests an agent should actually run**. See
+[README.md](README.md) for project orientation and [GAME_RULE.md](GAME_RULE.md)
+for the game rules.
+
+## The lifecycle
+
+Every non-trivial change follows the same five steps. Steps 1–3 happen in the
+working tree; steps 4–5 go through the `no-mistakes` gate.
+
+1. **Requirement.** Start from what the user wants to accomplish — the goal, not a
+   diff. Capture it in the user's own words; it becomes the `--intent` later.
+
+2. **Discuss & plan (`lavish`).** Turn the proposed approach into a reviewable
+   artifact with the **`lavish`** skill (installed at `~/.claude/skills/lavish`)
+   and share it: the plan, trade-offs, affected files, and the tests you intend to
+   run. Iterate on the artifact until the user **explicitly approves**.
+   **Do not start implementing before approval.**
+
+3. **Implement.** Create a feature branch (never work on `master`), make the
+   change, and run the **scoped tests** for the area you touched (see
+   [Scope tests to the changed workspace](#scope-tests-to-the-changed-workspace)).
+   Commit on the feature branch.
+
+4. **Validate with `no-mistakes`.** Drive the gate — `/no-mistakes` in Claude
+   Code, or `no-mistakes axi run --intent "<the requirement from step 1>"`. The
+   pipeline runs *review → test → document → lint → push → PR → CI* and opens a PR
+   only after every step passes. See [no-mistakes and the test
+   step](#no-mistakes-and-the-test-step) for how scoping applies here.
+
+5. **Merge.** The gate stops at `checks-passed` (PR ready, CI green) and leaves the
+   merge to the user. Review the PR and merge it.
+
+## Scope tests to the changed workspace
+
+This repo is a **uv workspace + a React app**, and the workspaces are independent.
+**Run only the tests for the area you changed.** A web-only change must not drag in
+the heavy PaddleOCR Python suite, and a Python change does not need the React
+tests. Match the changed paths to the smallest test set that covers them:
+
+| Changed paths | Tests to run |
+|---|---|
+| `web/**` (source under `web/src/`) | **Web unit tests** (Jest): `cd web && CI=true npx react-scripts test --watchAll=false` |
+| `web/**` that changes UI flow / rendered behavior | The unit tests above **and** the **e2e tests** (Playwright): `cd web && npx playwright test` (first time: `npx playwright install`) |
+| `image_extraction/**` | **Python tests**: `make test` (runs `uv run pytest image_extraction/`; needs `make sync` first if deps aren't installed — loads PaddleOCR, ~40s) |
+| `data/**` (`export_battle_stats.py`, `remove_duplicate_battles.py`) | No unit tests. Validate by running the script — e.g. `make export-stats` — and confirming `web/src/battle_stats.json` regenerates and the web app still loads. |
+| `study-battle-report/**` | No automated tests. Validate with a manual OCR run: `uv run python study-battle-report/ocr_battle_log.py [<id>] --use-cache`. |
+| `learn/**`, `autojs/**`, `bilibili/**`, `research/**` | No tests — nothing to run. |
+| Docs only (`*.md`, `README`, this file) | No tests — nothing to run. |
+
+Notes:
+- When a change spans more than one workspace, run each affected workspace's tests.
+- Fresh checkouts have no installed deps: web tests need `npm ci` (or `npm install`)
+  in `web/`; Python tests need `make sync`.
+- The canonical commands live in the [README `Commands`](README.md#commands)
+  section and the `Makefile` — prefer them over ad-hoc invocations.
+
+## no-mistakes and the test step
+
+The `no-mistakes` gate has its own **test** step, and the same scoping rule
+applies there — it should exercise only the changed workspace:
+
+- **Skip the test step entirely** when the change touches only areas with no tests
+  (docs, `autojs/`, `learn/`, etc.):
+  `no-mistakes axi run --intent "..." --skip=test`.
+- **Otherwise let the test step run**, and rely on this document (surfaced to the
+  gate's test agent via `CLAUDE.md`) plus a clear `--intent` so it picks the
+  workspace-appropriate tests rather than the full suite. For example, for a
+  `web/`-only change the test step should run the web Jest tests, not `make test`.
+- A precise `--intent` (the requirement from step 1, enriched with the decisions
+  you made) is what lets the review and test steps tell a deliberate choice apart
+  from a mistake — keep it complete, not a one-line diff summary.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,7 +47,7 @@ tests. Match the changed paths to the smallest test set that covers them:
 | `image_extraction/**` | **Python tests**: `make test` (runs `uv run pytest image_extraction/`; needs `make sync` first if deps aren't installed — loads PaddleOCR, ~40s) |
 | `data/**` (`export_battle_stats.py`, `remove_duplicate_battles.py`) | No unit tests. Validate by running the script — e.g. `make export-stats` — and confirming `web/src/battle_stats.json` regenerates and the web app still loads. |
 | `study-battle-report/**` | No automated tests. Validate with a manual OCR run: `uv run python study-battle-report/ocr_battle_log.py [<id>] --use-cache`. |
-| `learn/**`, `autojs/**`, `bilibili/**`, `research/**` | No tests — nothing to run. |
+| `learn/**`, `autojs/**`, `research/**` | No tests — nothing to run. |
 | Docs only (`*.md`, `README`, this file) | No tests — nothing to run. |
 
 Notes:


### PR DESCRIPTION
## Intent

Add DEVELOPMENT.md documenting the repo's development lifecycle: a change starts from a requirement, is discussed/planned with the lavish skill until the user approves, then implemented, then validated through the no-mistakes gate. Because this is a multi-workspace monorepo (uv workspace + a React app), the doc's central rule is that agents run only the tests for the changed workspace (e.g. web-only changes run the web Jest/Playwright tests, not the heavy PaddleOCR Python suite), with a paths->tests mapping table. Also import DEVELOPMENT.md from CLAUDE.md alongside README.md and GAME_RULE.md so it auto-loads for coding agents including the no-mistakes gate's test step. This is a docs-only change (DEVELOPMENT.md added, CLAUDE.md import line added); the test step is intentionally skipped via --skip=test because no code or testable workspace is touched. The resulting PR is for the user to review and merge.

## What Changed

- Added `DEVELOPMENT.md` documenting the five-step change lifecycle (requirement → plan with `lavish` → implement → validate via the `no-mistakes` gate → merge), with a paths→tests mapping table enforcing the rule that agents run only the changed workspace's tests (e.g. web-only changes run the web Jest/Playwright suites, not the PaddleOCR Python tests) and how that scoping applies to the gate's test step.
- Updated `CLAUDE.md` to import `DEVELOPMENT.md` alongside `README.md` and `GAME_RULE.md` so it auto-loads for coding agents.
- Updated `AGENTS.md` to reference the new `DEVELOPMENT.md`.

## Risk Assessment

✅ Low: Docs-only change (new DEVELOPMENT.md + one CLAUDE.md import line) whose referenced paths, Makefile targets, and test commands all verified accurate against the repo; the only prior finding was already fixed.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `DEVELOPMENT.md:50` - The no-tests table row lists `bilibili/` as a workspace, but there is no `bilibili/` directory in the repo (top-level dirs are autojs, data, image_extraction, learn, research, study-battle-report, web). Listing a non-existent path alongside real ones (`learn/`, `autojs/`, `research/`) is misleading; either drop `bilibili/` or note it&#39;s a future/optional path.

🔧 Fix: remove nonexistent bilibili/ path from DEVELOPMENT.md test table
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
