### PR TITLE
docs: require telemetry-disabled no-mistakes runs in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,10 +24,11 @@ working tree; steps 4–5 go through the `no-mistakes` gate.
    [Scope tests to the changed workspace](#scope-tests-to-the-changed-workspace)).
    Commit on the feature branch.
 
-4. **Validate with `no-mistakes`.** Drive the gate — `/no-mistakes` in Claude
-   Code, or `no-mistakes axi run --intent "<the requirement from step 1>"`. The
-   pipeline runs *review → test → document → lint → push → PR → CI* and opens a PR
-   only after every step passes. See [no-mistakes and the test
+4. **Validate with `no-mistakes` (telemetry disabled).** Follow the telemetry
+   setup below, then drive the gate — `/no-mistakes` in Claude Code, or
+   `NO_MISTAKES_TELEMETRY=off no-mistakes axi run --intent "<the requirement from step 1>"`.
+   The pipeline runs *review → test → document → lint → push → PR → CI* and opens
+   a PR only after every step passes. See [no-mistakes and the test
    step](#no-mistakes-and-the-test-step) for how scoping applies here.
 
 5. **Merge.** The gate stops at `checks-passed` (PR ready, CI green) and leaves the
@@ -59,12 +60,28 @@ Notes:
 
 ## no-mistakes and the test step
 
+### Disable telemetry
+
+All `no-mistakes` runs for this repository must have telemetry disabled for
+both the CLI and its background daemon. Set the opt-out in the login-shell
+environment used by the daemon and restart it once after adding the setting:
+
+```bash
+export NO_MISTAKES_TELEMETRY=off
+no-mistakes daemon restart
+```
+
+Keep `NO_MISTAKES_TELEMETRY=off` in the login-shell startup file so future
+daemon restarts retain the opt-out. Also prefix each CLI invocation with the
+variable as defense in depth. Setting it only inline on `axi run` is not enough
+when an already-running daemon was started with telemetry enabled.
+
 The `no-mistakes` gate has its own **test** step, and the same scoping rule
 applies there — it should exercise only the changed workspace:
 
 - **Skip the test step entirely** when the change touches only areas with no tests
   (docs, `autojs/`, `learn/`, etc.):
-  `no-mistakes axi run --intent "..." --skip=test`.
+  `NO_MISTAKES_TELEMETRY=off no-mistakes axi run --intent "..." --skip=test`.
 - **Otherwise let the test step run**, and rely on this document (surfaced to the
   gate's test agent via `CLAUDE.md`) plus a clear `--intent` so it picks the
   workspace-appropriate tests rather than the full suite. For example, for a


### PR DESCRIPTION
## Intent

Update DEVELOPMENT.md so every no-mistakes validation for this repository runs with telemetry disabled. Document that the opt-out must cover both the CLI and background daemon, include the persistent login-shell and daemon-restart setup, prefix CLI examples with NO_MISTAKES_TELEMETRY=off, and explain why an inline-only setting is insufficient for an already-running daemon.

## What Changed

- Updated the "Disable telemetry" guidance in `DEVELOPMENT.md` to require every `no-mistakes` validation for this repo to run with telemetry off for both the CLI and its background daemon.
- Documented the persistent setup: export `NO_MISTAKES_TELEMETRY=off` in the login-shell startup file, run `no-mistakes daemon restart` once, and prefix each CLI invocation (`axi run`) with the variable as defense in depth.
- Explained why an inline-only `axi run` setting is insufficient when the daemon was already started with telemetry enabled.

## Risk Assessment

✅ Low: The change is a documentation-only edit to DEVELOPMENT.md that clearly and accurately fulfills the stated intent with no code or behavior impact.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
