### PR TITLE
test(web): pin real recommendation scores in characterization golden tests

### DIFF
--- a/web/src/services/__tests__/__snapshots__/recommendationEngine.characterization.test.ts.snap
+++ b/web/src/services/__tests__/__snapshots__/recommendationEngine.characterization.test.ts.snap
@@ -29,7 +29,7 @@ exports[`recommendHeroSet is stable 1`] = `
 exports[`recommendSingleHero is stable 1`] = `
 {
   "hero": "姜维",
-  "score": undefined,
+  "score": 55.4168375,
 }
 `;
 
@@ -334,7 +334,7 @@ exports[`recommendTeams is stable 1`] = `
 
 exports[`recommendTwoSkills is stable 1`] = `
 {
-  "score": undefined,
+  "score": 45.191208712000005,
   "skills": [
     "锐不可当",
     "折冲御侮",

--- a/web/src/services/__tests__/__snapshots__/recommendationEngine.characterization.test.ts.snap
+++ b/web/src/services/__tests__/__snapshots__/recommendationEngine.characterization.test.ts.snap
@@ -7,21 +7,21 @@ exports[`recommendHeroSet is stable 1`] = `
       "祝融",
       "孟获",
     ],
-    "score": undefined,
+    "score": 40.2939977611375,
   },
   {
     "heroes": [
       "司马懿",
       "姜维",
     ],
-    "score": undefined,
+    "score": 36.144444651449994,
   },
   {
     "heroes": [
       "诸葛亮2",
       "张宁",
     ],
-    "score": undefined,
+    "score": 28.353405732225,
   },
 ]
 `;
@@ -36,21 +36,21 @@ exports[`recommendSingleHero is stable 1`] = `
 exports[`recommendSkillSet is stable 1`] = `
 [
   {
-    "score": undefined,
+    "score": 42.078295,
     "skills": [
       "折冲御侮",
       "胜敌益强",
     ],
   },
   {
-    "score": undefined,
+    "score": 43.2139,
     "skills": [
       "避其锐气",
       "明其虚实",
     ],
   },
   {
-    "score": undefined,
+    "score": 44.230631098399996,
     "skills": [
       "锐不可当",
       "料事如神",

--- a/web/src/services/__tests__/recommendationEngine.characterization.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.characterization.test.ts
@@ -42,12 +42,12 @@ test('recommendSkillSet is stable', () => {
 
 test('recommendSingleHero is stable', () => {
   const result = recommendSingleHero(['祝融', '司马懿', '姜维'], ['皇甫嵩2', '袁术'], SKILL_POOL.slice(0, 4), battleStats) as any;
-  expect({ hero: result.hero, score: result.score }).toMatchSnapshot();
+  expect({ hero: result.hero, score: result.analysis[0]?.finalScore }).toMatchSnapshot();
 });
 
 test('recommendTwoSkills is stable', () => {
   const result = recommendTwoSkills(SKILL_POOL.slice(0, 6), ['皇甫嵩2', '袁术'], SKILL_POOL.slice(6, 10), battleStats) as any;
-  expect({ skills: result.skills, score: result.score }).toMatchSnapshot();
+  expect({ skills: result.skills, score: result.analysis[0]?.finalScore }).toMatchSnapshot();
 });
 
 test('recommendTeams is stable', () => {

--- a/web/src/services/__tests__/recommendationEngine.characterization.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.characterization.test.ts
@@ -26,20 +26,18 @@ test('recommendHeroSet is stable', () => {
     battleStats,
     []
   );
-  expect(result.analysis.map(a => ({ heroes: a.heroes, score: a.total_score }))).toMatchSnapshot();
+  expect(result.analysis.map(a => ({ heroes: a.heroes, score: a.final_score }))).toMatchSnapshot();
 });
 
 test('recommendSkillSet is stable', () => {
-  // NOTE: argument order here (battleStats 3rd, [] 4th) is preserved exactly as
-  // written to keep the golden snapshot byte-identical; cast past the typed
-  // signature rather than "fixing" the order (which would change output).
-  const result = (recommendSkillSet as any)(
+  // Signature: (availableSets, currentHeroes, currentSkills, battleStats).
+  const result = recommendSkillSet(
     [['折冲御侮', '胜敌益强'], ['避其锐气', '明其虚实'], ['锐不可当', '料事如神']],
     ['皇甫嵩2', '袁术'],
-    battleStats,
-    []
+    [],
+    battleStats
   );
-  expect(result.analysis.map((a: any) => ({ skills: a.skills, score: a.total_score }))).toMatchSnapshot();
+  expect(result.analysis.map((a: any) => ({ skills: a.skills, score: a.final_score }))).toMatchSnapshot();
 });
 
 test('recommendSingleHero is stable', () => {


### PR DESCRIPTION
## Intent

Fix the recommendationEngine characterization golden tests, which the TS migration revealed were not actually guarding recommendation scores. Two coupled test-only bugs: (1) the recommendSkillSet stable test passed arguments in the wrong order — recommendSkillSet signature is availableSets, currentHeroes, currentSkills, battleStats, but the test put battleStats in the currentSkills slot and an empty array in the battleStats slot (it was copied from recommendHeroSet whose signature differs), so it ran the engine with empty stats; corrected the order. (2) Both hero-set and skill-set characterization tests projected a.total_score, a field that does not exist on the analysis elements — the real field is final_score — so every pinned score value was undefined; switched the projection to final_score. Re-pinned the snapshot: it now records real recommendation scores (hero 40.3/36.1/28.4, skill 42.1/43.2/44.2) instead of undefined. This is a TEST-ONLY change (one .test.ts file plus its .snap); NO production/source code changed. The snapshot change is intentional and reviewed — it makes the golden tests meaningful. This is a web/-only change: the test step must run the WEB checks (npm run typecheck, npx vitest run) and must NOT run the Python/PaddleOCR suite (make test).

## What Changed

- Fixed the `recommendSkillSet` stable characterization test, which passed arguments in the wrong order (copied from `recommendHeroSet`, whose signature differs) — `battleStats` landed in the `currentSkills` slot and an empty array in the `battleStats` slot, so the engine ran against empty stats; corrected to `availableSets, currentHeroes, currentSkills, battleStats`.
- Switched the hero-set/skill-set score projection from the nonexistent `total_score` field to the real `final_score`, and re-pinned the `.snap` so it records actual recommendation scores (hero 40.3/36.1/28.4, skill 42.1/43.2/44.2) instead of `undefined`.
- Also re-pinned the sibling `recommendSingleHero`/`recommendTwoSkills` snapshots to project `analysis[0].finalScore` so they guard a real score rather than `undefined` (review auto-fix).

## Risk Assessment

✅ Low: Test-only change that corrects a wrong argument order and swaps nonexistent projection fields (total_score/score) for the real ones (final_score/analysis[0].finalScore), verified against the engine; snapshots re-pinned to real scores with no production code touched.

## Testing

Scoped to the web workspace per the intent (no Python/PaddleOCR suite run). Ran the web typecheck (clean) and the full Vitest suite (41/41 pass) — the shell's default Node 20.15.1 couldn't load the vite 8 / vitest 4 config (require(ESM) unsupported), so I used the machine's Node 22.17.1, a setup fix not a product issue. The four re-pinned characterization tests pass and now record real recommendation scores (hero 40.3/36.1/28.4, skill 42.1/43.2/44.2, single-hero 55.4, two-skills 45.2) matching the intent. To prove the fix is meaningful — not just green — I mutated a pinned score and confirmed the test now fails, whereas before the fix it compared undefined to undefined and guarded nothing; then restored the pristine snapshot and re-confirmed a clean pass. Evidence is a CLI transcript rather than a screenshot because this is a test-logic/data change with no rendered UI surface.

<details>
<summary>Evidence: Characterization test run + real pinned scores</summary>

<code>✓ recommendHeroSet/recommendSkillSet/recommendSingleHero/recommendTwoSkills/recommendTeams — 5 passed&#10;Real scores now pinned (were all `undefined`): hero 40.29/36.14/28.35, skill 42.08/43.21/44.23, single-hero 55.42, two-skills 45.19</code>

```text
### recommendationEngine characterization tests — verbose run (Node v22.17.1)
 ✓ src/services/__tests__/recommendationEngine.characterization.test.ts > recommendHeroSet is stable 2ms
 ✓ src/services/__tests__/recommendationEngine.characterization.test.ts > recommendSkillSet is stable 0ms
 ✓ src/services/__tests__/recommendationEngine.characterization.test.ts > recommendSingleHero is stable 0ms
 ✓ src/services/__tests__/recommendationEngine.characterization.test.ts > recommendTwoSkills is stable 0ms
 ✓ src/services/__tests__/recommendationEngine.characterization.test.ts > recommendTeams is stable 1ms
 Test Files  1 passed (1)
      Tests  5 passed (5)

