### PR TITLE
fix(web): improve accessibility and mobile layout

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -121,6 +121,7 @@ web/
 ### Common
 - **ErrorBoundary**: Global error handling
 - **LoadingSkeleton**: Loading states for better UX
+- **ResponsiveDisclosure**: Keeps dense detail expanded on larger screens while giving mobile users a toggle to collapse it (content stays mounted)
 
 ## Data & Logic
 

--- a/web/src/components/common/ErrorBoundary.tsx
+++ b/web/src/components/common/ErrorBoundary.tsx
@@ -61,7 +61,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
                 mb: 2,
               }}
             />
-            <Typography variant="h5" gutterBottom>
+            <Typography component="h1" variant="h5" gutterBottom>
               出错了
             </Typography>
             <Typography variant="body1" color="text.secondary" paragraph>

--- a/web/src/components/common/ResponsiveDisclosure.tsx
+++ b/web/src/components/common/ResponsiveDisclosure.tsx
@@ -1,0 +1,52 @@
+import { useId, useState, type ReactNode } from 'react';
+import { Box, Button, Collapse, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+interface ResponsiveDisclosureProps {
+  children: ReactNode;
+  label: string;
+  defaultMobileOpen?: boolean;
+}
+
+/**
+ * Keeps content expanded on larger screens while giving mobile users control
+ * over dense supporting detail. Content remains mounted so state is preserved.
+ */
+const ResponsiveDisclosure = ({
+  children,
+  label,
+  defaultMobileOpen = false,
+}: ResponsiveDisclosureProps) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const [mobileOpen, setMobileOpen] = useState(defaultMobileOpen);
+  const contentId = useId();
+  const expanded = !isMobile || mobileOpen;
+
+  return (
+    <Box>
+      {isMobile && (
+        <Button
+          type="button"
+          variant="outlined"
+          size="small"
+          fullWidth
+          aria-expanded={expanded}
+          aria-controls={contentId}
+          onClick={() => setMobileOpen((open) => !open)}
+          startIcon={expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          sx={{ mb: expanded ? 1.5 : 0 }}
+        >
+          {expanded ? `收起${label}` : `展开${label}`}
+        </Button>
+      )}
+      <Collapse in={expanded} timeout="auto">
+        <Box id={contentId}>{children}</Box>
+      </Collapse>
+    </Box>
+  );
+};
+
+export default ResponsiveDisclosure;

--- a/web/src/components/common/__tests__/ResponsiveDisclosure.test.tsx
+++ b/web/src/components/common/__tests__/ResponsiveDisclosure.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ResponsiveDisclosure from '../ResponsiveDisclosure';
+
+const mockMatchMedia = (matches: boolean) => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+};
+
+describe('ResponsiveDisclosure', () => {
+  test('keeps desktop content expanded without adding a disclosure control', () => {
+    mockMatchMedia(false);
+
+    render(
+      <ResponsiveDisclosure label="详细数据">
+        <div>详细内容</div>
+      </ResponsiveDisclosure>
+    );
+
+    expect(screen.getByText('详细内容')).toBeVisible();
+    expect(screen.queryByRole('button', { name: '展开详细数据' })).not.toBeInTheDocument();
+  });
+
+  test('starts collapsed on mobile and exposes an accessible toggle', async () => {
+    mockMatchMedia(true);
+
+    render(
+      <ResponsiveDisclosure label="详细数据">
+        <div>详细内容</div>
+      </ResponsiveDisclosure>
+    );
+
+    const toggle = screen.getByRole('button', { name: '展开详细数据' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole('button', { name: '收起详细数据' })).toHaveAttribute('aria-expanded', 'true');
+    await waitFor(() => expect(screen.getByText('详细内容')).toBeVisible());
+  });
+});

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -4,6 +4,7 @@ import StarIcon from '@mui/icons-material/Star';
 import { HERO_RECOMMEND_OPTIONS, SKILL_RECOMMEND_OPTIONS } from '../../services/recommendationEngine';
 import { formatHeroRank, formatSkillTier } from '../../utils/itemMetadata';
 import type { CurrentRoundInputs, SetName, RoundType, HeroMeta, SkillMeta } from '../../types/game';
+import ResponsiveDisclosure from '../common/ResponsiveDisclosure';
 
 interface AnalysisGridProps {
   sets: CurrentRoundInputs;
@@ -102,13 +103,13 @@ const AnalysisGrid = ({
           <CardContent sx={{ pt: 5 }}>
             <Box>
               <Typography variant="overline" color="text.secondary">OPTION {String.fromCharCode(65 + index)}</Typography>
-              <Typography variant="h5" gutterBottom>
+              <Typography component="h3" variant="h5" gutterBottom>
                 第{index + 1}组
               </Typography>
             
               {setAnalysis?.final_score !== undefined && (
               <Box sx={{ mb: 2 }}>
-                <Typography variant="h4" color="primary">
+                <Typography component="p" variant="h4" color="primary">
                   {setAnalysis.final_score.toFixed(1)}
                 </Typography>
                 <Typography variant="caption" color="text.secondary">
@@ -119,7 +120,7 @@ const AnalysisGrid = ({
             </Box>
             
             <Box sx={{ mb: 2, minWidth: 0 }}>
-              <Typography variant="subtitle2" gutterBottom>
+              <Typography component="div" variant="subtitle2" gutterBottom>
                 {roundType === 'hero' ? '武将评分:' : '战法评分:'}
               </Typography>
               {items.map((item, idx) => {
@@ -144,6 +145,7 @@ const AnalysisGrid = ({
               })}
             </Box>
             
+            <ResponsiveDisclosure label={`第${index + 1}组详细分析`}>
             {roundType === 'hero' && (
               <>
                 <Box sx={{ mb: 2, p: 1, bgcolor: 'action.hover', borderRadius: 1 }}>
@@ -325,6 +327,7 @@ const AnalysisGrid = ({
                 )}
               </>
             )}
+            </ResponsiveDisclosure>
             
             <Button
               variant={isSelected ? "contained" : "outlined"}
@@ -347,7 +350,7 @@ const AnalysisGrid = ({
       <Typography variant="overline" color="error.main">
         参谋推演
       </Typography>
-      <Typography variant="h5" gutterBottom>
+      <Typography component="h2" variant="h5" gutterBottom>
         选项分析
       </Typography>
       <Grid container spacing={1.5}>

--- a/web/src/components/game/CurrentTeam.tsx
+++ b/web/src/components/game/CurrentTeam.tsx
@@ -137,7 +137,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
           <Box sx={{ mr: 1 }}>
             <Typography variant="overline" color="error.main" sx={{ display: 'block', lineHeight: 1.2 }}>CURRENT ROSTER</Typography>
-            <Typography variant="h5">当前阵容</Typography>
+            <Typography component="h2" variant="h5">当前阵容</Typography>
           </Box>
           {heroes.length <= 10 && !hasSupportHero && (
             <Button
@@ -196,7 +196,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
       
       <Grid container spacing={3}>
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="subtitle2" gutterBottom>
+          <Typography component="div" variant="subtitle2" gutterBottom>
             武将 ({editMode ? editedHeroes.length : heroes.length}{supportHero ? ' +1支援' : ''})
           </Typography>
           
@@ -232,7 +232,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
         </Grid>
         
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="subtitle2" gutterBottom>
+          <Typography component="div" variant="subtitle2" gutterBottom>
             战法 ({editMode ? editedSkills.length : skills.length}{(supportSkills || []).length > 0 ? ` +${supportSkills.length}支援` : ''})
           </Typography>
           
@@ -273,7 +273,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
         <DialogTitle>推荐支援武将</DialogTitle>
         <DialogContent>
           <Box sx={{ mb: 2 }}>
-            <Typography variant="subtitle2" gutterBottom>
+            <Typography component="div" variant="subtitle2" gutterBottom>
               手动搜索武将：
             </Typography>
             <AutocompleteInput
@@ -290,7 +290,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
               <Alert severity="success" sx={{ mb: 2 }}>
                 推荐武将：<strong>{heroRecResult.hero}</strong>
               </Alert>
-              <Typography variant="subtitle2" gutterBottom>
+              <Typography component="div" variant="subtitle2" gutterBottom>
                 或从推荐列表中选择：
               </Typography>
               <List dense>
@@ -353,7 +353,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
         <DialogTitle>推荐支援战法</DialogTitle>
         <DialogContent>
           <Box sx={{ mb: 2 }}>
-            <Typography variant="subtitle2" gutterBottom>
+            <Typography component="div" variant="subtitle2" gutterBottom>
               手动搜索战法（最多选2个）：
             </Typography>
             <AutocompleteInput
@@ -386,7 +386,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
                   <Chip key={i} label={s} color="secondary" size="small" sx={{ ml: 0.5 }} />
                 ))}
               </Alert>
-              <Typography variant="subtitle2" gutterBottom>
+              <Typography component="div" variant="subtitle2" gutterBottom>
                 或从推荐列表中选择：
               </Typography>
               <List dense>

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -70,7 +70,7 @@ const GameBoard = () => {
           <RoundInfo roundNumber={7} />
           <Paper sx={{ p: 3, mb: 3, textAlign: "center" }}>
             <Typography variant="overline" color="error.main">州内小组赛</Typography>
-            <Typography variant="h4" gutterBottom sx={{ mb: 3 }}>
+            <Typography component="h2" variant="h4" gutterBottom sx={{ mb: 3 }}>
               整军再战
             </Typography>
             <CurrentTeam

--- a/web/src/components/game/KnownStrongTeams.tsx
+++ b/web/src/components/game/KnownStrongTeams.tsx
@@ -1,6 +1,7 @@
 import { Paper, Typography, Box, type SxProps } from '@mui/material';
 import { selectRelevantTeamComps } from '../../services/promptGenerator';
 import { tierRank } from '../../utils/tiers';
+import ResponsiveDisclosure from '../common/ResponsiveDisclosure';
 
 type OwnershipStatus = 'owned' | 'candidate' | 'missing';
 
@@ -22,7 +23,12 @@ const STATUS: Record<OwnershipStatus, StatusStyle> = {
   },
   missing: {
     label: '尚未拥有',
-    sx: { borderColor: 'divider', bgcolor: 'rgba(29,36,33,0.025)', opacity: 0.56 },
+    sx: {
+      borderColor: 'divider',
+      borderStyle: 'dashed',
+      bgcolor: 'rgba(29,36,33,0.035)',
+      color: 'text.secondary',
+    },
   },
 };
 
@@ -103,7 +109,7 @@ const KnownStrongTeams = ({ selectedHeroes = [], candidateHeroes = [], isFirstRo
       >
         <Box>
           <Typography variant="overline" color="error.main">阵容情报</Typography>
-          <Typography variant="h6">已知强力阵容</Typography>
+          <Typography component="h2" variant="h6">已知强力阵容</Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
             根据当前武将与本轮选项，找出可衔接的成型队伍。
           </Typography>
@@ -125,65 +131,67 @@ const KnownStrongTeams = ({ selectedHeroes = [], candidateHeroes = [], isFirstRo
         ))}
       </Box>
 
-      <Box
-        component="ol"
-        sx={{
-          listStyle: 'none',
-          m: 0,
-          p: 0,
-          display: 'grid',
-          gridTemplateColumns: { xs: 'minmax(0, 1fr)', xl: 'repeat(2, minmax(0, 1fr))' },
-          gap: 1.25,
-        }}
-      >
-        {sorted.map(({ comp }, idx) => (
-          <Box
-            component="li"
-            data-testid="strong-team-row"
-            key={`${comp.tier}-${comp.heroes.join('-')}-${idx}`}
-            sx={{
-              display: 'grid',
-              gridTemplateColumns: { xs: '52px minmax(0, 1fr)', sm: '64px minmax(0, 1fr)' },
-              border: '1px solid',
-              borderColor: 'divider',
-              bgcolor: 'rgba(251,248,239,0.72)',
-            }}
-          >
+      <ResponsiveDisclosure label={`${sorted.length}组强力阵容`}>
+        <Box
+          component="ol"
+          sx={{
+            listStyle: 'none',
+            m: 0,
+            p: 0,
+            display: 'grid',
+            gridTemplateColumns: { xs: 'minmax(0, 1fr)', xl: 'repeat(2, minmax(0, 1fr))' },
+            gap: 1.25,
+          }}
+        >
+          {sorted.map(({ comp }, idx) => (
             <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                justifyContent: 'center',
-                bgcolor: idx === 0 ? '#243b34' : '#e7dfcc',
-                color: idx === 0 ? '#fff8e9' : 'text.primary',
-                borderRight: '1px solid',
-                borderColor: idx === 0 ? '#243b34' : 'divider',
-                px: 0.75,
-              }}
-            >
-              <Typography data-testid="team-tier" sx={{ fontFamily: 'Georgia, serif', fontWeight: 800, fontSize: 18 }}>
-                {comp.tier}
-              </Typography>
-              <Typography variant="caption" sx={{ opacity: 0.7, fontSize: 10 }}>强度</Typography>
-            </Box>
-            <Box
+              component="li"
+              data-testid="strong-team-row"
+              key={`${comp.tier}-${comp.heroes.join('-')}-${idx}`}
               sx={{
                 display: 'grid',
-                gridTemplateColumns: `repeat(${comp.heroes.length}, minmax(0, 1fr))`,
-                gap: 0.75,
-                p: 0.75,
+                gridTemplateColumns: { xs: '52px minmax(0, 1fr)', sm: '64px minmax(0, 1fr)' },
+                border: '1px solid',
+                borderColor: 'divider',
+                bgcolor: 'rgba(251,248,239,0.72)',
               }}
             >
-              {comp.heroes.map((hero) => (
-                <Box key={hero}>
-                  <HeroChip hero={hero} status={statusOf(hero)} />
-                </Box>
-              ))}
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  bgcolor: idx === 0 ? '#243b34' : '#e7dfcc',
+                  color: idx === 0 ? '#fff8e9' : 'text.primary',
+                  borderRight: '1px solid',
+                  borderColor: idx === 0 ? '#243b34' : 'divider',
+                  px: 0.75,
+                }}
+              >
+                <Typography data-testid="team-tier" sx={{ fontFamily: 'Georgia, serif', fontWeight: 800, fontSize: 18 }}>
+                  {comp.tier}
+                </Typography>
+                <Typography variant="caption" sx={{ opacity: 0.7, fontSize: 10 }}>强度</Typography>
+              </Box>
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: `repeat(${comp.heroes.length}, minmax(0, 1fr))`,
+                  gap: 0.75,
+                  p: 0.75,
+                }}
+              >
+                {comp.heroes.map((hero) => (
+                  <Box key={hero}>
+                    <HeroChip hero={hero} status={statusOf(hero)} />
+                  </Box>
+                ))}
+              </Box>
             </Box>
-          </Box>
-        ))}
-      </Box>
+          ))}
+        </Box>
+      </ResponsiveDisclosure>
     </Paper>
   );
 };

--- a/web/src/components/game/OptionSetInput.tsx
+++ b/web/src/components/game/OptionSetInput.tsx
@@ -69,7 +69,7 @@ const OptionSetInput = ({
           gap: 2,
           bgcolor: 'rgba(251,248,239,0.58)',
         }}>
-          <Typography variant="h6" sx={{ mb: { xs: 1.5, sm: 0 } }}>
+          <Typography component="h3" variant="h6" sx={{ mb: { xs: 1.5, sm: 0 } }}>
             {setLabel} ({currentSet.length}/{itemsPerSet})
           </Typography>
           
@@ -107,7 +107,7 @@ const OptionSetInput = ({
       <Typography variant="overline" color="error.main">
         本轮候选
       </Typography>
-      <Typography variant="h5" gutterBottom>
+      <Typography component="h2" variant="h5" gutterBottom>
         填写三组选项
       </Typography>
       <Typography variant="body2" color="text.secondary" paragraph>

--- a/web/src/components/game/RecommendationPanel.tsx
+++ b/web/src/components/game/RecommendationPanel.tsx
@@ -23,7 +23,7 @@ const RecommendationPanel = ({ recommendation, roundType }: RecommendationPanelP
         <AutoAwesomeOutlinedIcon sx={{ mr: 1, fontSize: 28, color: 'primary.main' }} />
         <Box>
           <Typography variant="overline" color="primary.dark" sx={{ display: 'block', lineHeight: 1.1 }}>参谋建议</Typography>
-          <Typography variant="h6">AI 推荐</Typography>
+          <Typography component="h2" variant="h6">AI 推荐</Typography>
         </Box>
       </Box>
       

--- a/web/src/components/game/RoundInfo.tsx
+++ b/web/src/components/game/RoundInfo.tsx
@@ -13,13 +13,23 @@ interface RoundInfoProps {
 const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
   const navigate = useNavigate();
   const info = getRoundInfo(roundNumber);
+  const rounds = [1, 2, 3, 4, 5, 6, 7, 8];
   
   return (
     <Paper sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, position: 'relative', borderTop: '3px solid', borderTopColor: 'text.primary' }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 2, mb: 2 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          justifyContent: 'space-between',
+          alignItems: { xs: 'stretch', sm: 'flex-start' },
+          gap: 2,
+          mb: 2,
+        }}
+      >
         <Box sx={{ flex: 1 }}>
           <Chip size="small" color="error" variant="outlined" label={`第 ${roundNumber} / 8 轮`} sx={{ mb: 1.5 }} />
-          <Typography variant="h4" gutterBottom>
+          <Typography component="h1" variant="h4" gutterBottom>
             {info.title}
           </Typography>
           <Typography variant="body1" color="text.secondary" paragraph>
@@ -33,16 +43,74 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
             size="small"
             startIcon={<AccountTreeOutlinedIcon />}
             onClick={() => navigate('/team-builder')}
-            sx={{ ml: 2, flexShrink: 0 }}
+            sx={{ ml: { xs: 0, sm: 2 }, flexShrink: 0, width: { xs: '100%', sm: 'auto' } }}
           >
             查看队伍推荐
           </Button>
         )}
       </Box>
       
-      <Box sx={{ overflowX: 'auto', pt: 1 }}>
+      <Box
+        role="list"
+        aria-label="8 轮进度"
+        sx={{
+          display: { xs: 'grid', sm: 'none' },
+          gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+          gap: 0.75,
+          pt: 1,
+        }}
+      >
+        {rounds.map((round) => {
+          const isHero = round === 1 || round === 4 || round === 7;
+          const isActive = round === roundNumber;
+          const isComplete = round < roundNumber;
+          const status = isActive ? '当前' : isComplete ? '已完成' : '未开始';
+
+          return (
+            <Box
+              key={round}
+              role="listitem"
+              aria-current={isActive ? 'step' : undefined}
+              aria-label={`第 ${round} 轮，${isHero ? '武将' : '战法'}，${status}`}
+              sx={{
+                minWidth: 0,
+                p: 0.75,
+                textAlign: 'center',
+                borderTop: '3px solid',
+                borderColor: isActive ? 'error.main' : isComplete ? 'primary.main' : 'divider',
+                bgcolor: isActive ? 'rgba(168,57,47,0.07)' : isComplete ? 'rgba(69,108,95,0.07)' : 'transparent',
+              }}
+            >
+              <Typography component="span" variant="caption" sx={{ display: 'block', fontWeight: 800 }}>
+                {isComplete ? '✓' : round}
+              </Typography>
+              <Typography component="span" variant="caption" sx={{ display: 'block', fontWeight: isActive ? 800 : 600 }}>
+                第 {round} 轮
+              </Typography>
+              <Typography component="span" variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                {isHero ? '武将' : '战法'}
+              </Typography>
+            </Box>
+          );
+        })}
+      </Box>
+
+      <Box
+        role="region"
+        aria-label="8 轮进度，可横向滚动"
+        tabIndex={0}
+        sx={{
+          display: { xs: 'none', sm: 'block' },
+          overflowX: 'auto',
+          pt: 1,
+          '&:focus-visible': {
+            outline: '3px solid rgba(69,108,95,0.42)',
+            outlineOffset: 2,
+          },
+        }}
+      >
       <Stepper activeStep={roundNumber - 1} alternativeLabel sx={{ mt: 2, minWidth: 660 }}>
-        {[1, 2, 3, 4, 5, 6, 7, 8].map((round) => {
+        {rounds.map((round) => {
           const isHero = round === 1 || round === 4 || round === 7;
           return (
             <Step key={round}>

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -27,6 +27,8 @@ const AppLayout = ({ children }: AppLayoutProps) => {
   const navButtonSx = (path: string) => ({
     minHeight: 42,
     px: 1.75,
+    whiteSpace: 'nowrap',
+    flexShrink: 0,
     color: location.pathname === path ? 'primary.dark' : 'text.secondary',
     border: 0,
     borderBottom: '2px solid',
@@ -43,7 +45,7 @@ const AppLayout = ({ children }: AppLayoutProps) => {
           component="nav"
           aria-label="主要导航"
           sx={{
-            position: 'sticky',
+            position: { xs: 'relative', md: 'sticky' },
             top: { xs: 0, md: 0 },
             zIndex: 15,
             borderBottom: '1px solid',
@@ -54,11 +56,11 @@ const AppLayout = ({ children }: AppLayoutProps) => {
         >
           <Container maxWidth="xl" sx={{ py: 1.25 }}>
             <Stack direction="row" alignItems="center" gap={1} sx={{ minWidth: 0 }}>
-              <Box sx={{ mr: { xs: 0.5, lg: 3 }, minWidth: 0 }}>
+              <Box sx={{ display: { xs: 'none', sm: 'block' }, mr: { sm: 1, lg: 3 }, minWidth: 0 }}>
                 <Typography variant="overline" color="error.main" sx={{ display: { xs: 'none', sm: 'block' }, lineHeight: 1 }}>
                   三国谋定天下
                 </Typography>
-                <Typography variant="h6" sx={{ whiteSpace: 'nowrap', fontSize: { xs: 17, sm: 20 } }}>
+                <Typography component="div" variant="h6" sx={{ whiteSpace: 'nowrap', fontSize: { xs: 17, sm: 20 } }}>
                   演武参谋
                 </Typography>
               </Box>

--- a/web/src/components/setup/SetupForm.tsx
+++ b/web/src/components/setup/SetupForm.tsx
@@ -79,7 +79,7 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
         <Typography variant="overline" color="error.main">
           初始名册 · 演武开局
         </Typography>
-        <Typography variant="h4" gutterBottom>
+        <Typography component="h1" variant="h4" gutterBottom>
           录入当前阵容
         </Typography>
         <Typography variant="body1" color="text.secondary" paragraph>
@@ -94,7 +94,7 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
 
         {/* Heroes Input */}
         <Box sx={{ mb: 3 }}>
-          <Typography variant="h6" gutterBottom sx={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid', borderColor: 'divider', pb: 1 }}>
+          <Typography component="h2" variant="h6" gutterBottom sx={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid', borderColor: 'divider', pb: 1 }}>
             初始武将 ({heroes.length}/4)
           </Typography>
           <AutocompleteInput
@@ -116,7 +116,7 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
 
         {/* Skills Input */}
         <Box sx={{ mb: 3 }}>
-          <Typography variant="h6" gutterBottom sx={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid', borderColor: 'divider', pb: 1 }}>
+          <Typography component="h2" variant="h6" gutterBottom sx={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid', borderColor: 'divider', pb: 1 }}>
             初始战法 ({skills.length}/8)
           </Typography>
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, type ReactNode } from 'react';
 import {
   Container,
   Box,
@@ -26,7 +26,33 @@ import { database } from '../data';
 import { tierRank } from '../utils/tiers';
 import AutocompleteInput from '../components/common/AutocompleteInput';
 import TagList from '../components/common/TagList';
+import ResponsiveDisclosure from '../components/common/ResponsiveDisclosure';
 import type { HeroMeta, SkillMeta } from '../types/game';
+
+interface ScrollableAnalyticsTableProps {
+  children: ReactNode;
+  label: string;
+}
+
+const ScrollableAnalyticsTable = ({ children, label }: ScrollableAnalyticsTableProps) => (
+  <>
+    <Typography
+      variant="caption"
+      color="text.secondary"
+      sx={{ display: { xs: 'block', sm: 'none' }, mb: 0.75 }}
+    >
+      表格可横向滚动，聚焦后也可使用键盘滚动。
+    </Typography>
+    <TableContainer
+      role="region"
+      aria-label={`${label}表格，可滚动`}
+      tabIndex={0}
+      sx={{ maxHeight: 800 }}
+    >
+      {children}
+    </TableContainer>
+  </>
+);
 
 const Analytics = () => {
   // Loose analytics payload from api.getAnalytics().
@@ -187,7 +213,7 @@ const Analytics = () => {
     <Container maxWidth="xl" disableGutters>
       <Box>
         <Typography variant="overline" color="error.main">BATTLE ARCHIVE</Typography>
-        <Typography variant="h3" gutterBottom>
+        <Typography component="h1" variant="h3" gutterBottom>
           数据洞察
         </Typography>
         <Typography variant="body1" color="text.secondary" paragraph>
@@ -197,7 +223,7 @@ const Analytics = () => {
         {/* Filters */}
         <Paper sx={{ p: { xs: 2, sm: 2.5 }, mb: 4, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
           <Box sx={{ display: 'flex', alignItems: 'center', mb: 1, gap: 1 }}>
-            <Typography variant="h6">筛选名册</Typography>
+            <Typography component="h2" variant="h6">筛选名册</Typography>
             {(hasHeroFilter || hasSkillFilter) && (
               <IconButton size="small" onClick={() => { setSelectedHeroes([]); setSelectedSkills([]); }} title="清除所有筛选">
                 <ClearIcon fontSize="small" />
@@ -245,9 +271,10 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography variant="h6">全部武将（按置信调整胜率排序）</Typography>
+                  <Typography component="h2" variant="h6">全部武将（按置信调整胜率排序）</Typography>
                 </Box>
-                <TableContainer sx={{ maxHeight: 800 }}>
+                <ResponsiveDisclosure label="全部武将排名">
+                <ScrollableAnalyticsTable label="全部武将排名">
                   <Table size="small" stickyHeader>
                     <TableHead>
                       <TableRow>
@@ -270,7 +297,8 @@ const Analytics = () => {
                       ))}
                     </TableBody>
                   </Table>
-                </TableContainer>
+                </ScrollableAnalyticsTable>
+                </ResponsiveDisclosure>
               </CardContent>
             </Card>
           </Grid>
@@ -280,9 +308,10 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography variant="h6">全部战法（按置信调整胜率排序）</Typography>
+                  <Typography component="h2" variant="h6">全部战法（按置信调整胜率排序）</Typography>
                 </Box>
-                <TableContainer sx={{ maxHeight: 800 }}>
+                <ResponsiveDisclosure label="全部战法排名">
+                <ScrollableAnalyticsTable label="全部战法排名">
                   <Table size="small" stickyHeader>
                     <TableHead>
                       <TableRow>
@@ -305,7 +334,8 @@ const Analytics = () => {
                       ))}
                     </TableBody>
                   </Table>
-                </TableContainer>
+                </ScrollableAnalyticsTable>
+                </ResponsiveDisclosure>
               </CardContent>
             </Card>
           </Grid>
@@ -316,10 +346,11 @@ const Analytics = () => {
           <Grid size={{ xs: 12, md: 6 }}>
             <Card>
               <CardContent>
-                <Typography variant="h6" gutterBottom>
+                <Typography component="h2" variant="h6" gutterBottom>
                   武将使用排行
                 </Typography>
-                <TableContainer sx={{ maxHeight: 800 }}>
+                <ResponsiveDisclosure label="武将使用排行">
+                <ScrollableAnalyticsTable label="武将使用排行">
                   <Table size="small" stickyHeader>
                     <TableHead>
                       <TableRow>
@@ -340,7 +371,8 @@ const Analytics = () => {
                       ))}
                     </TableBody>
                   </Table>
-                </TableContainer>
+                </ScrollableAnalyticsTable>
+                </ResponsiveDisclosure>
               </CardContent>
             </Card>
           </Grid>
@@ -348,10 +380,11 @@ const Analytics = () => {
           <Grid size={{ xs: 12, md: 6 }}>
             <Card>
               <CardContent>
-                <Typography variant="h6" gutterBottom>
+                <Typography component="h2" variant="h6" gutterBottom>
                   战法使用排行
                 </Typography>
-                <TableContainer sx={{ maxHeight: 800 }}>
+                <ResponsiveDisclosure label="战法使用排行">
+                <ScrollableAnalyticsTable label="战法使用排行">
                   <Table size="small" stickyHeader>
                     <TableHead>
                       <TableRow>
@@ -372,7 +405,8 @@ const Analytics = () => {
                       ))}
                     </TableBody>
                   </Table>
-                </TableContainer>
+                </ScrollableAnalyticsTable>
+                </ResponsiveDisclosure>
               </CardContent>
             </Card>
           </Grid>
@@ -384,12 +418,13 @@ const Analytics = () => {
             <CardContent>
               <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                 <LinkIcon sx={{ mr: 1, color: 'info.main' }} />
-                <Typography variant="h6">武将羁绊依赖分析</Typography>
+                <Typography component="h2" variant="h6">武将羁绊依赖分析</Typography>
               </Box>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                 部分武将的胜率高度依赖特定搭档。"增幅"表示有搭档 vs 无搭档的胜率差值，"占比"表示与该搭档同队的比赛占总场次的百分比。
               </Typography>
-              <TableContainer sx={{ maxHeight: 800 }}>
+              <ResponsiveDisclosure label="武将羁绊依赖分析">
+              <ScrollableAnalyticsTable label="武将羁绊依赖分析">
                 <Table size="small" stickyHeader>
                   <TableHead>
                     <TableRow>
@@ -438,7 +473,8 @@ const Analytics = () => {
                     )}
                   </TableBody>
                 </Table>
-              </TableContainer>
+              </ScrollableAnalyticsTable>
+              </ResponsiveDisclosure>
             </CardContent>
           </Card>
         )}
@@ -449,12 +485,13 @@ const Analytics = () => {
             <CardContent>
               <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                 <LinkIcon sx={{ mr: 1, color: 'secondary.main' }} />
-                <Typography variant="h6">战法羁绊依赖分析</Typography>
+                <Typography component="h2" variant="h6">战法羁绊依赖分析</Typography>
               </Box>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                 部分战法的胜率高度依赖特定武将。"增幅"表示有该武将 vs 无该武将时的胜率差值，"占比"表示该战法被该武将使用的比赛占总场次的百分比。
               </Typography>
-              <TableContainer sx={{ maxHeight: 800 }}>
+              <ResponsiveDisclosure label="战法羁绊依赖分析">
+              <ScrollableAnalyticsTable label="战法羁绊依赖分析">
                 <Table size="small" stickyHeader>
                   <TableHead>
                     <TableRow>
@@ -503,7 +540,8 @@ const Analytics = () => {
                     )}
                   </TableBody>
                 </Table>
-              </TableContainer>
+              </ScrollableAnalyticsTable>
+              </ResponsiveDisclosure>
             </CardContent>
           </Card>
         )}
@@ -511,10 +549,11 @@ const Analytics = () => {
         {/* Winning Combinations */}
         <Card>
           <CardContent>
-            <Typography variant="h6" gutterBottom>
+            <Typography component="h2" variant="h6" gutterBottom>
               武将三人组合胜率排行（按置信调整胜率排序）
             </Typography>
-            <TableContainer sx={{ maxHeight: 800 }}>
+            <ResponsiveDisclosure label="武将三人组合胜率排行">
+            <ScrollableAnalyticsTable label="武将三人组合胜率排行">
               <Table stickyHeader>
                 <TableHead>
                   <TableRow>
@@ -547,7 +586,8 @@ const Analytics = () => {
                   ))}
                 </TableBody>
               </Table>
-            </TableContainer>
+            </ScrollableAnalyticsTable>
+            </ResponsiveDisclosure>
           </CardContent>
         </Card>
       </Box>

--- a/web/src/pages/BuildATeam.tsx
+++ b/web/src/pages/BuildATeam.tsx
@@ -419,7 +419,7 @@ const BuildATeam = () => {
       >
         <Box>
           <Typography variant="overline" color="error.main">FORMATION WORKSHOP</Typography>
-          <Typography variant="h3">组队 / Build a Team</Typography>
+          <Typography component="h1" variant="h3">组队 / Build a Team</Typography>
           <Typography variant="body2" color="text.secondary">
             从当前卡池拖拽武将与战法到 3 支队伍（每队 3 武将，每武将 2 战法）。放入后会从卡池移除，清除槽位即可放回。
           </Typography>
@@ -451,7 +451,7 @@ const BuildATeam = () => {
 
       {/* Pool panel — full width */}
       <Paper sx={{ p: { xs: 2, sm: 2.5 }, mb: 2, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
-        <Typography variant="subtitle1" fontWeight={700} gutterBottom>
+        <Typography component="h2" variant="subtitle1" fontWeight={700} gutterBottom>
           卡池武将（{poolHeroes.length}）
         </Typography>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
@@ -490,7 +490,7 @@ const BuildATeam = () => {
 
         <Divider sx={{ my: 2 }} />
 
-        <Typography variant="subtitle1" fontWeight={700} gutterBottom>
+        <Typography component="h2" variant="subtitle1" fontWeight={700} gutterBottom>
           卡池战法（{poolSkills.length}）
         </Typography>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
@@ -540,7 +540,7 @@ const BuildATeam = () => {
                 spacing={1}
                 sx={{ mb: 1.5 }}
               >
-                <Typography variant="subtitle1" fontWeight={700}>
+                <Typography component="h2" variant="subtitle1" fontWeight={700}>
                   队伍 {teamIdx + 1}
                 </Typography>
                 <FormControl size="small" sx={{ minWidth: 110 }}>

--- a/web/src/pages/TeamBuilder.tsx
+++ b/web/src/pages/TeamBuilder.tsx
@@ -19,6 +19,7 @@ import {
 } from '../services/teamPairStats';
 import { copyToClipboard } from '../utils/clipboard';
 import type { BattleStats, StatEntry } from '../types/battleStats';
+import ResponsiveDisclosure from '../components/common/ResponsiveDisclosure';
 
 interface HeroBestPairs {
   bestHeroPair: HeroPairRanking[] | null;
@@ -188,7 +189,7 @@ const TeamBuilder = () => {
           </Button>
           <Box>
             <Typography variant="overline" color="error.main" sx={{ display: 'block', lineHeight: 1.2 }}>FORMATION DOSSIER</Typography>
-            <Typography variant="h3">队伍策案</Typography>
+            <Typography component="h1" variant="h3">队伍策案</Typography>
           </Box>
           {heroes.length >= 3 && (
             <Button
@@ -224,7 +225,7 @@ const TeamBuilder = () => {
         {heroes.length >= 9 && skills.length >= 18 && (
           <Card sx={{ mt: 4 }}>
             <CardContent>
-              <Typography variant="h6" gutterBottom>
+              <Typography component="h2" variant="h6" gutterBottom>
                 推荐组队
               </Typography>
               <Typography variant="body2" color="text.secondary" paragraph>
@@ -248,7 +249,7 @@ const TeamBuilder = () => {
                         }}
                       >
                         <CardContent>
-                          <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+                          <Typography component="h3" variant="subtitle1" fontWeight="bold" gutterBottom>
                             队伍 {teamIdx + 1}
                           </Typography>
                           {team.comboStats && (
@@ -316,9 +317,10 @@ const TeamBuilder = () => {
         {heroes.length >= 3 && (
           <Card sx={{ mt: 4 }}>
             <CardContent>
-              <Typography variant="h6" gutterBottom>
+              <Typography component="h2" variant="h6" gutterBottom>
                 可能的队伍组合
               </Typography>
+              <ResponsiveDisclosure label="可能的队伍组合">
               {loading ? (
                 <Box sx={{ textAlign: 'center', py: 4 }}>
                   <Typography>正在加载推荐...</Typography>
@@ -340,7 +342,7 @@ const TeamBuilder = () => {
                         }}
                       >
                         <CardContent>
-                          <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+                          <Typography component="h3" variant="subtitle1" fontWeight="bold" gutterBottom>
                             队伍 {idx + 1}
                           </Typography>
                           <Box sx={{ mb: 2 }}>
@@ -368,6 +370,7 @@ const TeamBuilder = () => {
                   ))}
                 </Grid>
               )}
+              </ResponsiveDisclosure>
             </CardContent>
           </Card>
         )}
@@ -376,13 +379,14 @@ const TeamBuilder = () => {
         {heroes.length > 0 && (
           <Card sx={{ mt: 4 }}>
             <CardContent>
-              <Typography variant="h6" gutterBottom>
+              <Typography component="h2" variant="h6" gutterBottom>
                 每位武将的最佳搭配
               </Typography>
               <Typography variant="body2" color="text.secondary" paragraph sx={{ mb: 3 }}>
                 根据历史表现，展示当前队伍中每位武将的最佳武将搭档与最佳战法搭配。
               </Typography>
 
+              <ResponsiveDisclosure label="每位武将的最佳搭配">
               {loading ? (
                 <Box sx={{ textAlign: 'center', py: 4 }}>
                   <Typography>正在加载最佳搭配...</Typography>
@@ -397,7 +401,7 @@ const TeamBuilder = () => {
                     <Grid size={{ xs: 12, sm: 6, md: 4 }} key={hero}>
                       <Card variant="outlined">
                         <CardContent>
-                          <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+                          <Typography component="h3" variant="subtitle1" fontWeight="bold" gutterBottom>
                             {hero}
                           </Typography>
                           
@@ -462,6 +466,7 @@ const TeamBuilder = () => {
                   ))}
                 </Grid>
               )}
+              </ResponsiveDisclosure>
             </CardContent>
           </Card>
         )}

--- a/web/src/theme/theme.ts
+++ b/web/src/theme/theme.ts
@@ -7,19 +7,20 @@ const paperDeep = '#e7dfcc';
 const jade = '#456c5f';
 const seal = '#a8392f';
 const gold = '#a38147';
+const accessibleGold = '#765d31';
 const rule = '#c9c2b1';
 
 export const theme = createTheme({
   palette: {
     mode: 'light',
     primary: { main: jade, dark: '#304f45', light: '#dfe8e2', contrastText: '#fffdf7' },
-    secondary: { main: gold, dark: '#725a2f', light: '#eee2ca', contrastText: '#fffdf7' },
+    secondary: { main: accessibleGold, dark: '#5f4925', light: '#eee2ca', contrastText: '#fffdf7' },
     error: { main: seal, dark: '#7e2923', light: '#f1dfd9' },
     warning: { main: gold, dark: '#725a2f', light: '#f0e5cf' },
     success: { main: '#4f755c', dark: '#36523f', light: '#e1eadf' },
     info: { main: '#526d75', dark: '#374e55', light: '#e1e8e9' },
     background: { default: paper, paper: paperLight },
-    text: { primary: ink, secondary: '#667069', disabled: '#979b93' },
+    text: { primary: ink, secondary: '#59635d', disabled: '#858b83' },
     divider: rule,
     action: {
       hover: alpha(jade, 0.07),
@@ -112,8 +113,8 @@ export const theme = createTheme({
         },
         containedSecondary: {
           color: '#fffaf0',
-          backgroundColor: gold,
-          '&:hover': { backgroundColor: '#826637' },
+          backgroundColor: accessibleGold,
+          '&:hover': { backgroundColor: '#5f4925' },
         },
       },
     },
@@ -154,7 +155,16 @@ export const theme = createTheme({
       },
     },
     MuiTableContainer: {
-      styleOverrides: { root: { border: `1px solid ${rule}`, backgroundColor: alpha(paperLight, 0.74) } },
+      styleOverrides: {
+        root: {
+          border: `1px solid ${rule}`,
+          backgroundColor: alpha(paperLight, 0.74),
+          '&:focus-visible': {
+            outline: `3px solid ${alpha(jade, 0.42)}`,
+            outlineOffset: 2,
+          },
+        },
+      },
     },
     MuiTableHead: { styleOverrides: { root: { backgroundColor: paperDeep } } },
     MuiTableCell: {

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -1,0 +1,79 @@
+const { test, expect } = require('@playwright/test');
+const {
+  seedGame,
+  makeGameState,
+  heroesWithMeta,
+  anySkills,
+} = require('./helpers');
+
+const lateRoundState = () => ({
+  ...makeGameState({
+    roundNumber: 7,
+    heroes: heroesWithMeta.slice(0, 9),
+    skills: anySkills(18),
+  }),
+  round7_interstitial_dismissed: true,
+});
+
+const lateRoundInputs = () => ({
+  set1: heroesWithMeta.slice(9, 11),
+  set2: heroesWithMeta.slice(11, 13),
+  set3: heroesWithMeta.slice(13, 15),
+});
+
+test.describe('Accessibility and responsive layout', () => {
+  test('each primary page exposes one level-one heading', async ({ page }) => {
+    await page.context().clearCookies();
+    await page.goto('/');
+    await expect(page.getByRole('heading', { level: 1, name: '录入当前阵容' })).toBeVisible();
+
+    await page.goto('/analytics');
+    await expect(page.getByRole('heading', { level: 1, name: '数据洞察' })).toBeVisible();
+
+    await seedGame(page, lateRoundState(), lateRoundInputs());
+    await expect(page.getByRole('heading', { level: 1, name: '第 7 轮：选择武将' })).toBeVisible();
+
+    await page.goto('/team-builder');
+    await expect(page.getByRole('heading', { level: 1, name: '队伍策案' })).toBeVisible();
+
+    await page.goto('/build-a-team');
+    await expect(page.getByRole('heading', { level: 1, name: '组队 / Build a Team' })).toBeVisible();
+  });
+
+  test('mobile round progress uses a complete non-scrolling grid', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await seedGame(page, lateRoundState(), lateRoundInputs());
+
+    const progress = page.getByRole('list', { name: '8 轮进度' });
+    await expect(progress).toBeVisible();
+    await expect(progress.getByRole('listitem')).toHaveCount(8);
+    await expect(progress.getByRole('listitem', { name: /第 7 轮.*当前/ })).toHaveAttribute('aria-current', 'step');
+    await expect(page.getByRole('region', { name: '8 轮进度，可横向滚动' })).not.toBeVisible();
+  });
+
+  test('mobile keeps key recommendation actions visible while details are collapsible', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await seedGame(page, lateRoundState(), lateRoundInputs());
+    await page.getByRole('button', { name: '获取 AI 推荐' }).click();
+
+    const firstDetails = page.getByRole('button', { name: '展开第1组详细分析' });
+    await expect(firstDetails).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('button', { name: '选择本组' })).toHaveCount(3);
+
+    await firstDetails.click();
+    await expect(page.getByText('评分详情:').first()).toBeVisible();
+  });
+
+  test('mobile analytics tables disclose into labelled keyboard-focusable regions', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/analytics');
+
+    const disclosure = page.getByRole('button', { name: '展开全部武将排名' });
+    await expect(disclosure).toBeVisible({ timeout: 15000 });
+    await disclosure.click();
+
+    const tableRegion = page.getByRole('region', { name: '全部武将排名表格，可滚动' });
+    await expect(tableRegion).toBeVisible();
+    await expect(tableRegion).toHaveAttribute('tabindex', '0');
+  });
+});


### PR DESCRIPTION
## Intent

Audit the web application across desktop and mobile, fixing all identified accessibility, layout, and design issues except the explicitly excluded drag-only team-builder issue. Preserve game behavior and validate the web changes with typecheck, unit tests, Playwright tests, production build, and accessibility/overflow audits.

## What Changed

- Added a `ResponsiveDisclosure` component (with unit tests) that collapses content behind an accessible `aria-expanded`/`aria-controls` toggle on mobile while keeping it mounted, and wired it into the analytics tables and per-option detail blocks so dense data is one tap away on small screens.
- Reworked game and layout components (`AnalysisGrid`, `CurrentTeam`, `KnownStrongTeams`, `RoundInfo`, `AppLayout`, `Analytics`, `TeamBuilder`, etc.) plus `theme.ts` for accessibility and responsive fixes — single `h1` per page, non-scrolling mobile round grid with `aria-current`, visible mobile recommendation actions, and keyboard-focusable table regions.
- Added the `tests/accessibilityLayout.spec.js` Playwright suite covering the new a11y/overflow behavior and documented `ResponsiveDisclosure` in the web README.

## Risk Assessment

✅ Low: The change is well-bounded and almost entirely cosmetic/semantic (heading roles, responsive layout, contrast colors) with no logic, data-key, or recommendation-engine changes and matching test coverage.

## Testing

Ran the full web validation matrix from the intent — typecheck (clean), Vitest unit tests (43 pass), Playwright e2e (23 pass including the 4 new accessibility/layout specs), and the vite production build (success). Fixed one environment-only setup issue: `npm ci` skipped the optional `@rolldown/binding-darwin-arm64` native binary (known npm optional-deps bug) which blocked Vitest, so I installed it into node_modules with `--no-save` and restored package-lock.json. I also captured reviewer-visible screenshots proving the end-user behavior: the mobile non-scrolling round-progress grid with the current round highlighted, the mobile recommendation view keeping "选择本组" actions visible while detail analysis is behind an "展开…详细分析" disclosure, the mobile analytics page collapsing each table behind a disclosure that expands into a keyboard-scrollable labelled region, and the desktop layout retaining its full horizontal round stepper and nav (game behavior preserved). All checks passed and no product issues were found.

- Evidence: Mobile (390px) non-scrolling round-progress grid — round 7 highlighted, replaces the old horizontal overflow strip (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXD2HVEFQMQ70W5VNJ8RJ82N/mobile-round-progress-grid.png</code>)
- Evidence: Mobile recommendation view — per-option 选择本组 actions stay visible while detailed analysis sits behind a 展开…详细分析 disclosure (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXD2HVEFQMQ70W5VNJ8RJ82N/mobile-recommendation-collapsed.png</code>)
- Evidence: Mobile recommendation view — first option&#39;s detail disclosure expanded (评分详情) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXD2HVEFQMQ70W5VNJ8RJ82N/mobile-recommendation-expanded.png</code>)
- Evidence: Mobile analytics — each table collapsed behind a disclosure button to keep the page compact (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXD2HVEFQMQ70W5VNJ8RJ82N/mobile-analytics-collapsed.png</code>)
- Evidence: Mobile analytics — 全部武将排名 expanded into a labelled, keyboard-scrollable region with scroll hint (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXD2HVEFQMQ70W5VNJ8RJ82N/mobile-analytics-expanded.png</code>)
- Evidence: Desktop (1280px) — full horizontal round stepper and nav preserved (behavior unchanged on wide screens) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXD2HVEFQMQ70W5VNJ8RJ82N/desktop-round-stepper.png</code>)
- Evidence: Desktop analytics page (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXD2HVEFQMQ70W5VNJ8RJ82N/desktop-analytics.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `web/src/components/common/ResponsiveDisclosure.tsx:45` - On mobile (xs), analytics data tables and per-option detail blocks now start collapsed behind a ResponsiveDisclosure toggle, and the AppLayout brand title/overline are fully hidden. This is a deliberate, accessible (aria-expanded/aria-controls, content stays mounted) mobile density improvement consistent with the stated intent; noting it so a human reviewer is aware data is one tap away rather than immediately visible on small screens.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm run typecheck` (tsc --noEmit) — clean</code>
- <code>`npx vitest run` — 9 files, 43 unit tests pass (incl. new `ResponsiveDisclosure.test.tsx`)</code>
- <code>`npx playwright test` — all 23 e2e tests pass, incl. 4 new `tests/accessibilityLayout.spec.js` cases (single h1 per page, non-scrolling mobile round grid with aria-current, visible mobile recommendation actions + collapsible details, keyboard-focusable analytics table regions)</code>
- <code>`npm run build` (vite production build) — built successfully</code>
- `Manual visual capture via a temporary Playwright screenshot spec at mobile 390×844 and desktop 1280×900, then removed`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
