### PR TITLE
feat(web): redesign UI with ink-and-paper command-table theme

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -82,7 +82,7 @@ web/
 │   ├── hooks/           # Custom React hooks (usePinyin)
 │   ├── pages/           # Page components (GameAdvisor, Analytics, etc.)
 │   ├── services/        # In-memory api shim and game logic (TypeScript)
-│   ├── theme/           # MUI theme configuration
+│   ├── theme/           # Custom 墨策台 MUI theme configuration
 │   ├── types/           # Hand-written domain/battle-stats/game-state types
 │   ├── utils/           # Utility functions (storage, tiers, clipboard)
 │   ├── data.ts          # Typed JSON boundary (imports/casts the bundled data)
@@ -164,7 +164,9 @@ Deployed as a static site to Cloudflare Pages. `npm run build` produces the
 Chinese hero and skill names can be searched using pinyin romanization for easier input.
 
 ### MUI Theme
-Uses Material-UI's default theme for consistency and accessibility.
+Uses a custom **墨策台** ("ink-strategy desk") theme in `src/theme/theme.ts` — a
+warm rice-paper, smoky-ink, muted-jade, and seal-red editorial palette with Songti
+serif headings, layered over MUI's component library.
 
 ## Troubleshooting
 

--- a/web/index.html
+++ b/web/index.html
@@ -8,11 +8,11 @@
     <meta name="theme-color" content="#17221e" />
     <meta
       name="description"
-      content="墨策台是一款三国谋定天下演武策略助手，基于战斗统计数据推荐武将、战法与队伍组合。"
+      content="三国谋定天下演武参谋，基于战斗统计数据推荐武将、战法与队伍组合。"
     />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>墨策台 · 三国谋定天下演武参谋</title>
+    <title>三国谋定天下演武参谋</title>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-TT628MS0J2"></script>
     <script>

--- a/web/index.html
+++ b/web/index.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="alternate icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#4a90e2" />
+    <meta name="theme-color" content="#17221e" />
     <meta
       name="description"
-      content="三谋演武助手是一款AI-powered游戏策略助手，基于战斗统计数据为玩家提供智能的武将和战法推荐。"
+      content="墨策台是一款三国谋定天下演武策略助手，基于战斗统计数据推荐武将、战法与队伍组合。"
     />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>三谋演武助手</title>