### Real recommendation scores now pinned in the golden snapshot
(previously every value was 'undefined' — the tests guarded nothing)
exports[`recommendHeroSet is stable 1`] = `
    "score": 40.2939977611375,
    "score": 36.144444651449994,
    "score": 28.353405732225,
exports[`recommendSingleHero is stable 1`] = `
  "score": 55.4168375,
exports[`recommendSkillSet is stable 1`] = `
    "score": 42.078295,
    "score": 43.2139,
    "score": 44.230631098399996,
exports[`recommendTeams is stable 1`] = `
            "score": 0.624579,
            "score": 0.58288,
            "score": 0.656307,
            "score": 0.627952,
            "score": 0.724789,
            "score": 0.630032,
            "score": 0.552267,
            "score": 0.319507,
            "score": 0.721704,
            "score": 0.681327,
            "score": 0.671998,
            "score": 0.595844,
            "score": 0.207655,
            "score": 0.206543,
            "score": 0.351993,
            "score": 0.309387,
            "score": 0.245145,
            "score": 0,
exports[`recommendTwoSkills is stable 1`] = `
  "score": 45.191208712000005,
```
</details>
<details>
<summary>Evidence: Guard-bites mutation demonstration</summary>

```text
After 40.2939977611375 -> 99.9999 in snapshot: `× recommendHeroSet is stable` — Snapshot mismatched, 1 failed. After restore: 5 passed. Confirms the test now meaningfully guards recommendation scores.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `web/src/services/__tests__/recommendationEngine.characterization.test.ts:45` - The two sibling characterization tests in the same file — recommendSingleHero (test line 45) and recommendTwoSkills (test line 50) — still project `result.score`, but those functions return `{ hero, analysis }` / `{ skills, analysis }` with NO top-level `score` field. So their snapshots pin `&#34;score&#34;: undefined` (snap lines 32 and 337) and do not guard any recommendation score — the exact defect this PR set out to remove for the hero-set/skill-set tests. To make them meaningful they should project the top candidate&#39;s score, e.g. `result.analysis[0].finalScore`, and the snapshot re-pinned. This is a pre-existing weakness (outside the diff) but leaves the stated goal (&#39;make the golden tests meaningful&#39;) only half done.

🔧 Fix: pin real finalScore in single-hero/two-skills characterization tests
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; npm run typecheck` (Go-native tsc) — clean</code>
- <code>`npx vitest run` — full web suite, 8 files / 41 tests pass (Node 22.17.1)</code>
- <code>`npx vitest run src/services/__tests__/recommendationEngine.characterization.test.ts --reporter=verbose` — all 5 characterization tests pass against the re-pinned real scores</code>
- <code>Mutation check: perturbed one pinned score (40.29→99.99) in the snapshot and confirmed `recommendHeroSet is stable` FAILS, proving the guard now bites (previously undefined==undefined passed for any output); restored the snapshot and re-ran to confirm clean</code>
- <code>Verified `git status --porcelain` is clean after the mutation test — no transient artifacts left</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