+    <title>墨策台 · 三国谋定天下演武参谋</title>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-TT628MS0J2"></script>
     <script>

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "三谋演武助手",
-  "name": "三谋演武助手",
+  "short_name": "墨策台",
+  "name": "墨策台 · 三国谋定天下演武参谋",
   "icons": [
     {
       "src": "favicon.ico",
@@ -20,6 +20,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#17221e",
+  "background_color": "#f3efe3"
 }

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "墨策台",
-  "name": "墨策台 · 三国谋定天下演武参谋",
+  "short_name": "演武参谋",
+  "name": "三国谋定天下演武参谋",
   "icons": [
     {
       "src": "favicon.ico",

--- a/web/src/components/common/AutocompleteInput.tsx
+++ b/web/src/components/common/AutocompleteInput.tsx
@@ -79,7 +79,7 @@ const AutocompleteInput = ({
           <Box component="li" key={key} {...otherProps}>
             <span style={{ fontWeight: 'bold' }}>{displayText}</span>
             {showPinyin && (
-              <span style={{ marginLeft: 8, fontSize: '0.85rem', color: '#718096' }}>
+              <span style={{ marginLeft: 8, fontSize: '0.85rem', color: '#667069' }}>
                 ({py})
               </span>
             )}
@@ -93,7 +93,7 @@ const AutocompleteInput = ({
           placeholder={placeholder}
           variant="outlined"
           fullWidth
-          sx={{ minWidth: 250 }}
+          sx={{ minWidth: { xs: '100%', sm: 250 } }}
         />
       )}
       noOptionsText={inputValue ? "无匹配结果" : "请输入..."}

--- a/web/src/components/common/TagList.tsx
+++ b/web/src/components/common/TagList.tsx
@@ -117,9 +117,9 @@ const TagList = ({ items, onRemove, label, color = 'primary', editable = true, s
           gap: 1,
           minHeight: 40,
           p: 1,
-          border: '2px dashed',
+          border: '1px dashed',
           borderColor: 'divider',
-          borderRadius: 2,
+          bgcolor: 'rgba(231,223,204,0.24)',
         }}
       >
         {items.length === 0 ? (

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -55,7 +55,7 @@ const AnalysisGrid = ({
     }
     
     return (
-      <Grid size={{ xs: 12 }} key={setName}>
+      <Grid size={{ xs: 12, md: 4 }} key={setName} data-testid="analysis-set-card">
         <Card 
           sx={{ 
             height: '100%',
@@ -65,9 +65,7 @@ const AnalysisGrid = ({
             position: 'relative',
             bgcolor: isSelected ? 'rgba(223,232,226,0.72)' : isRecommended ? 'rgba(240,229,207,0.4)' : 'background.paper',
             transition: 'transform 160ms ease, background-color 160ms ease',
-            '&:hover': {
-              transform: 'translateX(3px)',
-            }
+            '&:hover': { transform: 'translateY(-3px)' }
           }}
         >
           {/* Reserve space for chips with absolute positioning */}

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -55,16 +55,18 @@ const AnalysisGrid = ({
     }
     
     return (
-      <Grid size={{ xs: 12, sm: 6, md: 4 }} key={setName}>
+      <Grid size={{ xs: 12 }} key={setName}>
         <Card 
           sx={{ 
             height: '100%',
-            border: 3,
+            border: 1,
+            borderLeft: '5px solid',
             borderColor: isSelected ? 'success.main' : isRecommended ? 'warning.main' : 'divider',
             position: 'relative',
-            transition: 'all 0.3s',
+            bgcolor: isSelected ? 'rgba(223,232,226,0.72)' : isRecommended ? 'rgba(240,229,207,0.4)' : 'background.paper',
+            transition: 'transform 160ms ease, background-color 160ms ease',
             '&:hover': {
-              boxShadow: 6,
+              transform: 'translateX(3px)',
             }
           }}
         >
@@ -100,11 +102,13 @@ const AnalysisGrid = ({
           </Box>
           
           <CardContent sx={{ pt: 5 }}>
-            <Typography variant="h6" gutterBottom>
-              第{index + 1}组
-            </Typography>
+            <Box>
+              <Typography variant="overline" color="text.secondary">OPTION {String.fromCharCode(65 + index)}</Typography>
+              <Typography variant="h5" gutterBottom>
+                第{index + 1}组
+              </Typography>
             
-            {setAnalysis?.final_score !== undefined && (
+              {setAnalysis?.final_score !== undefined && (
               <Box sx={{ mb: 2 }}>
                 <Typography variant="h4" color="primary">
                   {setAnalysis.final_score.toFixed(1)}
@@ -113,9 +117,10 @@ const AnalysisGrid = ({
                   综合评分
                 </Typography>
               </Box>
-            )}
+              )}
+            </Box>
             
-            <Box sx={{ mb: 2 }}>
+            <Box sx={{ mb: 2, minWidth: 0 }}>
               <Typography variant="subtitle2" gutterBottom>
                 {roundType === 'hero' ? '武将评分:' : '战法评分:'}
               </Typography>
@@ -329,6 +334,7 @@ const AnalysisGrid = ({
               fullWidth
               onClick={() => onSelectSet(index)}
               startIcon={isSelected ? <CheckCircleIcon /> : null}
+              sx={{ alignSelf: 'center', mt: { xs: 1, lg: 0 } }}
             >
               {isSelected ? '已选' : '选择本组'}
             </Button>
@@ -340,10 +346,13 @@ const AnalysisGrid = ({
   
   return (
     <Box sx={{ mb: 3 }}>
-      <Typography variant="h6" gutterBottom>
-        📊 选项分析
+      <Typography variant="overline" color="error.main">
+        参谋推演
       </Typography>
-      <Grid container spacing={3}>
+      <Typography variant="h5" gutterBottom>
+        选项分析
+      </Typography>
+      <Grid container spacing={1.5}>
         {renderSetCard('set1', 0)}
         {renderSetCard('set2', 1)}
         {renderSetCard('set3', 2)}

--- a/web/src/components/game/CurrentTeam.tsx
+++ b/web/src/components/game/CurrentTeam.tsx
@@ -163,11 +163,6 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
               推荐自选战法
             </Button>
           )}
-          {editable && (!hasSupportHero || !hasSupportSkills) && (
-            <Alert severity="info" variant="outlined" icon={false} sx={{ py: 0, px: 1, fontSize: '0.75rem', '& .MuiAlert-message': { py: 0.5 } }}>
-              尽早添加支援武将和战法，推荐会更准确
-            </Alert>
-          )}
         </Box>
         
         {editable && availableHeroes && availableSkills && onUpdateTeam && (

--- a/web/src/components/game/CurrentTeam.tsx
+++ b/web/src/components/game/CurrentTeam.tsx
@@ -132,12 +132,13 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
   };
 
   return (
-    <Paper sx={{ p: 3, mb: 3 }}>
+    <Paper sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2, flexWrap: 'wrap', gap: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-          <Typography variant="h6">
-            📋 当前队伍
-          </Typography>
+          <Box sx={{ mr: 1 }}>
+            <Typography variant="overline" color="error.main" sx={{ display: 'block', lineHeight: 1.2 }}>CURRENT ROSTER</Typography>
+            <Typography variant="h5">当前阵容</Typography>
+          </Box>
           {heroes.length <= 10 && !hasSupportHero && (
             <Button
               size="small"
@@ -164,7 +165,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
           )}
           {editable && (!hasSupportHero || !hasSupportSkills) && (
             <Alert severity="info" variant="outlined" icon={false} sx={{ py: 0, px: 1, fontSize: '0.75rem', '& .MuiAlert-message': { py: 0.5 } }}>
-              💡 尽早添加您将会支援的武将和战法，推荐算法将据此给出更精准的建议
+              尽早添加支援武将和战法，推荐会更准确
             </Alert>
           )}
         </Box>
@@ -274,7 +275,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
 
       {/* Hero Recommendation Dialog */}
       <Dialog open={heroRecDialog} onClose={() => setHeroRecDialog(false)} maxWidth="sm" fullWidth>
-        <DialogTitle>🎯 推荐支援武将</DialogTitle>
+        <DialogTitle>推荐支援武将</DialogTitle>
         <DialogContent>
           <Box sx={{ mb: 2 }}>
             <Typography variant="subtitle2" gutterBottom>
@@ -354,7 +355,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
 
       {/* Skill Recommendation Dialog */}
       <Dialog open={skillRecDialog} onClose={() => setSkillRecDialog(false)} maxWidth="sm" fullWidth>
-        <DialogTitle>🎯 推荐支援战法</DialogTitle>
+        <DialogTitle>推荐支援战法</DialogTitle>
         <DialogContent>
           <Box sx={{ mb: 2 }}>
             <Typography variant="subtitle2" gutterBottom>

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -65,12 +65,13 @@ const GameBoard = () => {
   // Interstitial page between round 6 and 7 (州内小组赛)
   if (roundNumber === 7 && !gameState.round7_interstitial_dismissed) {
     return (
-      <Container maxWidth="xl">
-        <Box sx={{ py: 4 }}>
+      <Container maxWidth="xl" disableGutters>
+        <Box>
           <RoundInfo roundNumber={7} />
           <Paper sx={{ p: 3, mb: 3, textAlign: "center" }}>
+            <Typography variant="overline" color="error.main">州内小组赛</Typography>
             <Typography variant="h4" gutterBottom sx={{ mb: 3 }}>
-              祝好运!
+              整军再战
             </Typography>
             <CurrentTeam
               heroes={gameState.current_heroes}
@@ -103,10 +104,10 @@ const GameBoard = () => {
   // Check if game is complete
   if (roundNumber > 8) {
     return (
-      <Container maxWidth="xl">
-        <Box sx={{ py: 4 }}>
+      <Container maxWidth="xl" disableGutters>
+        <Box>
           <Alert severity="success" sx={{ mb: 3 }}>
-            <strong>🎉 对局完成！</strong>
+            <strong>对局完成</strong>
             <br />
             你已完成全部 8 轮。可查看最终队伍配置。
           </Alert>
@@ -220,8 +221,8 @@ const GameBoard = () => {
     currentRoundInputs.set3?.length === itemsPerSet;
 
   return (
-    <Container maxWidth="xl">
-      <Box sx={{ py: 4 }}>
+    <Container maxWidth="xl" disableGutters>
+      <Box>
         <RoundInfo roundNumber={roundNumber} />
 
         <CurrentTeam
@@ -264,7 +265,7 @@ const GameBoard = () => {
             {loading ? (
               <CircularProgress size={24} />
             ) : (
-              "🤖 获取 AI 推荐"
+              "获取 AI 推荐"
             )}
           </Button>
         </Box>
@@ -276,22 +277,8 @@ const GameBoard = () => {
           onClick={handleGeneratePrompt}
           disabled={!allSetsComplete}
           startIcon={<ContentCopyIcon />}
-          sx={{
-            mb: 3,
-            backgroundColor: '#ffffff',
-            color: '#1a1a2e',
-            fontWeight: 'bold',
-            border: '2px solid #ffd700',
-            '&:hover': {
-              backgroundColor: '#ffd700',
-              color: '#1a1a2e',
-            },
-            '&.Mui-disabled': {
-              backgroundColor: 'rgba(255,255,255,0.2)',
-              color: 'rgba(255,255,255,0.4)',
-              border: '2px solid rgba(255,215,0,0.3)',
-            },
-          }}
+          color="secondary"
+          sx={{ mb: 3 }}
         >
           复制 AI 分析提示词
         </Button>
@@ -300,7 +287,7 @@ const GameBoard = () => {
           open={snackbarOpen}
           autoHideDuration={2000}
           onClose={() => setSnackbarOpen(false)}
-          message="✅ 提示词已复制到剪贴板"
+          message="提示词已复制到剪贴板"
           anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         />
 
@@ -340,7 +327,7 @@ const GameBoard = () => {
               onClick={handleRecordChoice}
               disabled={selectedOptionIndex === null}
             >
-              ✅ 确认选择并进入下一轮
+              确认选择并进入下一轮
             </Button>
           </>
         )}

--- a/web/src/components/game/KnownStrongTeams.tsx
+++ b/web/src/components/game/KnownStrongTeams.tsx
@@ -1,30 +1,29 @@
-import type { ReactElement } from 'react';
-import {
-  Paper, Typography, Box, Chip,
-  Table, TableBody, TableCell, TableHead, TableRow,
-  type ChipProps, type SxProps,
-} from '@mui/material';
-import GroupsIcon from '@mui/icons-material/Groups';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import { Paper, Typography, Box, type SxProps } from '@mui/material';
 import { selectRelevantTeamComps } from '../../services/promptGenerator';
 import { tierRank } from '../../utils/tiers';
 
 type OwnershipStatus = 'owned' | 'candidate' | 'missing';
 
 interface StatusStyle {
-  color: ChipProps['color'];
-  variant: ChipProps['variant'];
-  icon: ReactElement | null;
+  label: string;
   sx: SxProps;
 }
 
-// Ownership status → color carries the meaning: green = owned, blue = obtainable
-// this round, faded grey = not owned.
+// Ownership is expressed with typography and a colored rule, avoiding the
+// icon-heavy chip language used elsewhere in the app.
 const STATUS: Record<OwnershipStatus, StatusStyle> = {
-  owned:     { color: 'success', variant: 'filled',   icon: <CheckCircleIcon />,      sx: {} },
-  candidate: { color: 'primary', variant: 'outlined', icon: <AddCircleOutlineIcon />, sx: {} },
-  missing:   { color: 'default', variant: 'outlined', icon: null,                     sx: { opacity: 0.45, border: 0 } },
+  owned: {
+    label: '已在阵中',
+    sx: { borderColor: 'primary.main', bgcolor: 'rgba(69,108,95,0.10)' },
+  },
+  candidate: {
+    label: '本轮可取',
+    sx: { borderColor: 'error.main', bgcolor: 'rgba(168,57,47,0.07)' },
+  },
+  missing: {
+    label: '尚未拥有',
+    sx: { borderColor: 'divider', bgcolor: 'rgba(29,36,33,0.025)', opacity: 0.56 },
+  },
 };
 
 interface HeroChipProps {
@@ -35,14 +34,29 @@ interface HeroChipProps {
 const HeroChip = ({ hero, status }: HeroChipProps) => {
   const s = STATUS[status];
   return (
-    <Chip
-      label={hero}
-      size="small"
-      color={s.color}
-      variant={s.variant}
-      icon={s.icon || undefined}
-      sx={{ fontWeight: status === 'owned' ? 600 : 400, ...s.sx }}
-    />
+    <Box
+      sx={{
+        minWidth: 0,
+        px: 1.25,
+        py: 1,
+        borderTop: '3px solid',
+        ...s.sx,
+      }}
+    >
+      <Typography
+        variant="body2"
+        sx={{ fontWeight: status === 'missing' ? 500 : 750, lineHeight: 1.3 }}
+      >
+        {hero}
+      </Typography>
+      <Typography
+        variant="caption"
+        color={status === 'candidate' ? 'error.dark' : 'text.secondary'}
+        sx={{ display: 'block', mt: 0.35, letterSpacing: '0.06em' }}
+      >
+        {s.label}
+      </Typography>
+    </Box>
   );
 };
 
@@ -50,10 +64,8 @@ const HeroChip = ({ hero, status }: HeroChipProps) => {
  * 已知强力阵容 — surfaces the known strong team comps that overlap the heroes
  * currently in play, mirroring the 【玩家心得】 block in the LLM prompt.
  *
- * Rendered as a table so the three heroes line up in columns. Ownership is shown
- * plainly: ✓ chip = already on the team, dashed ⊕ chip = obtainable this round
- * (pick the matching option set), faded text = not yet owned. Hidden when nothing
- * is relevant.
+ * Rendered as a compact field-guide of formations. Each formation is a card with
+ * a tier marker and text-only ownership states. Hidden when nothing is relevant.
  */
 interface KnownStrongTeamsProps {
   selectedHeroes?: string[];
@@ -77,46 +89,101 @@ const KnownStrongTeams = ({ selectedHeroes = [], candidateHeroes = [], isFirstRo
 
   // Strongest tiers first (stable sort keeps the selector's most-actionable order within a tier).
   const sorted = [...relevant].sort((a, b) => tierRank(a.comp.tier) - tierRank(b.comp.tier));
-  const maxHeroes = sorted.reduce((m, { comp }) => Math.max(m, comp.heroes.length), 0);
-
   return (
-    <Paper sx={{ p: 3, mb: 3 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
-        <GroupsIcon sx={{ mr: 1, fontSize: 28 }} color="action" />
-        <Typography variant="h6">已知强力阵容</Typography>
+    <Paper sx={{ p: { xs: 2, sm: 3 }, mb: 3, overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: { xs: 'flex-start', sm: 'flex-end' },
+          justifyContent: 'space-between',
+          flexDirection: { xs: 'column', sm: 'row' },
+          gap: 1,
+          mb: 2.25,
+        }}
+      >
+        <Box>
+          <Typography variant="overline" color="error.main">阵容情报</Typography>
+          <Typography variant="h6">已知强力阵容</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            根据当前武将与本轮选项，找出可衔接的成型队伍。
+          </Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+          共 {sorted.length} 组
+        </Typography>
       </Box>
 
-      {/* Visual legend */}
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 1 }}>
-        <HeroChip hero="已选" status="owned" />
-        <HeroChip hero="本轮可选" status="candidate" />
-        <HeroChip hero="未拥有" status="missing" />
+      <Box
+        aria-label="阵容状态图例"
+        sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2.25 }}
+      >
+        {(Object.keys(STATUS) as OwnershipStatus[]).map((status) => (
+          <Box key={status} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+            <Box sx={{ width: 20, borderTop: '3px solid', ...STATUS[status].sx, bgcolor: 'transparent' }} />
+            <Typography variant="caption" color="text.secondary">{STATUS[status].label}</Typography>
+          </Box>
+        ))}
       </Box>
 
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell sx={{ fontWeight: 700, width: 64, whiteSpace: 'nowrap' }}>强度</TableCell>
-            <TableCell sx={{ fontWeight: 700 }} colSpan={maxHeroes}>武将</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {sorted.map(({ comp }, idx) => (
-            <TableRow key={idx} hover>
-              <TableCell sx={{ fontWeight: 700 }}>{comp.tier}</TableCell>
+      <Box
+        component="ol"
+        sx={{
+          listStyle: 'none',
+          m: 0,
+          p: 0,
+          display: 'grid',
+          gridTemplateColumns: { xs: 'minmax(0, 1fr)', xl: 'repeat(2, minmax(0, 1fr))' },
+          gap: 1.25,
+        }}
+      >
+        {sorted.map(({ comp }, idx) => (
+          <Box
+            component="li"
+            data-testid="strong-team-row"
+            key={`${comp.tier}-${comp.heroes.join('-')}-${idx}`}
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '52px minmax(0, 1fr)', sm: '64px minmax(0, 1fr)' },
+              border: '1px solid',
+              borderColor: 'divider',
+              bgcolor: 'rgba(251,248,239,0.72)',
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                bgcolor: idx === 0 ? '#243b34' : '#e7dfcc',
+                color: idx === 0 ? '#fff8e9' : 'text.primary',
+                borderRight: '1px solid',
+                borderColor: idx === 0 ? '#243b34' : 'divider',
+                px: 0.75,
+              }}
+            >
+              <Typography data-testid="team-tier" sx={{ fontFamily: 'Georgia, serif', fontWeight: 800, fontSize: 18 }}>
+                {comp.tier}
+              </Typography>
+              <Typography variant="caption" sx={{ opacity: 0.7, fontSize: 10 }}>强度</Typography>
+            </Box>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: `repeat(${comp.heroes.length}, minmax(0, 1fr))`,
+                gap: 0.75,
+                p: 0.75,
+              }}
+            >
               {comp.heroes.map((hero) => (
-                <TableCell key={hero}>
+                <Box key={hero}>
                   <HeroChip hero={hero} status={statusOf(hero)} />
-                </TableCell>
+                </Box>
               ))}
-              {/* pad short comps so columns stay aligned */}
-              {Array.from({ length: maxHeroes - comp.heroes.length }).map((_, i) => (
-                <TableCell key={`pad-${i}`} />
-              ))}
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+            </Box>
+          </Box>
+        ))}
+      </Box>
     </Paper>
   );
 };

--- a/web/src/components/game/OptionSetInput.tsx
+++ b/web/src/components/game/OptionSetInput.tsx
@@ -55,15 +55,21 @@ const OptionSetInput = ({
     const allSelected = getAllSelectedItems();
 
     return (
-      <Grid size={{ xs: 12, md: 4 }} key={setName}>
+      <Grid size={{ xs: 12 }} key={setName}>
         <Box sx={{ 
-          p: 2, 
-          border: '2px solid',
+          p: { xs: 1.75, sm: 2.25 },
+          border: '1px solid',
           borderColor: 'divider',
-          borderRadius: 2,
+          borderLeft: '4px solid',
+          borderLeftColor: 'primary.main',
           height: '100%',
+          display: { sm: 'grid' },
+          gridTemplateColumns: { sm: '160px minmax(240px, 0.75fr) minmax(0, 1.25fr)' },
+          alignItems: 'center',
+          gap: 2,
+          bgcolor: 'rgba(251,248,239,0.58)',
         }}>
-          <Typography variant="h6" gutterBottom>
+          <Typography variant="h6" sx={{ mb: { xs: 1.5, sm: 0 } }}>
             {setLabel} ({currentSet.length}/{itemsPerSet})
           </Typography>
           
@@ -97,9 +103,12 @@ const OptionSetInput = ({
     (sets.set3?.length === itemsPerSet);
   
   return (
-    <Paper sx={{ p: 3, mb: 3 }}>
-      <Typography variant="h6" gutterBottom>
-        🎯 填写三组选项
+    <Paper sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
+      <Typography variant="overline" color="error.main">
+        本轮候选
+      </Typography>
+      <Typography variant="h5" gutterBottom>
+        填写三组选项
       </Typography>
       <Typography variant="body2" color="text.secondary" paragraph>
         每组需恰好包含 {itemsPerSet} 个{roundType === 'hero' ? '武将' : '战法'}。将从这三组中选定一组。
@@ -111,7 +120,7 @@ const OptionSetInput = ({
         </Alert>
       )}
       
-      <Grid container spacing={2}>
+      <Grid container spacing={1.5}>
         {renderSetInput('set1', '第 1 组')}
         {renderSetInput('set2', '第 2 组')}
         {renderSetInput('set3', '第 3 组')}

--- a/web/src/components/game/RecommendationPanel.tsx
+++ b/web/src/components/game/RecommendationPanel.tsx
@@ -1,5 +1,5 @@
 import { Paper, Typography, Box, Alert } from '@mui/material';
-import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import AutoAwesomeOutlinedIcon from '@mui/icons-material/AutoAwesomeOutlined';
 import type { Recommendation, RoundType } from '../../types/game';
 
 interface RecommendationPanelProps {
@@ -18,12 +18,13 @@ const RecommendationPanel = ({ recommendation, roundType }: RecommendationPanelP
   const { recommended_set_index, round_info } = recommendation;
   
   return (
-    <Paper sx={{ p: 3, mb: 3, bgcolor: 'success.light', color: 'success.contrastText' }}>
+    <Paper sx={{ p: 3, mb: 3, bgcolor: 'rgba(223,232,226,0.8)', border: '1px solid', borderColor: 'primary.main', borderLeftWidth: 5 }}>
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-        <EmojiEventsIcon sx={{ mr: 1, fontSize: 32 }} />
-        <Typography variant="h6">
-          AI 推荐
-        </Typography>
+        <AutoAwesomeOutlinedIcon sx={{ mr: 1, fontSize: 28, color: 'primary.main' }} />
+        <Box>
+          <Typography variant="overline" color="primary.dark" sx={{ display: 'block', lineHeight: 1.1 }}>参谋建议</Typography>
+          <Typography variant="h6">AI 推荐</Typography>
+        </Box>
       </Box>
       
       <Alert severity="success" sx={{ mb: 2 }}>

--- a/web/src/components/game/RoundInfo.tsx
+++ b/web/src/components/game/RoundInfo.tsx
@@ -1,4 +1,5 @@
-import { Typography, Stepper, Step, StepLabel, Paper, Box, Button } from '@mui/material';
+import { Typography, Stepper, Step, StepLabel, Paper, Box, Button, Chip } from '@mui/material';
+import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
 import { useNavigate } from 'react-router-dom';
 import { getRoundInfo } from '../../services/gameLogic';
 
@@ -14,10 +15,11 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
   const info = getRoundInfo(roundNumber);
   
   return (
-    <Paper sx={{ p: 3, mb: 3, position: 'relative' }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}>
+    <Paper sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, position: 'relative', borderTop: '3px solid', borderTopColor: 'text.primary' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 2, mb: 2 }}>
         <Box sx={{ flex: 1 }}>
-          <Typography variant="h5" gutterBottom>
+          <Chip size="small" color="error" variant="outlined" label={`第 ${roundNumber} / 8 轮`} sx={{ mb: 1.5 }} />
+          <Typography variant="h4" gutterBottom>
             {info.title}
           </Typography>
           <Typography variant="body1" color="text.secondary" paragraph>
@@ -29,15 +31,17 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
             variant="outlined"
             color="primary"
             size="small"
+            startIcon={<AccountTreeOutlinedIcon />}
             onClick={() => navigate('/team-builder')}
             sx={{ ml: 2, flexShrink: 0 }}
           >
-            🛠️ 查看队伍推荐
+            查看队伍推荐
           </Button>
         )}
       </Box>
       
-      <Stepper activeStep={roundNumber - 1} alternativeLabel sx={{ mt: 2 }}>
+      <Box sx={{ overflowX: 'auto', pt: 1 }}>
+      <Stepper activeStep={roundNumber - 1} alternativeLabel sx={{ mt: 2, minWidth: 660 }}>
         {[1, 2, 3, 4, 5, 6, 7, 8].map((round) => {
           const isHero = round === 1 || round === 4 || round === 7;
           return (
@@ -53,6 +57,7 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
           );
         })}
       </Stepper>
+      </Box>
     </Paper>
   );
 };

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -1,13 +1,15 @@
 import type { ReactNode } from 'react';
-import { Box, Container, Button, Stack } from '@mui/material';
+import { Box, Container, Button, Stack, Typography } from '@mui/material';
+import SportsEsportsOutlinedIcon from '@mui/icons-material/SportsEsportsOutlined';
+import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
+import QueryStatsOutlinedIcon from '@mui/icons-material/QueryStatsOutlined';
+import RestartAltOutlinedIcon from '@mui/icons-material/RestartAltOutlined';
 import { useNavigate, useLocation } from 'react-router-dom';
 import Header from './Header';
 import JoinGroupButton from './JoinGroupButton';
 import { useGame } from '../../context/GameContext';
 
-interface AppLayoutProps {
-  children: ReactNode;
-}
+interface AppLayoutProps { children: ReactNode; }
 
 const AppLayout = ({ children }: AppLayoutProps) => {
   const navigate = useNavigate();
@@ -22,92 +24,79 @@ const AppLayout = ({ children }: AppLayoutProps) => {
     }
   };
 
-  return (
-    <Box
-      sx={{
-        minHeight: '100vh',
-        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-        pb: 4,
-      }}
-    >
-      <Header />
-      
-      {/* Navigation */}
-      <Container maxWidth="lg" sx={{ mb: 3 }}>
-        <Stack 
-          direction={{ xs: 'column', sm: 'row' }}
-          spacing={1}
-          justifyContent="center" 
-          alignItems="center"
-          flexWrap="wrap"
-        >
-          <Button
-            variant={location.pathname === '/' ? 'contained' : 'outlined'}
-            onClick={() => navigate('/')}
-            sx={{
-              bgcolor: location.pathname === '/' ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.2)',
-              color: 'white',
-              borderColor: 'rgba(255,255,255,0.3)',
-              '&:hover': {
-                bgcolor: 'rgba(255,255,255,0.4)',
-              },
-            }}
-          >
-            🎮 对局推荐
-          </Button>
-          {roundNumber > 3 && (
-            <Button
-              variant={location.pathname === '/team-builder' ? 'contained' : 'outlined'}
-              onClick={() => navigate('/team-builder')}
-              sx={{
-                bgcolor: location.pathname === '/team-builder' ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.2)',
-                color: 'white',
-                borderColor: 'rgba(255,255,255,0.3)',
-                '&:hover': {
-                  bgcolor: 'rgba(255,255,255,0.4)',
-                },
-              }}
-            >
-              🛠️ 查看队伍推荐
-            </Button>
-          )}
-          <Button
-            variant={location.pathname === '/analytics' ? 'contained' : 'outlined'}
-            onClick={() => navigate('/analytics')}
-            sx={{
-              bgcolor: location.pathname === '/analytics' ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.2)',
-              color: 'white',
-              borderColor: 'rgba(255,255,255,0.3)',
-              '&:hover': {
-                bgcolor: 'rgba(255,255,255,0.4)',
-              },
-            }}
-          >
-            📊 数据
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={handleResetProgress}
-            sx={{
-              bgcolor: 'rgba(255,0,0,0.3)',
-              color: 'white',
-              borderColor: 'rgba(255,255,255,0.3)',
-              '&:hover': {
-                bgcolor: 'rgba(255,0,0,0.5)',
-              },
-            }}
-            title="重置所有已保存进度"
-          >
-            🔄 重置进度
-          </Button>
-          <JoinGroupButton />
-        </Stack>
-      </Container>
+  const navButtonSx = (path: string) => ({
+    minHeight: 42,
+    px: 1.75,
+    color: location.pathname === path ? 'primary.dark' : 'text.secondary',
+    border: 0,
+    borderBottom: '2px solid',
+    borderColor: location.pathname === path ? 'error.main' : 'transparent',
+    bgcolor: location.pathname === path ? 'rgba(69,108,95,0.08)' : 'transparent',
+    '&:hover': { bgcolor: 'rgba(69,108,95,0.08)', borderColor: location.pathname === path ? 'error.main' : 'divider' },
+  });
 
-      {/* Main Content */}
-      <Container maxWidth="lg">
-        {children}
-      </Container>
+  return (
+    <Box sx={{ minHeight: '100vh', display: 'grid', gridTemplateColumns: { xs: 'minmax(0, 1fr)', md: '80px minmax(0, 1fr)' } }}>
+      <Header />
+      <Box sx={{ minWidth: 0 }}>
+        <Box
+          component="nav"
+          aria-label="主要导航"
+          sx={{
+            position: 'sticky',
+            top: { xs: 0, md: 0 },
+            zIndex: 15,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            bgcolor: 'rgba(243,239,227,0.94)',
+            backdropFilter: 'blur(12px)',
+          }}
+        >
+          <Container maxWidth="xl" sx={{ py: 1.25 }}>
+            <Stack direction="row" alignItems="center" gap={1} sx={{ minWidth: 0 }}>
+              <Box sx={{ mr: { xs: 0.5, lg: 3 }, minWidth: 0 }}>
+                <Typography variant="overline" color="error.main" sx={{ display: { xs: 'none', sm: 'block' }, lineHeight: 1 }}>
+                  三国谋定天下
+                </Typography>
+                <Typography variant="h6" sx={{ whiteSpace: 'nowrap', fontSize: { xs: 17, sm: 20 } }}>
+                  演武参谋
+                </Typography>
+              </Box>
+
+              <Stack direction="row" gap={0.25} sx={{ overflowX: 'auto', flex: 1, minWidth: 0 }}>
+                <Button startIcon={<SportsEsportsOutlinedIcon />} onClick={() => navigate('/')} sx={navButtonSx('/')}>
+                  对局推荐
+                </Button>
+                {roundNumber > 3 && (
+                  <Button startIcon={<AccountTreeOutlinedIcon />} onClick={() => navigate('/team-builder')} sx={navButtonSx('/team-builder')}>
+                    队伍推荐
+                  </Button>
+                )}
+                <Button startIcon={<QueryStatsOutlinedIcon />} onClick={() => navigate('/analytics')} sx={navButtonSx('/analytics')}>
+                  数据洞察
+                </Button>
+              </Stack>
+
+              <Stack direction="row" gap={0.75} sx={{ display: { xs: 'none', lg: 'flex' } }}>
+                <JoinGroupButton />
+                <Button color="error" variant="text" startIcon={<RestartAltOutlinedIcon />} onClick={handleResetProgress} title="重置所有已保存进度">
+                  重置
+                </Button>
+              </Stack>
+            </Stack>
+            <Stack direction="row" gap={1} sx={{ display: { xs: 'flex', lg: 'none' }, mt: 1, justifyContent: 'flex-end' }}>
+              <JoinGroupButton />
+              <Button color="error" size="small" startIcon={<RestartAltOutlinedIcon />} onClick={handleResetProgress} title="重置所有已保存进度">
+                重置
+              </Button>
+            </Stack>
+          </Container>
+        </Box>
+
+        <Container component="main" maxWidth="xl" sx={{ py: { xs: 2.5, sm: 4 }, minWidth: 0 }}>
+          {children}
+        </Container>
+      </Box>
     </Box>
   );
 };

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -12,6 +12,9 @@ function formatGeneratedAt(isoString: string | undefined | null): string {
 const Header = () => {
   const generatedAt = formatGeneratedAt(battleStatsData.generated_at);
   const totalBattles = battleStatsData.total_battles ?? 0;
+  const addedBattles = Number.isFinite(battleStatsData.added_battles)
+    ? battleStatsData.added_battles
+    : 0;
 
   return (
     <Box
@@ -66,6 +69,7 @@ const Header = () => {
         <UpdateIcon sx={{ fontSize: 14 }} />
         <span>{generatedAt}</span>
         {totalBattles > 0 && <span>· {totalBattles} 场</span>}
+        {addedBattles > 0 && <span style={{ color: '#d98a5c' }}>· 新增 {addedBattles}</span>}
       </Box>
     </Box>
   );

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,88 +1,72 @@
-import { Box, Typography, Container, Chip } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import UpdateIcon from '@mui/icons-material/Update';
 import { battleStats as battleStatsData } from '../../data';
 
-/**
- * Format an ISO-8601 timestamp (e.g. "2026-05-09T02:01:36+00:00") into a
- * compact local date string (date only, no time-of-day). Falls back to the
- * raw string on parse error and to "未知" when no timestamp is available.
- */
 function formatGeneratedAt(isoString: string | undefined | null): string {
   if (!isoString) return '未知';
-  const d = new Date(isoString);
-  if (Number.isNaN(d.getTime())) return isoString;
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, '0');
-  const dd = String(d.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) return isoString;
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
 }
 
 const Header = () => {
-  const generatedAt = battleStatsData.generated_at;
-  const addedBattles = Number.isFinite(battleStatsData.added_battles)
-    ? battleStatsData.added_battles
-    : 0;
+  const generatedAt = formatGeneratedAt(battleStatsData.generated_at);
   const totalBattles = battleStatsData.total_battles ?? 0;
 
   return (
     <Box
+      component="header"
       sx={{
-        textAlign: 'center',
-        color: 'white',
-        py: 4,
+        position: { xs: 'relative', md: 'sticky' },
+        top: 0,
+        zIndex: 20,
+        minHeight: { xs: 62, md: '100vh' },
+        height: { md: '100vh' },
+        bgcolor: '#17221e',
+        color: '#f4ecdc',
+        borderRight: { md: '1px solid #53625c' },
+        borderBottom: { xs: '1px solid #53625c', md: 0 },
+        px: { xs: 2.25, md: 1.5 },
+        py: { xs: 1.25, md: 3 },
+        display: 'flex',
+        flexDirection: { xs: 'row', md: 'column' },
+        alignItems: 'center',
+        justifyContent: { xs: 'space-between', md: 'flex-start' },
+        gap: { xs: 2, md: 2.5 },
       }}
     >
-      <Container maxWidth="lg">
-        <Typography variant="h6">
-          基于战斗数据的策略推荐
-        </Typography>
-        <Box
-          sx={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            flexWrap: 'wrap',
-            gap: 1,
-            mt: 1.5,
-            px: 2,
-            py: 1,
-            bgcolor: 'rgba(255, 255, 255, 0.18)',
-            border: '1px solid rgba(255, 255, 255, 0.35)',
-            borderRadius: 2,
-            backdropFilter: 'blur(4px)',
-            boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
-          }}
-        >
-          <UpdateIcon fontSize="small" sx={{ color: 'white' }} />
-          <Typography
-            variant="subtitle2"
-            sx={{ color: 'white', fontWeight: 700, letterSpacing: 0.3 }}
-          >
-            战报更新时: {formatGeneratedAt(generatedAt)}
-          </Typography>
-          {addedBattles > 0 && (
-            <Chip
-              size="small"
-              label={`新增 ${addedBattles} 场`}
-              sx={{
-                bgcolor: '#4caf50',
-                color: 'white',
-                fontWeight: 700,
-              }}
-            />
-          )}
-          {totalBattles > 0 && (
-            <Chip
-              size="small"
-              label={`共 ${totalBattles} 场`}
-              sx={{
-                bgcolor: 'rgba(255, 255, 255, 0.85)',
-                color: '#3a2270',
-                fontWeight: 700,
-              }}
-            />
-          )}
-        </Box>
-      </Container>
+      <Typography
+        component="div"
+        sx={{
+          writingMode: { xs: 'horizontal-tb', md: 'vertical-rl' },
+          fontFamily: '"Songti SC", STSong, Georgia, serif',
+          fontSize: { xs: 20, md: 22 },
+          fontWeight: 800,
+          letterSpacing: { xs: '0.18em', md: '0.28em' },
+          whiteSpace: 'nowrap',
+        }}
+      >
+        演武策牒
+      </Typography>
+
+      <Box sx={{ width: { md: 1 }, height: { xs: 1, md: 'auto' }, flex: 1, bgcolor: '#53625c', opacity: 0.75 }} />
+
+      <Box
+        sx={{
+          writingMode: { xs: 'horizontal-tb', md: 'vertical-rl' },
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          color: '#b8c0ba',
+          fontSize: 11,
+          letterSpacing: '0.1em',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <UpdateIcon sx={{ fontSize: 14 }} />
+        <span>{generatedAt}</span>
+        {totalBattles > 0 && <span>· {totalBattles} 场</span>}
+      </Box>
     </Box>
   );
 };

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -49,8 +49,6 @@ const Header = () => {
         演武策牒
       </Typography>
 
-      <Box sx={{ width: { md: 1 }, height: { xs: 1, md: 'auto' }, flex: 1, bgcolor: '#53625c', opacity: 0.75 }} />
-
       <Box
         sx={{
           writingMode: { xs: 'horizontal-tb', md: 'vertical-rl' },

--- a/web/src/components/layout/JoinGroupButton.tsx
+++ b/web/src/components/layout/JoinGroupButton.tsx
@@ -12,6 +12,7 @@ import {
   AlertTitle,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 
 /**
  * Button that opens a dialog displaying the author's WeChat QR code so users
@@ -32,18 +33,10 @@ const JoinGroupButton = () => {
       <Button
         variant="outlined"
         onClick={handleOpen}
-        sx={{
-          bgcolor: 'rgba(7, 193, 96, 0.85)', // WeChat green
-          color: 'white',
-          borderColor: 'rgba(255,255,255,0.4)',
-          fontWeight: 700,
-          '&:hover': {
-            bgcolor: 'rgba(7, 193, 96, 1)',
-            borderColor: 'white',
-          },
-        }}
+        size="small"
+        startIcon={<ForumOutlinedIcon />}
       >
-        💬 加演武讨论群
+        讨论群
       </Button>
 
       <Dialog
@@ -78,8 +71,8 @@ const JoinGroupButton = () => {
                 width: '100%',
                 maxWidth: 280,
                 height: 'auto',
-                borderRadius: 1,
-                border: '1px solid #eee',
+                border: '1px solid',
+                borderColor: 'divider',
               }}
             />
             <Typography variant="body2" color="text.secondary" align="center">

--- a/web/src/components/setup/SetupForm.tsx
+++ b/web/src/components/setup/SetupForm.tsx
@@ -74,10 +74,13 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
   }
 
   return (
-    <Card>
-      <CardContent>
-        <Typography variant="h5" gutterBottom>
-          🎮 对局设置
+    <Card sx={{ maxWidth: 1040, mx: 'auto', borderTop: '3px solid', borderTopColor: 'text.primary' }}>
+      <CardContent sx={{ p: { xs: 2.25, sm: 4 }, '&:last-child': { pb: { xs: 2.25, sm: 4 } } }}>
+        <Typography variant="overline" color="error.main">
+          初始名册 · 演武开局
+        </Typography>
+        <Typography variant="h4" gutterBottom>
+          录入当前阵容
         </Typography>
         <Typography variant="body1" color="text.secondary" paragraph>
           输入初始 4 个武将和 8 个战法以开始对局。
@@ -91,7 +94,7 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
 
         {/* Heroes Input */}
         <Box sx={{ mb: 3 }}>
-          <Typography variant="h6" gutterBottom>
+          <Typography variant="h6" gutterBottom sx={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid', borderColor: 'divider', pb: 1 }}>
             初始武将 ({heroes.length}/4)
           </Typography>
           <AutocompleteInput
@@ -113,7 +116,7 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
 
         {/* Skills Input */}
         <Box sx={{ mb: 3 }}>
-          <Typography variant="h6" gutterBottom>
+          <Typography variant="h6" gutterBottom sx={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid', borderColor: 'divider', pb: 1 }}>
             初始战法 ({skills.length}/8)
           </Typography>
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -184,19 +184,20 @@ const Analytics = () => {
     : (skill_synergy || []);
 
   return (
-    <Container maxWidth="xl">
-      <Box sx={{ py: 4 }}>
-        <Typography variant="h4" gutterBottom>
-          📊 数据看板
+    <Container maxWidth="xl" disableGutters>
+      <Box>
+        <Typography variant="overline" color="error.main">BATTLE ARCHIVE</Typography>
+        <Typography variant="h3" gutterBottom>
+          数据洞察
         </Typography>
         <Typography variant="body1" color="text.secondary" paragraph>
           战斗统计与表现分析（共 {summary?.total_battles ?? '...'} 场对局）
         </Typography>
 
         {/* Filters */}
-        <Paper sx={{ p: 2, mb: 4 }}>
+        <Paper sx={{ p: { xs: 2, sm: 2.5 }, mb: 4, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
           <Box sx={{ display: 'flex', alignItems: 'center', mb: 1, gap: 1 }}>
-            <Typography variant="h6">🔍 筛选</Typography>
+            <Typography variant="h6">筛选名册</Typography>
             {(hasHeroFilter || hasSkillFilter) && (
               <IconButton size="small" onClick={() => { setSelectedHeroes([]); setSelectedSkills([]); }} title="清除所有筛选">
                 <ClearIcon fontSize="small" />
@@ -383,7 +384,7 @@ const Analytics = () => {
             <CardContent>
               <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                 <LinkIcon sx={{ mr: 1, color: 'info.main' }} />
-                <Typography variant="h6">🤝 武将羁绊依赖分析</Typography>
+                <Typography variant="h6">武将羁绊依赖分析</Typography>
               </Box>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                 部分武将的胜率高度依赖特定搭档。"增幅"表示有搭档 vs 无搭档的胜率差值，"占比"表示与该搭档同队的比赛占总场次的百分比。
@@ -448,7 +449,7 @@ const Analytics = () => {
             <CardContent>
               <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                 <LinkIcon sx={{ mr: 1, color: 'secondary.main' }} />
-                <Typography variant="h6">⚔️ 战法羁绊依赖分析</Typography>
+                <Typography variant="h6">战法羁绊依赖分析</Typography>
               </Box>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                 部分战法的胜率高度依赖特定武将。"增幅"表示有该武将 vs 无该武将时的胜率差值，"占比"表示该战法被该武将使用的比赛占总场次的百分比。
@@ -511,7 +512,7 @@ const Analytics = () => {
         <Card>
           <CardContent>
             <Typography variant="h6" gutterBottom>
-              🏆 武将三人组合胜率排行（按置信调整胜率排序）
+              武将三人组合胜率排行（按置信调整胜率排序）
             </Typography>
             <TableContainer sx={{ maxHeight: 800 }}>
               <Table stickyHeader>

--- a/web/src/pages/BuildATeam.tsx
+++ b/web/src/pages/BuildATeam.tsx
@@ -409,7 +409,7 @@ const BuildATeam = () => {
   const noPool = poolHeroes.length === 0 && poolSkills.length === 0;
 
   return (
-    <Box sx={{ p: { xs: 1, sm: 2 } }}>
+    <Box>
       <Stack
         direction={{ xs: 'column', sm: 'row' }}
         justifyContent="space-between"
@@ -418,9 +418,8 @@ const BuildATeam = () => {
         sx={{ mb: 2 }}
       >
         <Box>
-          <Typography variant="h5" fontWeight={800}>
-            组队 / Build a Team
-          </Typography>
+          <Typography variant="overline" color="error.main">FORMATION WORKSHOP</Typography>
+          <Typography variant="h3">组队 / Build a Team</Typography>
           <Typography variant="body2" color="text.secondary">
             从当前卡池拖拽武将与战法到 3 支队伍（每队 3 武将，每武将 2 战法）。放入后会从卡池移除，清除槽位即可放回。
           </Typography>
@@ -451,7 +450,7 @@ const BuildATeam = () => {
       )}
 
       {/* Pool panel — full width */}
-      <Paper sx={{ p: 2, mb: 2 }}>
+      <Paper sx={{ p: { xs: 2, sm: 2.5 }, mb: 2, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
         <Typography variant="subtitle1" fontWeight={700} gutterBottom>
           卡池武将（{poolHeroes.length}）
         </Typography>

--- a/web/src/pages/TeamBuilder.tsx
+++ b/web/src/pages/TeamBuilder.tsx
@@ -176,9 +176,9 @@ const TeamBuilder = () => {
   }, [heroes.join(','), skills.join(',')]);
 
   return (
-    <Container maxWidth="xl">
-      <Box sx={{ py: 4 }}>
-        <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
+    <Container maxWidth="xl" disableGutters>
+      <Box>
+        <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 2, borderBottom: '2px solid', borderColor: 'text.primary', pb: 2 }}>
           <Button
             startIcon={<ArrowBackIcon />}
             onClick={() => navigate(-1)}
@@ -186,9 +186,10 @@ const TeamBuilder = () => {
           >
             返回
           </Button>
-          <Typography variant="h4">
-            🛠️ 查看队伍推荐
-          </Typography>
+          <Box>
+            <Typography variant="overline" color="error.main" sx={{ display: 'block', lineHeight: 1.2 }}>FORMATION DOSSIER</Typography>
+            <Typography variant="h3">队伍策案</Typography>
+          </Box>
           {heroes.length >= 3 && (
             <Button
               startIcon={<ContentCopyIcon />}
@@ -224,7 +225,7 @@ const TeamBuilder = () => {
           <Card sx={{ mt: 4 }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
-                🏆 推荐组队
+                推荐组队
               </Typography>
               <Typography variant="body2" color="text.secondary" paragraph>
                 根据当前武将和战法池，自动推荐 3 支队伍。每支队伍 3 名武将，每名武将分配 2 个战法。
@@ -316,7 +317,7 @@ const TeamBuilder = () => {
           <Card sx={{ mt: 4 }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
-                💡 可能的队伍组合
+                可能的队伍组合
               </Typography>
               {loading ? (
                 <Box sx={{ textAlign: 'center', py: 4 }}>
@@ -376,7 +377,7 @@ const TeamBuilder = () => {
           <Card sx={{ mt: 4 }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
-                🎯 每位武将的最佳搭配
+                每位武将的最佳搭配
               </Typography>
               <Typography variant="body2" color="text.secondary" paragraph sx={{ mb: 3 }}>
                 根据历史表现，展示当前队伍中每位武将的最佳武将搭档与最佳战法搭配。
@@ -483,4 +484,3 @@ const TeamBuilder = () => {
 };
 
 export default TeamBuilder;
-

--- a/web/src/theme/theme.ts
+++ b/web/src/theme/theme.ts
@@ -1,4 +1,210 @@
-import { createTheme } from '@mui/material/styles';
+import { alpha, createTheme } from '@mui/material/styles';
 
-// Use Material UI's default theme with no custom overrides
-export const theme = createTheme();
+const ink = '#1d2421';
+const paper = '#f3efe3';
+const paperLight = '#fbf8ef';
+const paperDeep = '#e7dfcc';
+const jade = '#456c5f';
+const seal = '#a8392f';
+const gold = '#a38147';
+const rule = '#c9c2b1';
+
+export const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: jade, dark: '#304f45', light: '#dfe8e2', contrastText: '#fffdf7' },
+    secondary: { main: gold, dark: '#725a2f', light: '#eee2ca', contrastText: '#fffdf7' },
+    error: { main: seal, dark: '#7e2923', light: '#f1dfd9' },
+    warning: { main: gold, dark: '#725a2f', light: '#f0e5cf' },
+    success: { main: '#4f755c', dark: '#36523f', light: '#e1eadf' },
+    info: { main: '#526d75', dark: '#374e55', light: '#e1e8e9' },
+    background: { default: paper, paper: paperLight },
+    text: { primary: ink, secondary: '#667069', disabled: '#979b93' },
+    divider: rule,
+    action: {
+      hover: alpha(jade, 0.07),
+      selected: alpha(jade, 0.13),
+      disabledBackground: alpha(ink, 0.07),
+    },
+  },
+  shape: { borderRadius: 2 },
+  spacing: 8,
+  typography: {
+    fontFamily: '-apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif',
+    h1: { fontFamily: '"Songti SC", STSong, Georgia, serif', fontWeight: 700, letterSpacing: '0.035em' },
+    h2: { fontFamily: '"Songti SC", STSong, Georgia, serif', fontWeight: 700, letterSpacing: '0.03em' },
+    h3: { fontFamily: '"Songti SC", STSong, Georgia, serif', fontWeight: 700, letterSpacing: '0.025em' },
+    h4: { fontFamily: '"Songti SC", STSong, Georgia, serif', fontWeight: 700, letterSpacing: '0.025em' },
+    h5: { fontFamily: '"Songti SC", STSong, Georgia, serif', fontWeight: 700, letterSpacing: '0.025em' },
+    h6: { fontFamily: '"Songti SC", STSong, Georgia, serif', fontWeight: 700, letterSpacing: '0.02em' },
+    button: { fontWeight: 700, letterSpacing: '0.06em', textTransform: 'none' },
+    overline: { fontWeight: 700, letterSpacing: '0.16em' },
+  },
+  shadows: [
+    'none',
+    '0 8px 24px rgba(44, 41, 30, 0.07)',
+    '0 12px 34px rgba(44, 41, 30, 0.09)',
+    '0 16px 42px rgba(44, 41, 30, 0.1)',
+    '0 20px 50px rgba(44, 41, 30, 0.11)',
+    ...Array(20).fill('0 20px 50px rgba(44, 41, 30, 0.12)'),
+  ] as any,
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        html: { minWidth: 320, backgroundColor: paper },
+        body: {
+          minWidth: 320,
+          backgroundColor: paper,
+          backgroundImage: `repeating-linear-gradient(0deg, ${alpha(ink, 0.018)} 0, ${alpha(ink, 0.018)} 1px, transparent 1px, transparent 4px)`,
+          backgroundAttachment: 'fixed',
+        },
+        '::selection': { backgroundColor: alpha(jade, 0.22) },
+        '*': { scrollbarColor: `${alpha(jade, 0.45)} transparent` },
+      },
+    },
+    MuiContainer: {
+      styleOverrides: { root: { minWidth: 0 } },
+    },
+    MuiPaper: {
+      defaultProps: { elevation: 0 },
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          border: `1px solid ${rule}`,
+          boxShadow: '0 10px 30px rgba(44, 41, 30, 0.055)',
+        },
+        outlined: { borderColor: rule },
+      },
+    },
+    MuiCard: {
+      defaultProps: { elevation: 0 },
+      styleOverrides: {
+        root: {
+          border: `1px solid ${rule}`,
+          backgroundColor: alpha(paperLight, 0.9),
+          backgroundImage: 'none',
+          boxShadow: '0 10px 30px rgba(44, 41, 30, 0.05)',
+        },
+      },
+    },
+    MuiCardContent: {
+      styleOverrides: { root: { padding: 24, '&:last-child': { paddingBottom: 24 } } },
+    },
+    MuiButton: {
+      defaultProps: { disableElevation: true },
+      styleOverrides: {
+        root: {
+          minHeight: 40,
+          borderRadius: 1,
+          paddingInline: 18,
+          borderWidth: 1,
+          '&:focus-visible': { outline: `3px solid ${alpha(jade, 0.3)}`, outlineOffset: 2 },
+        },
+        containedPrimary: {
+          backgroundColor: seal,
+          color: '#fff8e9',
+          '&:hover': { backgroundColor: '#8d3028' },
+        },
+        outlinedPrimary: {
+          color: ink,
+          borderColor: '#7a837e',
+          '&:hover': { borderColor: jade, backgroundColor: alpha(jade, 0.07) },
+        },
+        containedSecondary: {
+          color: '#fffaf0',
+          backgroundColor: gold,
+          '&:hover': { backgroundColor: '#826637' },
+        },
+      },
+    },
+    MuiIconButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 1,
+          '&:focus-visible': { outline: `3px solid ${alpha(jade, 0.3)}`, outlineOffset: 2 },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: { borderRadius: 1, fontWeight: 650, borderColor: rule },
+        colorPrimary: { backgroundColor: alpha(jade, 0.13), color: '#2f5045', borderColor: alpha(jade, 0.42) },
+        colorSecondary: { backgroundColor: alpha(gold, 0.14), color: '#685126', borderColor: alpha(gold, 0.45) },
+        colorWarning: { backgroundColor: alpha(gold, 0.17), color: '#6e5528' },
+        colorSuccess: { backgroundColor: alpha('#4f755c', 0.14), color: '#36523f' },
+      },
+    },
+    MuiTextField: { defaultProps: { size: 'small' } },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          borderRadius: 1,
+          backgroundColor: alpha('#fffdf7', 0.78),
+          '& .MuiOutlinedInput-notchedOutline': { borderColor: '#a9aa9f' },
+          '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: jade },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: jade, borderWidth: 2 },
+        },
+      },
+    },
+    MuiInputLabel: { styleOverrides: { root: { color: '#677069' } } },
+    MuiAutocomplete: {
+      styleOverrides: {
+        paper: { marginTop: 4, border: `1px solid ${rule}`, backgroundColor: paperLight },
+        option: { borderBottom: `1px solid ${alpha(rule, 0.65)}` },
+      },
+    },
+    MuiTableContainer: {
+      styleOverrides: { root: { border: `1px solid ${rule}`, backgroundColor: alpha(paperLight, 0.74) } },
+    },
+    MuiTableHead: { styleOverrides: { root: { backgroundColor: paperDeep } } },
+    MuiTableCell: {
+      styleOverrides: {
+        root: { borderColor: rule },
+        head: { color: ink, fontWeight: 750, letterSpacing: '0.035em', backgroundColor: paperDeep },
+      },
+    },
+    MuiTableRow: {
+      styleOverrides: { root: { '&.MuiTableRow-hover:hover': { backgroundColor: alpha(jade, 0.055) } } },
+    },
+    MuiDivider: { styleOverrides: { root: { borderColor: rule } } },
+    MuiAlert: {
+      styleOverrides: {
+        root: { borderRadius: 1, border: `1px solid ${rule}`, alignItems: 'center' },
+        standardInfo: { backgroundColor: '#e9eeee' },
+        standardSuccess: { backgroundColor: '#e5ede3' },
+        standardWarning: { backgroundColor: '#f2e9d7' },
+        standardError: { backgroundColor: '#f1dfd9' },
+      },
+    },
+    MuiDialog: {
+      styleOverrides: { paper: { border: `1px solid ${rule}`, backgroundColor: paperLight } },
+    },
+    MuiDialogTitle: {
+      styleOverrides: { root: { fontFamily: '"Songti SC", STSong, Georgia, serif', fontWeight: 700, borderBottom: `1px solid ${rule}` } },
+    },
+    MuiToggleButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 1,
+          color: ink,
+          borderColor: rule,
+          '&.Mui-selected': { color: '#29463d', backgroundColor: alpha(jade, 0.15) },
+        },
+      },
+    },
+    MuiStepper: {
+      styleOverrides: { root: { backgroundColor: 'transparent' } },
+    },
+    MuiStepIcon: {
+      styleOverrides: {
+        root: {
+          color: '#c7c1b3',
+          '&.Mui-active': { color: seal },
+          '&.Mui-completed': { color: jade },
+        },
+        text: { fill: '#fffdf7', fontWeight: 700 },
+      },
+    },
+    MuiTooltip: { styleOverrides: { tooltip: { backgroundColor: ink, color: '#fffdf7', borderRadius: 1 } } },
+  },
+});

--- a/web/tests/knownStrongTeams.spec.js
+++ b/web/tests/knownStrongTeams.spec.js
@@ -4,7 +4,7 @@ const { database, seedGame, makeGameState, heroesWithMeta, anySkills } = require
 // Acceptance tests for the 已知强力阵容 panel (web/src/components/game/KnownStrongTeams.js):
 //   - renders above the "AI 推荐" panel during hero rounds
 //   - surfaces known strong comps that overlap the current team
-//   - rows are sorted by tier, strongest first
+//   - formation cards are sorted by tier, strongest first
 //   - hidden entirely on skill rounds
 
 const TIER_ORDER = { OP: 0, T0: 1, 'T1+': 2, T1: 3, T2: 4, T3: 5, T4: 6 };
@@ -47,7 +47,7 @@ test.describe('已知强力阵容 panel', () => {
     expect(panelBox.y).toBeLessThan(recBox.y);
   });
 
-  test('hero round: rows are sorted by tier, strongest first', async ({ page }) => {
+  test('hero round: formation cards are sorted by tier, strongest first', async ({ page }) => {
     await seedGame(
       page,
       makeGameState({ roundNumber: 1, heroes: team, skills: anySkills(8) }),
@@ -58,7 +58,7 @@ test.describe('已知强力阵容 panel', () => {
     await expect(page.getByRole('heading', { name: '已知强力阵容' })).toBeVisible({ timeout: 15000 });
 
     const panel = page.locator('.MuiPaper-root', { hasText: '已知强力阵容' }).first();
-    const tierTexts = await panel.locator('tbody tr td:first-child').allInnerTexts();
+    const tierTexts = await panel.getByTestId('team-tier').allInnerTexts();
     expect(tierTexts.length).toBeGreaterThan(1);
 
     const ranks = tierTexts.map((t) => TIER_ORDER[t.trim()] ?? Number.MAX_SAFE_INTEGER);

--- a/web/tests/knownStrongTeams.spec.js
+++ b/web/tests/knownStrongTeams.spec.js
@@ -75,7 +75,7 @@ test.describe('已知强力阵容 panel', () => {
 
     await page.getByRole('button', { name: '获取 AI 推荐' }).click();
     // Recommendation rendered (skill round), but no 已知强力阵容 panel.
-    await expect(page.getByText('📊 选项分析')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('选项分析')).toBeVisible({ timeout: 15000 });
     await expect(page.getByRole('heading', { name: '已知强力阵容' })).toHaveCount(0);
   });
 });

--- a/web/tests/optionAnalysisLabels.spec.js
+++ b/web/tests/optionAnalysisLabels.spec.js
@@ -30,7 +30,7 @@ test.describe('选项分析 — hero & skill labels', () => {
     );
 
     await page.getByRole('button', { name: '获取 AI 推荐' }).click();
-    await expect(page.getByText('📊 选项分析')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('选项分析')).toBeVisible({ timeout: 15000 });
 
     // Every candidate hero renders its labeled chip in 选项分析 (labels render
     // nowhere else — see the scoping test below).
@@ -55,7 +55,7 @@ test.describe('选项分析 — hero & skill labels', () => {
     );
 
     await page.getByRole('button', { name: '获取 AI 推荐' }).click();
-    await expect(page.getByText('📊 选项分析')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('选项分析')).toBeVisible({ timeout: 15000 });
 
     for (const skill of candidates) {
       await expect(page.getByText(skillChipLabel(skill), { exact: true }).first()).toBeVisible();

--- a/web/tests/optionAnalysisLabels.spec.js
+++ b/web/tests/optionAnalysisLabels.spec.js
@@ -14,6 +14,27 @@ const {
 // autocomplete, setup form) was intentionally left showing bare names.
 
 test.describe('选项分析 — hero & skill labels', () => {
+  test('desktop: all three option sets share one horizontal row', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    const team = heroesWithMeta.slice(0, 4);
+    const candidates = heroesWithMeta.slice(4, 13);
+
+    await seedGame(
+      page,
+      makeGameState({ roundNumber: 1, heroes: team, skills: anySkills(8) }),
+      { set1: candidates.slice(0, 3), set2: candidates.slice(3, 6), set3: candidates.slice(6, 9) },
+    );
+
+    await page.getByRole('button', { name: '获取 AI 推荐' }).click();
+    const cards = page.getByTestId('analysis-set-card');
+    await expect(cards).toHaveCount(3, { timeout: 15000 });
+    const boxes = await cards.evaluateAll((nodes) => nodes.map((node) => node.getBoundingClientRect()));
+
+    expect(Math.max(...boxes.map(({ y }) => y)) - Math.min(...boxes.map(({ y }) => y))).toBeLessThan(2);
+    expect(boxes[0].x).toBeLessThan(boxes[1].x);
+    expect(boxes[1].x).toBeLessThan(boxes[2].x);
+  });
+
   test('hero round: candidate chips under 武将评分 show 定位#排名', async ({ page }) => {
     // 4 team heroes + 9 distinct candidate heroes (3 per option set), all with metadata.
     const team = heroesWithMeta.slice(0, 4);

--- a/web/tests/supportHeroSkills.spec.js
+++ b/web/tests/supportHeroSkills.spec.js
@@ -264,8 +264,8 @@ test.describe('Support Hero & Skills', () => {
     await page.goto('/team-builder');
     await expect(page.getByText('查看与管理当前队伍配置')).toBeVisible({ timeout: 5000 });
 
-    // Scope checks to the 当前队伍 Paper section on TeamBuilder page
-    const teamSection = page.locator('.MuiPaper-root', { hasText: '📋 当前队伍' }).first();
+    // Scope checks to the 当前阵容 Paper section on TeamBuilder page
+    const teamSection = page.locator('.MuiPaper-root', { hasText: '当前阵容' }).first();
 
     // Support hero should appear exactly once in the team section
     const tbSupportHeroChips = teamSection.getByText(`⭐支援 ${supportHeroCandidate}`);


### PR DESCRIPTION
## Intent

Redesign the hobby website in ./web away from the default theme using the approved option 2 ink-and-paper command-table direction, with no backwards-compatibility requirement and using web/refs only as visual context. Preserve the branding as 三国谋定天下演武参谋 and remove 墨策台 from site metadata; keep 演武策牒 in the left rail but remove the unexplained divider before the generated date. Present all three 选项分析 sets side-by-side on desktop while retaining responsive mobile behavior. Redesign 已知强力阵容 as a cleaner, icon-free formation-card presentation that clearly distinguishes heroes already owned, obtainable this round, and missing. Remove the label 尽早添加支援武将和战法，推荐会更准确 from the current-team header. Preserve recommendation logic, game behavior, and the existing new-battles indicator.

## What Changed

- Reworked the web app's visual design around an ink-and-paper "command table" theme: expanded `theme/theme.ts` and updated layout (`AppLayout`, `Header`, `JoinGroupButton`), setup, and page components; branding stays 三国谋定天下演武参谋 with 墨策台 removed from `index.html`/`manifest.json` metadata and the unexplained divider dropped from the left-rail 演武策牒 date.
- Changed the 选项分析 grid (`AnalysisGrid`/`OptionSetInput`) to show all three option sets side-by-side on desktop while keeping responsive mobile behavior, and rebuilt 已知强力阵容 (`KnownStrongTeams`) as an icon-free formation-card layout distinguishing owned, obtainable-this-round, and missing heroes.
- Removed the 尽早添加支援武将和战法，推荐会更准确 hint from the current-team header while preserving recommendation logic, game behavior, and the 新增 added-battles indicator; updated Playwright specs (`knownStrongTeams`, `optionAnalysisLabels`, `supportHeroSkills`) accordingly.

## Risk Assessment

✅ Low: The change is a well-bounded, client-side-only visual/theme redesign with recommendation and game logic left intact; JSX restructuring is balanced and tests were updated to match, with no correctness, security, or behavioral regressions found.

## Testing

Baseline setup required fixing an environment issue (a missing rolldown darwin-arm64 native binding after npm ci, plus using node v22.17.1 since the default v20.15.1 is too old for vitest 4); after that, typecheck and all 41 Vitest unit tests passed and the full 19-test Playwright e2e suite passed, including the modified specs that encode the redesign's behavioral assertions. I then captured six reviewer-visible screenshots (desktop full page, side-by-side 选项分析, icon-free 已知强力阵容 formation cards, vertical 演武策牒 left rail with dividerless date, dividerless 当前阵容 header, and mobile responsive stack) that visually confirm each item of the user intent; the transient screenshot spec and installed dev artifacts were cleaned up, leaving the working tree clean.

- Evidence: Desktop full-page redesign (ink-and-paper theme, left rail, 选项分析, 已知强力阵容, 当前阵容) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXCWTYKN511YC8SZB1TXJ965/01-desktop-full.png</code>)
- Evidence: 选项分析 — all three option sets side-by-side on desktop (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXCWTYKN511YC8SZB1TXJ965/02-option-analysis-sidebyside.png</code>)
- Evidence: 已知强力阵容 — icon-free formation cards (已在阵中/本轮可取/尚未拥有) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXCWTYKN511YC8SZB1TXJ965/03-known-strong-teams.png</code>)
- Evidence: Left rail — vertical 演武策牒 + generated date, no divider, 新增 indicator preserved (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXCWTYKN511YC8SZB1TXJ965/04-left-rail.png</code>)
- Evidence: 当前阵容 header — removed &#39;尽早添加…&#39; hint (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXCWTYKN511YC8SZB1TXJ965/05-current-team-header.png</code>)
- Evidence: Mobile responsive — option sets stack vertically (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXCWTYKN511YC8SZB1TXJ965/06-mobile-full.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `web/src/components/layout/AppLayout.tsx:81` - JoinGroupButton is mounted twice in AppLayout (lines 81 and 88) to place it in both the lg+ toolbar and the sub-lg row, toggled purely via CSS display. Each instance keeps independent dialog state and renders its own QR image, so two copies are always in the DOM. Harmless but a candidate for a single shared instance if the responsive placement is ever unified.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm run typecheck` (tsc --noEmit) — clean</code>
- <code>`npx vitest run` — 41 unit tests pass (8 files), incl. recommendation/prompt characterization snapshots</code>
- <code>`npx playwright test optionAnalysisLabels.spec.js knownStrongTeams.spec.js supportHeroSkills.spec.js` — 12 pass (incl. new desktop side-by-side option-sets assertion and formation-card tier ordering)</code>
- <code>`npx playwright test buildATeam.spec.js gameRounds.spec.js setup.spec.js` — 7 pass (no regressions)</code>
- <code>Custom screenshot spec `tests/_evidence.spec.js` (removed after run) driving a seeded hero round to capture desktop full page, 选项分析 grid, 已知强力阵容 panel, left rail, 当前阵容 header, and mobile viewport; asserted title contains 三国谋定天下演武参谋 and &#39;尽早添加&#39; copy count is 0</code>
- <code>`grep -rn 墨策台` over index.html/manifest/src — no matches in site metadata</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
