### PR TITLE
feat(recommendation): rework team formation into diverse top-two-band options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ in the browser:
   hero), not two independent top-1 picks. The final formation enumerates a
   deterministic bounded beam of disjoint 3×3 hero partitions (each level unions a
   strength-ranked and a structure-ranked slice so structurally good partitions
-  survive the prune), then for **each** candidate performs the global unique
+  survive the prune), caps full evaluation at 1,920 partitions, then for **each** candidate performs the global unique
   18-skill assignment (2/hero, never a hero's signature skill) and scores every
   team with the full model. The winner is chosen in two global stages: (1) find
   the single maximum **top-two-team** summed strength and retain every formation
@@ -59,10 +59,13 @@ in the browser:
   preferences sourced from `database.json` (exactly one 输出核心 per team, then
   exactly one 体系核心, then same-camp teams), then the stronger third team, total
   strength, and a deterministic key. The soft role/camp preferences never
-  override skill/signature feasibility and never widen the band. The only
-  user-facing summary is **总评分** — the display-unit sum of all three team
-  strengths — plus compact positive per-team evidence (武将配合 / 武将与战法 /
-  战法搭配, each with 加分 and reference battle counts).
+  override skill/signature feasibility and never widen the band. From that same
+  already-scored retained set, the engine returns up to three deterministic,
+  distinct formation options: the winner first, then alternatives chosen to
+  minimise team overlap without sacrificing the strength band. The UI shows
+  each team's **评分** and compact positive evidence (武将配合 / 武将与战法 /
+  战法搭配, each with 加分 and reference battle counts); there is no aggregate
+  总评分.
 
 ## Layout (a uv workspace + a React app)
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,21 @@ in the browser:
   skill pick is chosen as a **joint pair** (each skill's presence + the best
   feasible hero routing + the within-hero skill-pair bonus when both land on one
   hero), not two independent top-1 picks. The final formation enumerates a
-  deterministic bounded beam of disjoint 3×3 hero partitions, then for **each**
-  candidate performs the global unique 18-skill assignment (2/hero, never a
-  hero's signature skill) and scores every team with the full model; the winner
-  is chosen by the true fully-assigned objective (aggregate strength minus a
-  weakest-team/balance term), and the returned objective is exactly that
-  selector.
+  deterministic bounded beam of disjoint 3×3 hero partitions (each level unions a
+  strength-ranked and a structure-ranked slice so structurally good partitions
+  survive the prune), then for **each** candidate performs the global unique
+  18-skill assignment (2/hero, never a hero's signature skill) and scores every
+  team with the full model. The winner is chosen in two global stages: (1) find
+  the single maximum **top-two-team** summed strength and retain every formation
+  within a fixed display-point band of it — so the two strongest main teams are
+  prioritised over the third; (2) rank the retained set by hidden soft
+  preferences sourced from `database.json` (exactly one 输出核心 per team, then
+  exactly one 体系核心, then same-camp teams), then the stronger third team, total
+  strength, and a deterministic key. The soft role/camp preferences never
+  override skill/signature feasibility and never widen the band. The only
+  user-facing summary is **总评分** — the display-unit sum of all three team
+  strengths — plus compact positive per-team evidence (武将配合 / 武将与战法 /
+  战法搭配, each with 加分 and reference battle counts).
 
 ## Layout (a uv workspace + a React app)
 

--- a/web/src/pages/TeamBuilder.tsx
+++ b/web/src/pages/TeamBuilder.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Container, Box, Typography, Button, Card, CardContent, Grid, Chip, Alert, Divider, Snackbar } from '@mui/material';
+import { Container, Box, Typography, Button, Card, CardContent, Grid, Chip, Alert, Divider, Snackbar, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useGame } from '../context/GameContext';
 import CurrentTeam from '../components/game/CurrentTeam';
@@ -66,10 +66,11 @@ const TeamEvidenceView = ({ evidence }: { evidence: TeamEvidence }) => {
 
 /**
  * Team Builder page. Shows the current pool and, once the pool is complete
- * (≥9 heroes / ≥18 skills), the globally-optimised three teams: the formation
- * optimiser jointly picks three disjoint 3-hero teams and a unique 18-skill
- * assignment, maximising aggregate relative roster strength with a
- * weakest-team/balance consideration (not a greedy team-one-first build).
+ * (≥9 heroes / ≥18 skills), up to three recommended formation options
+ * (方案一（推荐）/方案二/方案三). A compact segmented selector switches between
+ * options; each shows three disjoint 3-hero teams, and every team card header
+ * carries its own 评分 (relative roster strength). No aggregate score or
+ * optimiser internals are surfaced.
  */
 const TeamBuilder = () => {
   const navigate = useNavigate();
@@ -81,6 +82,9 @@ const TeamBuilder = () => {
   const [resultKey, setResultKey] = useState<string | null>(null);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
+  // Which formation option (方案) is currently displayed. Reset to the
+  // recommended option (index 0) whenever a fresh formation is computed.
+  const [selectedOption, setSelectedOption] = useState(0);
 
   const { gameState, availableHeroes, availableSkills } = state;
 
@@ -145,6 +149,7 @@ const TeamBuilder = () => {
         }
         if (!cancelled) {
           setFormation(result);
+          setSelectedOption(0);
           // Mark this pool key as completed (even on failure) so the render
           // switches from loading to either the formation or the incomplete
           // warning. Stale runs are ignored via the `cancelled` guard.
@@ -184,7 +189,7 @@ const TeamBuilder = () => {
 
         <Box sx={{ mb: 3 }}>
           <Typography variant="body1" color="text.secondary" paragraph>
-            查看与管理当前队伍配置。填满 9 名武将与 18 个战法后，将自动给出全局最优的三队编排。
+            查看与管理当前队伍配置。填满 9 名武将与 18 个战法后，将自动给出至多三套推荐编排。
           </Typography>
         </Box>
 
@@ -204,29 +209,49 @@ const TeamBuilder = () => {
           <Card sx={{ mt: 4 }}>
             <CardContent>
               <Typography component="h2" variant="h6" gutterBottom>
-                全局最优编排
+                推荐编排
               </Typography>
               <Typography variant="body2" color="text.secondary" paragraph>
-                同时优化三支互不重叠的队伍与 18 个战法的唯一分配，优先组建两支主力队伍，再安排第三支队伍。分数为相对强度。
+                为当前武将与战法池给出至多三套可选编排。切换方案查看不同的三队组合，每支队伍单独给出评分。
               </Typography>
 
               {isPending ? (
                 <Box sx={{ textAlign: 'center', py: 4 }}>
                   <Typography>正在优化...</Typography>
                 </Box>
-              ) : formation && !formation.incomplete ? (
+              ) : formation && !formation.incomplete && formation.options.length > 0 ? (
                 <>
-                  <Box sx={{ mb: 2, display: 'flex', flexWrap: 'wrap', gap: 2 }}>
-                    <Chip label={`总评分 ${formation.totalScore.toFixed(1)}`} color="primary" />
-                  </Box>
+                  {formation.options.length > 1 && (
+                    <Box sx={{ mb: 2 }}>
+                      <ToggleButtonGroup
+                        exclusive
+                        size="small"
+                        color="primary"
+                        value={Math.min(selectedOption, formation.options.length - 1)}
+                        onChange={(_e, value) => {
+                          if (value !== null) setSelectedOption(value);
+                        }}
+                        aria-label="方案选择"
+                      >
+                        {formation.options.map((_opt, i) => (
+                          <ToggleButton key={i} value={i}>
+                            {i === 0 ? '方案一（推荐）' : i === 1 ? '方案二' : '方案三'}
+                          </ToggleButton>
+                        ))}
+                      </ToggleButtonGroup>
+                    </Box>
+                  )}
                   <Grid container spacing={3}>
-                    {formation.teams.map((team, teamIdx) => (
+                    {formation.options[Math.min(selectedOption, formation.options.length - 1)].teams.map((team, teamIdx) => (
                       <Grid size={{ xs: 12, md: 4 }} key={teamIdx}>
                         <Card variant="outlined" sx={{ height: '100%', borderColor: teamBorder(teamIdx), borderWidth: 2 }}>
                           <CardContent>
-                            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
                               <Typography component="h3" variant="subtitle1" fontWeight="bold">
                                 队伍 {teamIdx + 1}
+                              </Typography>
+                              <Typography variant="subtitle2" color="text.secondary" fontWeight="bold">
+                                评分：{team.strength.toFixed(1)}
                               </Typography>
                             </Box>
                             <Divider sx={{ mb: 2 }} />

--- a/web/src/pages/TeamBuilder.tsx
+++ b/web/src/pages/TeamBuilder.tsx
@@ -6,10 +6,63 @@ import CurrentTeam from '../components/game/CurrentTeam';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
-import { recommendationData } from '../data';
-import { recommendTeams, type FormationRecommendation } from '../services/recommendationEngine';
+import { recommendationData, database } from '../data';
+import {
+  recommendTeams,
+  type FormationRecommendation,
+  type HeroMeta,
+  type TeamEvidence,
+} from '../services/recommendationEngine';
 import { generateTeamBuilderPrompt } from '../services/promptGenerator';
 import { copyToClipboard } from '../utils/clipboard';
+
+// Soft 阵营/定位 metadata for the optimiser, sourced cleanly from the database.
+// Derived once at module load; passed to recommendTeams so the deterministic
+// recommendation can apply its best-effort role/camp preferences.
+const HERO_META: HeroMeta = Object.fromEntries(
+  Object.entries(database.heroes || {}).map(([name, hero]) => [
+    name,
+    { camp: hero.camp, label: hero.label },
+  ])
+);
+
+/**
+ * Compact positive paired-model evidence under a team. Groups are shown with
+ * plain wording (武将配合 / 武将与战法 / 战法搭配); each non-empty group shows its
+ * top rows as `加分 +N.N · 参考 K 场`. No win probabilities or deductions.
+ */
+const TeamEvidenceView = ({ evidence }: { evidence: TeamEvidence }) => {
+  const groups: { title: string; rows: TeamEvidence['heroSynergy'] }[] = [
+    { title: '武将配合', rows: evidence.heroSynergy },
+    { title: '武将与战法', rows: evidence.heroSkill },
+    { title: '战法搭配', rows: evidence.skillSynergy },
+  ].filter((g) => g.rows.length > 0);
+
+  if (groups.length === 0) return null;
+
+  return (
+    <>
+      <Divider sx={{ my: 1.5 }} />
+      {groups.map((group) => (
+        <Box key={group.title} sx={{ mb: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 'bold', display: 'block' }}>
+            {group.title}
+          </Typography>
+          {group.rows.map((row, i) => (
+            <Box key={i} sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+              <Typography variant="caption" color="text.primary" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {row.label}
+              </Typography>
+              <Typography variant="caption" color="success.main" sx={{ whiteSpace: 'nowrap' }}>
+                加分 +{row.gain.toFixed(1)} · 参考 {row.support} 场
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      ))}
+    </>
+  );
+};
 
 /**
  * Team Builder page. Shows the current pool and, once the pool is complete
@@ -79,7 +132,13 @@ const TeamBuilder = () => {
       const handle = setTimeout(() => {
         let result: FormationRecommendation | null = null;
         try {
-          result = recommendTeams(heroes, skills, recommendationData, recommendationData.catalog);
+          result = recommendTeams(
+            heroes,
+            skills,
+            recommendationData,
+            recommendationData.catalog,
+            HERO_META,
+          );
         } catch (err) {
           console.error('Failed to recommend teams:', err);
           result = null;
@@ -148,7 +207,7 @@ const TeamBuilder = () => {
                 全局最优编排
               </Typography>
               <Typography variant="body2" color="text.secondary" paragraph>
-                同时优化三支互不重叠的队伍与 18 个战法的唯一分配，最大化整体相对阵容强度，并兼顾各队均衡（避免最弱一队过弱）。分数为相对强度。
+                同时优化三支互不重叠的队伍与 18 个战法的唯一分配，优先组建两支主力队伍，再安排第三支队伍。分数为相对强度。
               </Typography>
 
               {isPending ? (
@@ -158,22 +217,16 @@ const TeamBuilder = () => {
               ) : formation && !formation.incomplete ? (
                 <>
                   <Box sx={{ mb: 2, display: 'flex', flexWrap: 'wrap', gap: 2 }}>
-                    <Chip label={`整体强度 ${formation.aggregateStrength.toFixed(1)}`} color="primary" />
-                    <Chip label={`最弱一队 ${formation.weakestTeamStrength.toFixed(1)}`} color="warning" variant="outlined" />
-                    <Chip label={`均衡差 ${formation.balanceSpread.toFixed(1)}`} variant="outlined" />
-                    <Chip label={`目标值 ${formation.objective.toFixed(1)}`} variant="outlined" />
+                    <Chip label={`总评分 ${formation.totalScore.toFixed(1)}`} color="primary" />
                   </Box>
                   <Grid container spacing={3}>
                     {formation.teams.map((team, teamIdx) => (
                       <Grid size={{ xs: 12, md: 4 }} key={teamIdx}>
                         <Card variant="outlined" sx={{ height: '100%', borderColor: teamBorder(teamIdx), borderWidth: 2 }}>
                           <CardContent>
-                            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                               <Typography component="h3" variant="subtitle1" fontWeight="bold">
                                 队伍 {teamIdx + 1}
-                              </Typography>
-                              <Typography variant="body2" color="text.secondary">
-                                强度 <strong>{team.strength.toFixed(1)}</strong>
                               </Typography>
                             </Box>
                             <Divider sx={{ mb: 2 }} />
@@ -191,6 +244,7 @@ const TeamBuilder = () => {
                                 </Box>
                               </Box>
                             ))}
+                            <TeamEvidenceView evidence={team.evidence} />
                           </CardContent>
                         </Card>
                       </Grid>

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -5,6 +5,8 @@ import {
   recommendSingleHero,
   recommendTwoSkills,
   recommendTeams,
+  enumerateFormationPartitions,
+  PARTITION_EVAL_CAP,
   getAnalytics,
   currentRosterScore,
 } from '../recommendationEngine';
@@ -492,6 +494,55 @@ describe('recommendTeams — global formation optimization', () => {
     const b = recommendTeams(heroes, skills, data, data.catalog, meta);
     expect(a).toEqual(b);
   });
+
+  test('caps the fully-evaluated partition set and keeps a deterministic strength/structure mix', () => {
+    // A 12-hero pool is where the beam over-produces: unioning strength- and
+    // structure-ranked slices per level can exceed the previous ~1920 search
+    // bound. The cap must hold that fully-evaluated set at PARTITION_EVAL_CAP,
+    // deterministically, without dropping either flavour of candidate.
+    const heroes = Array.from({ length: 12 }, (_, i) => `h${i}`);
+    // Varied hero weights so the strength ranking is non-degenerate, plus a rich
+    // camp/label mix so many partitions carry a positive structure score.
+    const weights: Record<string, number> = {};
+    heroes.forEach((h, i) => {
+      weights[`H|${h}`] = (12 - i) * 0.1;
+    });
+    const data = makeData({ weights, support: {}, n_features: heroes.length });
+    const meta = Object.fromEntries(
+      heroes.map((h, i) => [h, { camp: i % 2 ? 'A' : 'B', label: i % 3 === 0 ? '输出核心' : i % 3 === 1 ? '体系核心' : '功能辅助' }])
+    );
+
+    const parts = enumerateFormationPartitions(heroes, data.model, meta);
+    // The cap actually engages on a 12-hero pool and is never exceeded.
+    expect(parts.length).toBe(PARTITION_EVAL_CAP);
+
+    // Every retained partition is a valid disjoint 3×3 over distinct heroes.
+    for (const trios of parts) {
+      const flat = trios.flat();
+      expect(flat).toHaveLength(9);
+      expect(new Set(flat).size).toBe(9);
+    }
+
+    // The interleave keeps both flavours: at least one partition attains the
+    // global-max structure score (would be dropped by a pure-strength truncation)
+    // and at least one attains the global-max strength proxy.
+    const structOf = (trios: string[][]) =>
+      trios.reduce((acc, t) => {
+        const oc = t.filter((h) => meta[h as keyof typeof meta]?.label === '输出核心').length === 1 ? 4 : 0;
+        const sc = t.filter((h) => meta[h as keyof typeof meta]?.label === '体系核心').length === 1 ? 2 : 0;
+        const camp = new Set(t.map((h) => meta[h as keyof typeof meta]?.camp)).size === 1 ? 1 : 0;
+        return acc + oc + sc + camp;
+      }, 0);
+    const maxStruct = Math.max(...parts.map(structOf));
+    expect(parts.some((p) => structOf(p) === maxStruct)).toBe(true);
+    expect(maxStruct).toBeGreaterThan(0);
+
+    // Deterministic: byte-identical partition sequence across repeated calls
+    // (the production pool is always canonically weight-sorted, so the input
+    // order the beam sees is itself fixed).
+    const again = enumerateFormationPartitions(heroes, data.model, meta);
+    expect(again).toEqual(parts);
+  }, 30000);
 
   test('tolerates missing metadata and partial pools (structure rules inert)', () => {
     const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -234,7 +234,7 @@ describe('recommendTeams — global formation optimization', () => {
     const data = makeData();
     const r = recommendTeams(['a', 'b', 'c'], ['s1', 's2'], data, data.catalog);
     expect(r.incomplete).toBe(true);
-    expect(r.teams).toHaveLength(0);
+    expect(r.options).toHaveLength(0);
   });
 
   test('is incomplete when skills contain duplicates that leave fewer than 18 unique', () => {
@@ -249,7 +249,7 @@ describe('recommendTeams — global formation optimization', () => {
     ];
     const r = recommendTeams(heroes, dupSkills, data, data.catalog);
     expect(r.incomplete).toBe(true);
-    expect(r.teams).toHaveLength(0);
+    expect(r.options).toHaveLength(0);
   });
 
   test('assigns exactly 9 unique heroes and 18 unique skills, 2 per hero, no signature skill', () => {
@@ -265,13 +265,14 @@ describe('recommendTeams — global formation optimization', () => {
     };
     const r = recommendTeams(heroes, skills, data, catalog);
     expect(r.incomplete).toBe(false);
-    const allHeroes = r.teams.flatMap((t) => t.heroes.map((h) => h.name));
+    const teams = r.options[0].teams;
+    const allHeroes = teams.flatMap((t) => t.heroes.map((h) => h.name));
     expect(new Set(allHeroes).size).toBe(9);
-    const allSkills = r.teams.flatMap((t) => t.heroes.flatMap((h) => h.skills));
+    const allSkills = teams.flatMap((t) => t.heroes.flatMap((h) => h.skills));
     expect(allSkills).toHaveLength(18);
     expect(new Set(allSkills).size).toBe(18);
-    r.teams.forEach((t) => t.heroes.forEach((h) => expect(h.skills).toHaveLength(2)));
-    for (const hero of r.teams.flatMap((t) => t.heroes)) {
+    teams.forEach((t) => t.heroes.forEach((h) => expect(h.skills).toHaveLength(2)));
+    for (const hero of teams.flatMap((t) => t.heroes)) {
       expect(hero.skills).not.toContain(catalog.default_skill[hero.name]);
     }
   });
@@ -287,20 +288,27 @@ describe('recommendTeams — global formation optimization', () => {
     });
     const r = recommendTeams(heroes, skills, data, data.catalog);
     expect(r.incomplete).toBe(false);
-    expect(r.teams).toHaveLength(3);
+    const teams = r.options[0].teams;
+    expect(teams).toHaveLength(3);
     // Disjoint heroes across all teams (9 unique).
-    const allHeroes = r.teams.flatMap((t) => t.heroes.map((h) => h.name));
+    const allHeroes = teams.flatMap((t) => t.heroes.map((h) => h.name));
     expect(new Set(allHeroes).size).toBe(9);
     // Unique 18-skill assignment, 2 per hero.
-    const allSkills = r.teams.flatMap((t) => t.heroes.flatMap((h) => h.skills));
+    const allSkills = teams.flatMap((t) => t.heroes.flatMap((h) => h.skills));
     expect(new Set(allSkills).size).toBe(allSkills.length);
-    r.teams.forEach((t) => t.heroes.forEach((h) => expect(h.skills.length).toBeLessThanOrEqual(2)));
-    // Reports a single total-score summary (no balance/weakest/objective fields).
-    expect(r).toHaveProperty('totalScore');
+    teams.forEach((t) => t.heroes.forEach((h) => expect(h.skills.length).toBeLessThanOrEqual(2)));
+    // Exposes up to three options and no aggregate/optimiser-internal summaries.
+    expect(r.options.length).toBeGreaterThanOrEqual(1);
+    expect(r.options.length).toBeLessThanOrEqual(3);
+    expect(r).not.toHaveProperty('totalScore');
     expect(r).not.toHaveProperty('objective');
     expect(r).not.toHaveProperty('weakestTeamStrength');
     expect(r).not.toHaveProperty('balanceSpread');
     expect(r).not.toHaveProperty('aggregateStrength');
+    // Each team carries its own display 评分.
+    r.options.forEach((opt) =>
+      opt.teams.forEach((t) => expect(typeof t.strength).toBe('number'))
+    );
   });
 
   test('is deterministic', () => {
@@ -326,7 +334,7 @@ describe('recommendTeams — global formation optimization', () => {
       n_features: 3,
     });
     const r = recommendTeams(heroes, skills, data, data.catalog);
-    const h0 = r.teams.flatMap((t) => t.heroes).find((h) => h.name === 'h0')!;
+    const h0 = r.options[0].teams.flatMap((t) => t.heroes).find((h) => h.name === 'h0')!;
     // The strongly-affine pair is routed onto h0.
     expect(new Set(h0.skills)).toEqual(new Set(['s0', 's1']));
   });
@@ -352,7 +360,7 @@ describe('recommendTeams — global formation optimization', () => {
 
     const r = recommendTeams(heroes, skills, data, data.catalog);
     const assigned = new Map(
-      r.teams.flatMap((team) => team.heroes.map((hero) => [hero.name, hero.skills] as const))
+      r.options[0].teams.flatMap((team) => team.heroes.map((hero) => [hero.name, hero.skills] as const))
     );
 
     expect(assigned.get('h0')).toContain('s0');
@@ -370,12 +378,12 @@ describe('recommendTeams — global formation optimization', () => {
     });
     const r = recommendTeams(heroes, skills, data, data.catalog);
     const teamOf = (name: string) =>
-      r.teams.findIndex((t) => t.heroes.some((h) => h.name === name));
+      r.options[0].teams.findIndex((t) => t.heroes.some((h) => h.name === name));
     expect(teamOf('h0')).toBe(teamOf('h1'));
     expect(teamOf('h2')).toBe(teamOf('h3'));
   });
 
-  test('totalScore equals the summed display strength of all three teams', () => {
+  test('exposes at most three options, option one is the recommended winner', () => {
     const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
     const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
     const data = makeData({
@@ -384,8 +392,85 @@ describe('recommendTeams — global formation optimization', () => {
       n_features: 4,
     });
     const r = recommendTeams(heroes, skills, data, data.catalog);
-    const summed = r.teams.reduce((a, t) => a + t.strength, 0);
-    expect(r.totalScore).toBeCloseTo(Math.round(summed * 10) / 10, 5);
+    expect(r.incomplete).toBe(false);
+    // At most three options; the recommended one is first.
+    expect(r.options.length).toBeGreaterThanOrEqual(1);
+    expect(r.options.length).toBeLessThanOrEqual(3);
+    // No aggregate total score anywhere in the result.
+    expect(r).not.toHaveProperty('totalScore');
+  });
+
+  test('options use distinct canonical hero partitions (no team-order variants)', () => {
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const data = makeData({
+      weights: { 'H|h0': 1.0, 'H|h1': 0.5, 'HP|h0|h1': 0.8, 'HS|h0|s0': 0.4 },
+      support: { 'H|h0': 50, 'H|h1': 50, 'HP|h0|h1': 30, 'HS|h0|s0': 20 },
+      n_features: 4,
+    });
+    const r = recommendTeams(heroes, skills, data, data.catalog);
+    // Canonical partition key for an option: teams as sorted hero-sets, sorted.
+    const canonKey = (opt: (typeof r.options)[number]) =>
+      opt.teams
+        .map((t) => [...t.heroes.map((h) => h.name)].sort().join('|'))
+        .sort()
+        .join('||');
+    const keys = r.options.map(canonKey);
+    // Every option is a distinct canonical partition.
+    expect(new Set(keys).size).toBe(keys.length);
+    // With 9 heroes and non-degenerate weights, three distinct options exist.
+    expect(r.options.length).toBe(3);
+    // Every alternative remains within the same 2.5-point top-two strength
+    // band as the recommended option (allowing 0.1 for display rounding).
+    const topTwo = r.options.map((opt) =>
+      opt.teams
+        .map((team) => team.strength)
+        .sort((a, b) => b - a)
+        .slice(0, 2)
+        .reduce((sum, score) => sum + score, 0)
+    );
+    expect(Math.max(...topTwo) - Math.min(...topTwo)).toBeLessThanOrEqual(2.6);
+  });
+
+  test('options are deterministic across repeated calls (no randomness)', () => {
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const data = makeData({
+      weights: { 'H|h0': 1.0, 'H|h1': 0.5, 'HP|h0|h1': 0.8, 'HS|h0|s0': 0.4 },
+      support: { 'H|h0': 50, 'H|h1': 50, 'HP|h0|h1': 30, 'HS|h0|s0': 20 },
+      n_features: 4,
+    });
+    const a = recommendTeams(heroes, skills, data, data.catalog);
+    const b = recommendTeams(heroes, skills, data, data.catalog);
+    expect(a.options).toEqual(b.options);
+  });
+
+  test('all options derive from the already-evaluated capped partition set (no extra enumeration)', () => {
+    // Every option's canonical hero partition must be one of the partitions the
+    // (capped) enumeration produced — options are selected from the already
+    // scored candidates, never enumerated or scored afresh.
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const data = makeData({
+      weights: { 'H|h0': 1.0, 'H|h1': 0.5, 'HP|h0|h1': 0.8, 'HS|h0|s0': 0.4 },
+      support: { 'H|h0': 50, 'H|h1': 50, 'HP|h0|h1': 30, 'HS|h0|s0': 20 },
+      n_features: 4,
+    });
+    const canonKey = (teams: string[][]) =>
+      teams
+        .map((t) => [...t].sort().join('|'))
+        .sort()
+        .join('||');
+    const enumerated = new Set(
+      enumerateFormationPartitions(heroes, data.model, {}).map((trios) => canonKey(trios))
+    );
+    const r = recommendTeams(heroes, skills, data, data.catalog);
+    for (const opt of r.options) {
+      const key = canonKey(opt.teams.map((t) => t.heroes.map((h) => h.name)));
+      expect(enumerated.has(key)).toBe(true);
+    }
+    // The evaluated partition set stays within the performance cap.
+    expect(enumerated.size).toBeLessThanOrEqual(PARTITION_EVAL_CAP);
   });
 
   test('ranks by the two strongest teams (top-two sum), third team secondary', () => {
@@ -400,7 +485,7 @@ describe('recommendTeams — global formation optimization', () => {
       n_features: 3,
     });
     const r = recommendTeams(heroes, skills, data, data.catalog);
-    const teamOf = (name: string) => r.teams.findIndex((t) => t.heroes.some((h) => h.name === name));
+    const teamOf = (name: string) => r.options[0].teams.findIndex((t) => t.heroes.some((h) => h.name === name));
     // The two strongest pairs stay together on the two strongest teams.
     expect(teamOf('h0')).toBe(teamOf('h1'));
     expect(teamOf('h2')).toBe(teamOf('h3'));
@@ -426,7 +511,7 @@ describe('recommendTeams — global formation optimization', () => {
       h8: { camp: 'X', label: '功能辅助' },
     };
     const r = recommendTeams(heroes, skills, data, data.catalog, meta);
-    const outputCoresPerTeam = r.teams.map(
+    const outputCoresPerTeam = r.options[0].teams.map(
       (t) => t.heroes.filter((h) => meta[h.name as keyof typeof meta]?.label === '输出核心').length
     );
     // Exactly one 输出核心 on every team (none clustered, none empty).
@@ -448,7 +533,7 @@ describe('recommendTeams — global formation optimization', () => {
       heroes.map((h, i) => [h, { camp: 'X', label: i < 2 ? '输出核心' : '功能辅助' }])
     );
     const r = recommendTeams(heroes, skills, data, data.catalog, meta);
-    const teamOf = (name: string) => r.teams.findIndex((t) => t.heroes.some((h) => h.name === name));
+    const teamOf = (name: string) => r.options[0].teams.findIndex((t) => t.heroes.some((h) => h.name === name));
     expect(teamOf('h0')).toBe(teamOf('h1'));
   });
 
@@ -476,7 +561,7 @@ describe('recommendTeams — global formation optimization', () => {
     const r = recommendTeams(heroes, skills, data, data.catalog, meta);
     expect(r.incomplete).toBe(false);
     // All three reserved low-strength cores survived the trim AND were placed.
-    const placed = new Set(r.teams.flatMap((t) => t.heroes.map((h) => h.name)));
+    const placed = new Set(r.options[0].teams.flatMap((t) => t.heroes.map((h) => h.name)));
     expect(placed.has('h10')).toBe(true);
     expect(placed.has('h11')).toBe(true);
     expect(placed.has('h12')).toBe(true);
@@ -552,7 +637,7 @@ describe('recommendTeams — global formation optimization', () => {
     const meta = { h0: { label: '输出核心' }, h1: { camp: 'A' } };
     const r = recommendTeams(heroes, skills, data, data.catalog, meta);
     expect(r.incomplete).toBe(false);
-    expect(r.teams).toHaveLength(3);
+    expect(r.options[0].teams).toHaveLength(3);
     // Same result whether metadata is omitted entirely or empty.
     const noMeta = recommendTeams(heroes, skills, data, data.catalog);
     const emptyMeta = recommendTeams(heroes, skills, data, data.catalog, {});
@@ -574,7 +659,7 @@ describe('recommendTeams — global formation optimization', () => {
       n_features: 4,
     });
     const r = recommendTeams(heroes, skills, data, data.catalog);
-    for (const team of r.teams) {
+    for (const team of r.options[0].teams) {
       expect(team).toHaveProperty('evidence');
       const { heroSynergy, heroSkill, skillSynergy } = team.evidence;
       for (const group of [heroSynergy, heroSkill, skillSynergy]) {
@@ -587,10 +672,10 @@ describe('recommendTeams — global formation optimization', () => {
       }
     }
     // The strong positive HP fires as hero-synergy on h0/h1's team.
-    const h0Team = r.teams.find((t) => t.heroes.some((h) => h.name === 'h0'))!;
+    const h0Team = r.options[0].teams.find((t) => t.heroes.some((h) => h.name === 'h0'))!;
     expect(h0Team.evidence.heroSynergy.some((e) => e.label.includes('h0'))).toBe(true);
     // No evidence row anywhere reflects the negative feature.
-    const allLabels = r.teams.flatMap((t) => [
+    const allLabels = r.options[0].teams.flatMap((t) => [
       ...t.evidence.heroSynergy,
       ...t.evidence.heroSkill,
       ...t.evidence.skillSynergy,
@@ -608,7 +693,7 @@ describe('recommendTeams — global formation optimization', () => {
     });
 
     const r = recommendTeams(heroes, skills, data, data.catalog);
-    const h0Team = r.teams.find((team) => team.heroes.some((hero) => hero.name === 'h0'))!;
+    const h0Team = r.options[0].teams.find((team) => team.heroes.some((hero) => hero.name === 'h0'))!;
 
     expect(h0Team.heroes.find((hero) => hero.name === 'h0')!.skills).toContain('s0');
     expect(h0Team.evidence.heroSkill).toEqual([]);

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -293,10 +293,12 @@ describe('recommendTeams — global formation optimization', () => {
     const allSkills = r.teams.flatMap((t) => t.heroes.flatMap((h) => h.skills));
     expect(new Set(allSkills).size).toBe(allSkills.length);
     r.teams.forEach((t) => t.heroes.forEach((h) => expect(h.skills.length).toBeLessThanOrEqual(2)));
-    // Reports balance/weakest-team objective.
-    expect(r).toHaveProperty('objective');
-    expect(r).toHaveProperty('weakestTeamStrength');
-    expect(r).toHaveProperty('balanceSpread');
+    // Reports a single total-score summary (no balance/weakest/objective fields).
+    expect(r).toHaveProperty('totalScore');
+    expect(r).not.toHaveProperty('objective');
+    expect(r).not.toHaveProperty('weakestTeamStrength');
+    expect(r).not.toHaveProperty('balanceSpread');
+    expect(r).not.toHaveProperty('aggregateStrength');
   });
 
   test('is deterministic', () => {
@@ -327,6 +329,34 @@ describe('recommendTeams — global formation optimization', () => {
     expect(new Set(h0.skills)).toEqual(new Set(['s0', 's1']));
   });
 
+  test('skill routing strengthens the top two teams before spending value on the third', () => {
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const weights: Record<string, number> = {
+      // Force two clearly dominant hero trios and leave h6/h7/h8 as team three.
+      'HP|h0|h1': 10,
+      'HP|h0|h2': 10,
+      'HP|h1|h2': 10,
+      'HP|h3|h4': 8,
+      'HP|h3|h5': 8,
+      'HP|h4|h5': 8,
+      // Greedy affinity initially prefers s0 on h6, but doing so only improves
+      // team three. Routing it to h0 gives less total gain while making a main
+      // team stronger, so the top-two-weighted swap objective must choose h0.
+      'HS|h6|s0': 1,
+      'HS|h0|s0': 0.6,
+    };
+    const data = makeData({ weights, support: {}, n_features: Object.keys(weights).length });
+
+    const r = recommendTeams(heroes, skills, data, data.catalog);
+    const assigned = new Map(
+      r.teams.flatMap((team) => team.heroes.map((hero) => [hero.name, hero.skills] as const))
+    );
+
+    expect(assigned.get('h0')).toContain('s0');
+    expect(assigned.get('h6')).not.toContain('s0');
+  });
+
   test('hero-pair affinity changes which heroes team up (selection follows the model)', () => {
     const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
     const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
@@ -343,7 +373,7 @@ describe('recommendTeams — global formation optimization', () => {
     expect(teamOf('h2')).toBe(teamOf('h3'));
   });
 
-  test('returned objective equals the fully-assigned aggregate minus balance penalty (it is the selector)', () => {
+  test('totalScore equals the summed display strength of all three teams', () => {
     const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
     const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
     const data = makeData({
@@ -352,13 +382,169 @@ describe('recommendTeams — global formation optimization', () => {
       n_features: 4,
     });
     const r = recommendTeams(heroes, skills, data, data.catalog);
-    const aggregate = r.teams.reduce((a, t) => a + t.strength, 0);
-    const spread =
-      Math.max(...r.teams.map((t) => t.strength)) - Math.min(...r.teams.map((t) => t.strength));
-    // The exact selector is computed before per-team display rounding, so a
-    // recomputation from the labels can differ by at most a small rounding step.
-    expect(Math.abs(r.objective - (aggregate - 0.5 * spread))).toBeLessThanOrEqual(0.2);
-    expect(r.aggregateStrength).toBeCloseTo(Math.round(aggregate * 10) / 10, 5);
+    const summed = r.teams.reduce((a, t) => a + t.strength, 0);
+    expect(r.totalScore).toBeCloseTo(Math.round(summed * 10) / 10, 5);
+  });
+
+  test('ranks by the two strongest teams (top-two sum), third team secondary', () => {
+    // Three tight pairs h0h1, h2h3, h4h5 with descending pair strength, and a
+    // weaker option to fill the third team. The optimiser should concentrate
+    // strength into the top two teams rather than spreading it evenly.
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const data = makeData({
+      weights: { 'HP|h0|h1': 6.0, 'HP|h2|h3': 5.0, 'HP|h4|h5': 1.0 },
+      support: { 'HP|h0|h1': 40, 'HP|h2|h3': 40, 'HP|h4|h5': 20 },
+      n_features: 3,
+    });
+    const r = recommendTeams(heroes, skills, data, data.catalog);
+    const teamOf = (name: string) => r.teams.findIndex((t) => t.heroes.some((h) => h.name === name));
+    // The two strongest pairs stay together on the two strongest teams.
+    expect(teamOf('h0')).toBe(teamOf('h1'));
+    expect(teamOf('h2')).toBe(teamOf('h3'));
+    // Those pairs are NOT split into the same (third) team.
+    expect(teamOf('h0')).not.toBe(teamOf('h2'));
+  });
+
+  test('within the tolerance band prefers exactly one 输出核心 per team (soft role rule)', () => {
+    // All heroes/pairs neutral → every partition ties on strength, so the soft
+    // role preference decides. Three 输出核心 spread one-per-team beats clustering.
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const data = makeData();
+    const meta = {
+      h0: { camp: 'X', label: '输出核心' },
+      h1: { camp: 'X', label: '输出核心' },
+      h2: { camp: 'X', label: '输出核心' },
+      h3: { camp: 'X', label: '功能辅助' },
+      h4: { camp: 'X', label: '功能辅助' },
+      h5: { camp: 'X', label: '功能辅助' },
+      h6: { camp: 'X', label: '功能辅助' },
+      h7: { camp: 'X', label: '功能辅助' },
+      h8: { camp: 'X', label: '功能辅助' },
+    };
+    const r = recommendTeams(heroes, skills, data, data.catalog, meta);
+    const outputCoresPerTeam = r.teams.map(
+      (t) => t.heroes.filter((h) => meta[h.name as keyof typeof meta]?.label === '输出核心').length
+    );
+    // Exactly one 输出核心 on every team (none clustered, none empty).
+    expect(outputCoresPerTeam.every((n) => n === 1)).toBe(true);
+  });
+
+  test('role/camp preferences never override a real strength gap larger than the band', () => {
+    // A dominant pair worth far more than 2.5 display points must team up even
+    // if that produces a worse role/camp structure.
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const data = makeData({
+      weights: { 'HP|h0|h1': 5.0 },
+      support: { 'HP|h0|h1': 40 },
+      n_features: 1,
+    });
+    // Meta that would "prefer" splitting h0/h1 (both 输出核心) across teams.
+    const meta = Object.fromEntries(
+      heroes.map((h, i) => [h, { camp: 'X', label: i < 2 ? '输出核心' : '功能辅助' }])
+    );
+    const r = recommendTeams(heroes, skills, data, data.catalog, meta);
+    const teamOf = (name: string) => r.teams.findIndex((t) => t.heroes.some((h) => h.name === name));
+    expect(teamOf('h0')).toBe(teamOf('h1'));
+  });
+
+  test('>12 pool trim reserves low-strength 输出核心/体系核心 before filling by strength', () => {
+    // 13 heroes so the pool must be trimmed to 12. The three soft cores are the
+    // *weakest* by individual H-weight, so a pure top-12-by-strength trim would
+    // discard them and no team could then get "exactly one core". The
+    // metadata-aware trim must reserve them, letting the soft role rule place
+    // exactly one 输出核心 and one 体系核心 on each team.
+    const heroes = Array.from({ length: 13 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    // h0..h9 are fillers each with a *small* positive individual weight so they
+    // out-rank the cores (which have zero weight and would be trimmed by a pure
+    // top-12), yet the weights are tiny enough (≤0.5 display pts) that placing a
+    // reserved core in a team stays inside the 2.5-display-point top-two band —
+    // so the soft role rule is free to distribute the surviving cores.
+    const weights: Record<string, number> = {};
+    for (let i = 0; i < 10; i++) weights[`H|h${i}`] = 0.05 - i * 0.002;
+    const data = makeData({ weights, support: {}, n_features: Object.keys(weights).length });
+    const meta = {
+      h10: { camp: 'X', label: '输出核心' },
+      h11: { camp: 'X', label: '体系核心' },
+      h12: { camp: 'X', label: '输出核心' },
+    };
+    const r = recommendTeams(heroes, skills, data, data.catalog, meta);
+    expect(r.incomplete).toBe(false);
+    // All three reserved low-strength cores survived the trim AND were placed.
+    const placed = new Set(r.teams.flatMap((t) => t.heroes.map((h) => h.name)));
+    expect(placed.has('h10')).toBe(true);
+    expect(placed.has('h11')).toBe(true);
+    expect(placed.has('h12')).toBe(true);
+    // Deterministic across repeated calls.
+    const r2 = recommendTeams(heroes, skills, data, data.catalog, meta);
+    expect(r2).toEqual(r);
+  }, 60000); // 13→12 trim exercises the full beam; allow extra time.
+
+  test('is deterministic with hero metadata', () => {
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const data = makeData();
+    const meta = Object.fromEntries(heroes.map((h, i) => [h, { camp: i % 2 ? 'A' : 'B', label: '输出核心' }]));
+    const a = recommendTeams(heroes, skills, data, data.catalog, meta);
+    const b = recommendTeams(heroes, skills, data, data.catalog, meta);
+    expect(a).toEqual(b);
+  });
+
+  test('tolerates missing metadata and partial pools (structure rules inert)', () => {
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const data = makeData();
+    // Only some heroes carry metadata; no camp on others. Must still complete.
+    const meta = { h0: { label: '输出核心' }, h1: { camp: 'A' } };
+    const r = recommendTeams(heroes, skills, data, data.catalog, meta);
+    expect(r.incomplete).toBe(false);
+    expect(r.teams).toHaveLength(3);
+    // Same result whether metadata is omitted entirely or empty.
+    const noMeta = recommendTeams(heroes, skills, data, data.catalog);
+    const emptyMeta = recommendTeams(heroes, skills, data, data.catalog, {});
+    expect(noMeta).toEqual(emptyMeta);
+  });
+
+  test('surfaces only positive, grouped evidence (no deductions) per team', () => {
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const data = makeData({
+      weights: {
+        'HP|h0|h1': 0.9,
+        'HS|h0|s0': 0.7,
+        'SP|h0|s0|s1': 0.6,
+        // A negative feature that must never appear in evidence.
+        'HP|h0|h2': -0.9,
+      },
+      support: { 'HP|h0|h1': 40, 'HS|h0|s0': 30, 'SP|h0|s0|s1': 25, 'HP|h0|h2': 40 },
+      n_features: 4,
+    });
+    const r = recommendTeams(heroes, skills, data, data.catalog);
+    for (const team of r.teams) {
+      expect(team).toHaveProperty('evidence');
+      const { heroSynergy, heroSkill, skillSynergy } = team.evidence;
+      for (const group of [heroSynergy, heroSkill, skillSynergy]) {
+        expect(group.length).toBeLessThanOrEqual(2);
+        for (const row of group) {
+          expect(row.gain).toBeGreaterThan(0);
+          expect(row).toHaveProperty('label');
+          expect(row).toHaveProperty('support');
+        }
+      }
+    }
+    // The strong positive HP fires as hero-synergy on h0/h1's team.
+    const h0Team = r.teams.find((t) => t.heroes.some((h) => h.name === 'h0'))!;
+    expect(h0Team.evidence.heroSynergy.some((e) => e.label.includes('h0'))).toBe(true);
+    // No evidence row anywhere reflects the negative feature.
+    const allLabels = r.teams.flatMap((t) => [
+      ...t.evidence.heroSynergy,
+      ...t.evidence.heroSkill,
+      ...t.evidence.skillSynergy,
+    ]);
+    expect(allLabels.every((e) => e.gain > 0)).toBe(true);
   });
 });
 

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -546,6 +546,22 @@ describe('recommendTeams — global formation optimization', () => {
     ]);
     expect(allLabels.every((e) => e.gain > 0)).toBe(true);
   });
+
+  test('does not surface a positive contribution that displays as 加分 +0.0', () => {
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const data = makeData({
+      weights: { 'HS|h0|s0': 0.004 },
+      support: { 'HS|h0|s0': 20 },
+      n_features: 1,
+    });
+
+    const r = recommendTeams(heroes, skills, data, data.catalog);
+    const h0Team = r.teams.find((team) => team.heroes.some((hero) => hero.name === 'h0'))!;
+
+    expect(h0Team.heroes.find((hero) => hero.name === 'h0')!.skills).toContain('s0');
+    expect(h0Team.evidence.heroSkill).toEqual([]);
+  });
 });
 
 describe('integration with the real generated artifact', () => {

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -920,8 +920,11 @@ function buildTeamEvidence(team: AssignedHero[], m: PairedModel): TeamEvidence {
   const pick = (family: string): EvidenceItem[] =>
     active
       .filter((c) => c.family === family && c.weight > 0)
-      .slice(0, 2)
-      .map(toItem);
+      .map(toItem)
+      // Do not show a nominally-positive contribution that rounds to +0.0 in
+      // the player-facing one-decimal score.
+      .filter((item) => item.gain > 0)
+      .slice(0, 2);
   return {
     heroSynergy: pick(F_HERO_PAIR),
     heroSkill: pick(F_HERO_SKILL),

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -19,12 +19,16 @@ import type {
 import type { Database } from '../types/domain';
 import {
   type AssignedHero,
+  type ActiveContribution,
+  F_HERO_PAIR,
   F_HERO_SKILL,
+  F_SKILL_PAIR,
   scoreTeam,
   scoreHeroes,
   weightOf,
   supportOf,
   evidenceFor,
+  activeTeamContributions,
   teamFeatureIds,
   heroId,
   skillId,
@@ -550,22 +554,64 @@ export interface ProjectedHero {
   /** Sum of hero-skill weights for the assigned skills. */
   skillScore: number;
 }
+/** One positive paired-model evidence row shown under a team. */
+export interface EvidenceItem {
+  /** Human-readable label for the feature (names only, family prefix dropped). */
+  label: string;
+  /** Positive display-unit contribution (加分). */
+  gain: number;
+  /** Support/evidence: battles this feature was observed in (参考 K 场). */
+  support: number;
+}
+
+/**
+ * Positive active evidence for a team, grouped by plain-worded family. Only
+ * positive contributions are surfaced (no win probabilities, no deductions).
+ */
+export interface TeamEvidence {
+  /** 武将配合 — hero-pair (HP) contributions. */
+  heroSynergy: EvidenceItem[];
+  /** 武将与战法 — hero-skill (HS) contributions. */
+  heroSkill: EvidenceItem[];
+  /** 战法搭配 — within-hero skill-pair (SP) contributions. */
+  skillSynergy: EvidenceItem[];
+}
+
 export interface ProjectedTeam {
   heroes: ProjectedHero[];
   /** Relative roster strength of the fully-assigned team. */
   strength: number;
+  /** Compact positive paired-model evidence for this team. */
+  evidence: TeamEvidence;
 }
+
 export interface FormationRecommendation {
   teams: ProjectedTeam[];
-  /** Aggregate objective actually optimised (sum − weakest-team penalty). */
-  objective: number;
-  aggregateStrength: number;
-  weakestTeamStrength: number;
-  /** How balanced the three teams are (0 = identical strength). */
-  balanceSpread: number;
+  /**
+   * The single summary shown to the user (总评分): the display-unit sum of all
+   * three fully-assigned team strengths. Optimiser internals (top-two/third
+   * sums, camp/core counts) are not surfaced.
+   */
+  totalScore: number;
   /** True when the pool wasn't large enough for a full 3×3 formation. */
   incomplete: boolean;
 }
+
+/** Optional per-hero soft metadata (阵营/定位) sourced from database.json. */
+export type HeroMeta = Record<string, { camp?: string; label?: string }>;
+
+/** The two soft role labels the formation prefers exactly one of, per team. */
+const OUTPUT_CORE_LABEL = '输出核心';
+const SYSTEM_CORE_LABEL = '体系核心';
+
+/**
+ * Displayed-point band for the top-two-team sum. After the single best top-two
+ * sum is found, every feasible formation whose top-two sum is within this many
+ * display points of that global maximum is retained; the soft role/camp
+ * preferences then rank the whole retained set. This is a true two-stage global
+ * band (find max → keep within band → rank), never a pairwise tolerance.
+ */
+const TOP_TWO_BAND = 2.5;
 
 /** Hero-only strength (hero + internal hero-pair weights) of a trio. */
 function trioHeroStrength(trio: string[], m: PairedModel): number {
@@ -630,9 +676,10 @@ function heroAssignedScore(
 /**
  * Globally assign exactly 18 unique skills across the three teams (2 per hero),
  * never a hero's own signature skill. A deterministic greedy affinity build is
- * followed by bounded swaps evaluated with the same balance-aware formation
- * objective used to choose the winning partition. Returns null if the supplied
- * pool has no valid signature-safe assignment.
+ * followed by bounded swaps that raise a top-two-weighted objective
+ * (topTwoSum + 0.25 * thirdStrength), so skills concentrate on the two
+ * strongest teams before helping the third. Returns null if the supplied pool
+ * has no valid signature-safe assignment.
  */
 function assignSkills(
   trios: string[][],
@@ -719,18 +766,26 @@ function assignSkills(
     if (!repaired) return null;
   }
 
-  const assignmentObjective = (): number =>
-    formationObjective(
-      trios.map((trio) =>
+  // Skill assignment prioritises the *two strongest* team scores, keeping the
+  // third team strictly secondary (topTwoSum + 0.25 * thirdStrength). This
+  // matches the formation-level objective (make the two main teams as strong as
+  // possible, then the third), so the assignment step never routes skills away
+  // from the best two teams merely to improve the third. Which heroes team up
+  // (and hence camp/role structure) is fixed by the partition.
+  const assignmentObjective = (): number => {
+    const scores = trios
+      .map((trio) =>
         scoreTeam(
           trio.map((name) => ({ name, skills: assign.get(name) ?? [] })),
           m
         )
       )
-    );
+      .sort((a, b) => b - a);
+    return scores[0] + scores[1] + 0.25 * scores[2];
+  };
 
   // Bounded local improvement: swap two assigned skills when it raises the
-  // actual fully-scored, balance-aware three-team objective.
+  // top-two-weighted objective (the two main teams first, third secondary).
   for (let pass = 0; pass < 4; pass++) {
     let improved = false;
     for (let a = 0; a < heroes.length; a++) {
@@ -766,64 +821,274 @@ function assignSkills(
   return result;
 }
 
-const BALANCE_PENALTY = 0.5;
-
-/** Final objective for a set of team strengths: aggregate − balance-spread penalty. */
-function formationObjective(strengths: number[]): number {
-  const aggregate = strengths.reduce((a, b) => a + b, 0);
-  const spread = Math.max(...strengths) - Math.min(...strengths);
-  return aggregate - BALANCE_PENALTY * spread;
+/** Count heroes on a team carrying a specific soft `label`. */
+function countLabel(trio: string[], label: string, meta: HeroMeta): number {
+  return trio.reduce((n, h) => (meta[h]?.label === label ? n + 1 : n), 0);
 }
 
-/** Assemble fully-assigned projected teams + their real `scoreTeam` strengths. */
+/** True when every hero on the team shares the same (defined) camp. */
+function isAllSameCamp(trio: string[], meta: HeroMeta): boolean {
+  const camps = trio.map((h) => meta[h]?.camp);
+  if (camps.some((c) => !c)) return false;
+  return camps.every((c) => c === camps[0]);
+}
+
+/**
+ * Soft structural preference score for a set of trios (higher is better). All
+ * three terms are best-effort — they never override skill/signature feasibility,
+ * and only break ties within the top-two-sum tolerance band. In priority order
+ * (encoded as a lexicographic tuple, later resolved by comparator):
+ *
+ *  1. Maximise teams with *exactly one* 输出核心 (strongly avoid zero or
+ *     multiple when an alternative exists).
+ *  2. Maximise teams with *exactly one* 体系核心.
+ *  3. Maximise all-same-camp teams.
+ */
+interface StructureScore {
+  outputCoreTeams: number;
+  systemCoreTeams: number;
+  sameCampTeams: number;
+}
+
+function structureScore(trios: string[][], meta: HeroMeta): StructureScore {
+  let outputCoreTeams = 0;
+  let systemCoreTeams = 0;
+  let sameCampTeams = 0;
+  for (const trio of trios) {
+    if (countLabel(trio, OUTPUT_CORE_LABEL, meta) === 1) outputCoreTeams += 1;
+    if (countLabel(trio, SYSTEM_CORE_LABEL, meta) === 1) systemCoreTeams += 1;
+    if (isAllSameCamp(trio, meta)) sameCampTeams += 1;
+  }
+  return { outputCoreTeams, systemCoreTeams, sameCampTeams };
+}
+
+/** How many of each soft core the formation reserves when trimming a big pool. */
+const RESERVED_PER_CORE = 3;
+
+/**
+ * Trim a strength-ranked hero list to at most `cap` heroes, metadata-aware.
+ *
+ * A pure top-`cap`-by-weight trim can discard every low-weight 输出核心/体系核心
+ * before the structural rules ever run, making "exactly one core per team"
+ * impossible. To avoid that we first *reserve* up to {@link RESERVED_PER_CORE}
+ * of the strongest available 输出核心 and up to {@link RESERVED_PER_CORE} of the
+ * strongest available 体系核心 (a hero labelled as both counts for both, but is
+ * only added once), then fill the remaining slots from the strength-ranked list,
+ * deduping. `ranked` is assumed already sorted strongest-first deterministically,
+ * so the result is deterministic. When no metadata is present the reservation is
+ * empty and this degrades to the plain top-`cap` trim.
+ */
+function trimPool(ranked: string[], meta: HeroMeta, cap: number): string[] {
+  if (ranked.length <= cap) return [...ranked];
+
+  const reserved: string[] = [];
+  const seen = new Set<string>();
+  const reserveByLabel = (label: string) => {
+    let taken = 0;
+    for (const h of ranked) {
+      if (taken >= RESERVED_PER_CORE || reserved.length >= cap) break;
+      if (seen.has(h)) continue;
+      if (meta[h]?.label !== label) continue;
+      reserved.push(h);
+      seen.add(h);
+      taken += 1;
+    }
+  };
+  reserveByLabel(OUTPUT_CORE_LABEL);
+  reserveByLabel(SYSTEM_CORE_LABEL);
+
+  const out = [...reserved];
+  for (const h of ranked) {
+    if (out.length >= cap) break;
+    if (seen.has(h)) continue;
+    seen.add(h);
+    out.push(h);
+  }
+  return out;
+}
+
+/** Compact positive, family-grouped evidence for one fully-assigned team. */
+function buildTeamEvidence(team: AssignedHero[], m: PairedModel): TeamEvidence {
+  const active = activeTeamContributions(team, m);
+  const toItem = (c: ActiveContribution): EvidenceItem => ({
+    label: labelFeature(c.featureId).label,
+    gain: displayScore(c.weight),
+    support: c.support,
+  });
+  // activeTeamContributions is already sorted by descending weight; take the
+  // top 2 positive rows per group. No negative deductions are surfaced.
+  const pick = (family: string): EvidenceItem[] =>
+    active
+      .filter((c) => c.family === family && c.weight > 0)
+      .slice(0, 2)
+      .map(toItem);
+  return {
+    heroSynergy: pick(F_HERO_PAIR),
+    heroSkill: pick(F_HERO_SKILL),
+    skillSynergy: pick(F_SKILL_PAIR),
+  };
+}
+
+/**
+ * A fully skill-assigned team *without* the (relatively expensive) positive
+ * evidence rows. Evidence is deferred to the single winning formation only —
+ * /team-builder already has a noticeable compute delay, so we never build
+ * evidence for the many discarded partitions.
+ */
+interface DraftTeam {
+  heroes: ProjectedHero[];
+  /** Assigned heroes (name + skills) — the input to scoreTeam / evidence. */
+  assigned: AssignedHero[];
+  /** Real `scoreTeam` strength (raw units). */
+  strength: number;
+}
+
+/** Assemble fully-assigned draft teams + their real `scoreTeam` strengths. */
 function projectFormation(
   trios: string[][],
   skillPool: string[],
   m: PairedModel,
   catalog: RecommendationCatalog
-): { teams: ProjectedTeam[]; strengths: number[] } | null {
-  const allHeroes = trios.flat();
+): { teams: DraftTeam[]; strengths: number[] } | null {
   const assignment = assignSkills(trios, skillPool, m, catalog);
   if (!assignment) return null;
-  const teams: ProjectedTeam[] = trios.map((trio) => {
-    const projected: ProjectedHero[] = trio.map((name) => {
+  const teams: DraftTeam[] = trios.map((trio) => {
+    const heroes: ProjectedHero[] = trio.map((name) => {
       const a = assignment.get(name)!;
       return { name, skills: a.skills, skillScore: displayScore(a.score) };
     });
-    const strength = scoreTeam(
-      projected.map((p) => ({ name: p.name, skills: p.skills })),
-      m
-    );
-    return { heroes: projected, strength };
+    const assigned = heroes.map((p) => ({ name: p.name, skills: p.skills }));
+    const strength = scoreTeam(assigned, m);
+    return { heroes, assigned, strength };
   });
   return { teams, strengths: teams.map((t) => t.strength) };
+}
+
+/** Soft-structure score for a single trio (higher = more structurally desirable). */
+function trioStructureRank(trio: string[], meta: HeroMeta): number {
+  let r = 0;
+  if (countLabel(trio, OUTPUT_CORE_LABEL, meta) === 1) r += 4;
+  if (countLabel(trio, SYSTEM_CORE_LABEL, meta) === 1) r += 2;
+  if (isAllSameCamp(trio, meta)) r += 1;
+  return r;
+}
+
+/**
+ * Union of the strength-ranked and structure-ranked top slices of a trio list,
+ * de-duplicated and returned in a deterministic order. Keeping both kinds of
+ * candidate ensures the beam retains structurally good partitions (exactly-one
+ * core / same-camp) that a pure strength prune would drop, while still bounding
+ * the branching factor.
+ */
+function beamTrios(
+  trios: string[][],
+  m: PairedModel,
+  meta: HeroMeta,
+  byStrength: number,
+  byStructure: number
+): string[][] {
+  const decorated = trios.map((trio) => ({
+    trio,
+    s: trioHeroStrength(trio, m),
+    st: trioStructureRank(trio, meta),
+    canon: [...trio].sort().join(','),
+  }));
+  const strengthTop = [...decorated]
+    .sort((x, y) => (y.s !== x.s ? y.s - x.s : x.canon.localeCompare(y.canon)))
+    .slice(0, byStrength);
+  const structureTop = [...decorated]
+    .sort((x, y) =>
+      y.st !== x.st ? y.st - x.st : y.s !== x.s ? y.s - x.s : x.canon.localeCompare(y.canon)
+    )
+    .slice(0, byStructure);
+  const out: string[][] = [];
+  const seen = new Set<string>();
+  for (const { trio, canon } of [...strengthTop, ...structureTop]) {
+    if (seen.has(canon)) continue;
+    seen.add(canon);
+    out.push(trio);
+  }
+  return out;
+}
+
+interface FormationCandidate {
+  teams: DraftTeam[];
+  /** Fully-assigned team strengths, sorted strongest-first. */
+  sorted: number[];
+  topTwoSum: number;
+  thirdStrength: number;
+  totalStrength: number;
+  structure: StructureScore;
+  /** Deterministic canonical key over the hero partition. */
+  key: string;
+}
+
+/**
+ * Lexicographic ranking comparator for candidates that have *already* been
+ * retained inside the global top-two band (see {@link recommendTeams}). The
+ * *better* candidate compares less-than, so a stable min-pick keeps the winner.
+ *
+ * This comparator is total, transitive and order-independent — it does NOT
+ * apply any tolerance. The strength band is enforced once, globally, before
+ * ranking; here every retained candidate is treated as strength-tied and ranked
+ * purely by the soft preferences and then deterministic tie-breaks:
+ *
+ *  1. More teams with exactly one 输出核心.
+ *  2. More teams with exactly one 体系核心.
+ *  3. More all-same-camp teams.
+ *  4. Stronger third team.
+ *  5. Higher total strength.
+ *  6. Deterministic canonical key.
+ */
+function compareCandidates(a: FormationCandidate, b: FormationCandidate): number {
+  if (a.structure.outputCoreTeams !== b.structure.outputCoreTeams)
+    return b.structure.outputCoreTeams - a.structure.outputCoreTeams;
+  if (a.structure.systemCoreTeams !== b.structure.systemCoreTeams)
+    return b.structure.systemCoreTeams - a.structure.systemCoreTeams;
+  if (a.structure.sameCampTeams !== b.structure.sameCampTeams)
+    return b.structure.sameCampTeams - a.structure.sameCampTeams;
+  if (Math.abs(a.thirdStrength - b.thirdStrength) > 1e-9)
+    return a.thirdStrength > b.thirdStrength ? -1 : 1;
+  if (Math.abs(a.totalStrength - b.totalStrength) > 1e-9)
+    return a.totalStrength > b.totalStrength ? -1 : 1;
+  return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
 }
 
 /**
  * Optimise all three disjoint 3-hero teams together with their unique 18-skill
  * assignment.
  *
- * The candidate *selection* is driven by the true final objective computed from
- * *fully skill-assigned* teams — not by a hero-only proxy. Concretely:
+ * Selection is driven by *fully skill-assigned* teams, not a hero-only proxy:
  *
- *  1. Enumerate a bounded, deterministic beam of disjoint 3×3 hero partitions
- *     (hero-only strength is used only to *prune* the beam, never to pick the
- *     winner).
- *  2. For every retained partition, run the global 18-skill assignment and score
- *     each team with the full model (`scoreTeam`: hero + hero-pair + skill +
- *     hero-skill + within-hero skill-pair features).
- *  3. Keep the partition whose fully-assigned objective (aggregate roster
- *     strength minus a weakest-team balance penalty) is highest. The returned
- *     `objective` is exactly that selector value.
+ *  1. Enumerate a bounded, deterministic beam of disjoint 3×3 hero partitions.
+ *     Each level's candidates are the *union* of a strength-ranked and a
+ *     structure-ranked (exactly-one-core / same-camp) top slice, so structurally
+ *     good partitions survive the prune while runtime stays bounded.
+ *  2. For every retained partition, run the global unique 18-skill assignment
+ *     (2/hero, never a signature skill) and score each team with the full model.
+ *  3. Select in two global stages, never pairwise: (a) find the single absolute
+ *     maximum top-two-team summed strength across all feasible formations, and
+ *     retain every formation whose top-two sum is within a
+ *     {@link TOP_TWO_BAND}-point display band of that maximum; (b) rank the
+ *     retained set with a pure, transitive lexicographic comparator — exactly
+ *     one 输出核心 per team, then exactly one 体系核心, then all-same-camp, then
+ *     the stronger third team, total strength, and a deterministic key. Role/camp
+ *     rules never override skill/signature feasibility and never widen the band.
  *
- * Deterministic and bounded for pools of 9–12 heroes (larger pools are trimmed
- * to the 12 strongest heroes by individual weight before enumeration).
+ * Only the aggregate 总评分 (sum of all three team strengths, display units) is
+ * returned as a user-facing summary. `heroMeta` carries the soft 阵营/定位 labels
+ * from the database; when omitted the structural preferences are simply inert.
+ *
+ * Deterministic and bounded for pools of 9–12 heroes. Larger pools are trimmed
+ * to 12 heroes with a metadata-aware trim (see {@link trimPool}) that reserves
+ * up to three of each soft core before filling by individual weight.
  */
 export function recommendTeams(
   heroPool: string[],
   skillPool: string[],
   data: RecommendationData,
-  catalog: RecommendationCatalog
+  catalog: RecommendationCatalog,
+  heroMeta: HeroMeta = {}
 ): FormationRecommendation {
   const m = model(data);
   const heroes = [...new Set(heroPool)];
@@ -831,48 +1096,41 @@ export function recommendTeams(
 
   const incompleteResult: FormationRecommendation = {
     teams: [],
-    objective: 0,
-    aggregateStrength: 0,
-    weakestTeamStrength: 0,
-    balanceSpread: 0,
+    totalScore: 0,
     incomplete: true,
   };
   if (heroes.length < 9 || skills.length < 18) return incompleteResult;
 
-  // Trim large pools to a bounded set of the strongest heroes (keeps the beam
-  // enumeration tractable); exactly-9 pools use all 9.
+  // Trim large pools to a bounded set (keeps the beam enumeration tractable);
+  // exactly-9 pools use all 9. Trimming by raw individual weight alone would
+  // drop every low-weight 输出核心/体系核心 before the structural rules run, so
+  // the trim is metadata-aware: reserve up to the three strongest available
+  // 输出核心 and up to the three strongest available 体系核心, then fill the
+  // remaining slots by individual strength. Missing metadata is inert (no hero
+  // is reserved), and the whole trim stays deterministic.
   const rankedHeroes = [...heroes].sort((a, b) => {
     const wa = weightOf(m, heroId(a));
     const wb = weightOf(m, heroId(b));
     if (wb !== wa) return wb - wa;
     return a.localeCompare(b);
   });
-  const pool = rankedHeroes.slice(0, Math.min(12, rankedHeroes.length));
+  const pool = trimPool(rankedHeroes, heroMeta, 12);
 
-  // Build a bounded, deterministic beam of disjoint partitions. Hero-only
-  // strength prunes the branching factor only; the winner is chosen later by the
-  // fully-assigned objective.
+  // Build a bounded, deterministic beam of disjoint partitions. Each level
+  // unions a strength-ranked and a structure-ranked slice so good structure
+  // survives the prune; the winner is chosen later by the full comparator.
   const partitions: [string[], string[], string[]][] = [];
   const seen = new Set<string>();
-  const firstTrios = combinations3(pool)
-    .map((t) => ({ trio: t, s: trioHeroStrength(t, m) }))
-    .sort((x, y) => (y.s !== x.s ? y.s - x.s : x.trio.join(',').localeCompare(y.trio.join(','))))
-    .slice(0, 40);
-  for (const { trio: t1 } of firstTrios) {
+  const firstTrios = beamTrios(combinations3(pool), m, heroMeta, 40, 16);
+  for (const t1 of firstTrios) {
     const used1 = new Set(t1);
     const rest1 = pool.filter((h) => !used1.has(h));
-    const secondTrios = combinations3(rest1)
-      .map((t) => ({ trio: t, s: trioHeroStrength(t, m) }))
-      .sort((x, y) => (y.s !== x.s ? y.s - x.s : x.trio.join(',').localeCompare(y.trio.join(','))))
-      .slice(0, 12);
-    for (const { trio: t2 } of secondTrios) {
+    const secondTrios = beamTrios(combinations3(rest1), m, heroMeta, 12, 6);
+    for (const t2 of secondTrios) {
       const used2 = new Set([...t1, ...t2]);
       const rest2 = pool.filter((h) => !used2.has(h));
-      const thirdTrios = combinations3(rest2)
-        .map((t) => ({ trio: t, s: trioHeroStrength(t, m) }))
-        .sort((x, y) => (y.s !== x.s ? y.s - x.s : x.trio.join(',').localeCompare(y.trio.join(','))))
-        .slice(0, 4);
-      for (const { trio: t3 } of thirdTrios) {
+      const thirdTrios = beamTrios(combinations3(rest2), m, heroMeta, 4, 4);
+      for (const t3 of thirdTrios) {
         // Canonicalise the partition (order trios, order heroes) to dedupe.
         const canon = [t1, t2, t3]
           .map((t) => [...t].sort().join('|'))
@@ -885,33 +1143,40 @@ export function recommendTeams(
     }
   }
 
-  // Choose by the true fully-assigned objective. Deterministic tie-break by the
-  // canonical hero ordering.
-  let best: {
-    teams: ProjectedTeam[];
-    strengths: number[];
-    objective: number;
-    key: string;
-  } | null = null;
+  // Stage 1: score every feasible fully-assigned partition into candidates.
+  const candidates: FormationCandidate[] = [];
   for (const trios of partitions) {
     const projected = projectFormation(trios, skills, m, catalog);
     if (!projected) continue;
     const { teams, strengths } = projected;
-    const objective = formationObjective(strengths);
-    const key = trios
-      .map((t) => t.map((p) => p).sort().join('|'))
-      .sort()
-      .join('||');
-    if (
-      best === null ||
-      objective > best.objective + 1e-9 ||
-      (Math.abs(objective - best.objective) <= 1e-9 && key < best.key)
-    ) {
-      best = { teams, strengths, objective, key };
-    }
+    const sorted = [...strengths].sort((a, b) => b - a);
+    candidates.push({
+      teams,
+      sorted,
+      topTwoSum: sorted[0] + sorted[1],
+      thirdStrength: sorted[2],
+      totalStrength: strengths.reduce((a, b) => a + b, 0),
+      structure: structureScore(trios, heroMeta),
+      key: trios
+        .map((t) => [...t].sort().join('|'))
+        .sort()
+        .join('||'),
+    });
   }
 
-  if (!best) return incompleteResult;
+  if (candidates.length === 0) return incompleteResult;
+
+  // Stage 2: true global band. Find the single absolute-maximum top-two sum,
+  // retain every candidate whose top-two sum is no more than TOP_TWO_BAND
+  // *display points* below that maximum, then rank the retained set with the
+  // pure lexicographic comparator (soft role/camp, then third team, total, key).
+  // This is order-independent: the band is fixed once against a global anchor,
+  // never applied pairwise.
+  const maxTopTwo = Math.max(...candidates.map((c) => c.topTwoSum));
+  const bandRaw = TOP_TWO_BAND / 10; // display points → raw units
+  const retained = candidates.filter((c) => c.topTwoSum >= maxTopTwo - bandRaw - 1e-9);
+  retained.sort(compareCandidates);
+  const best = retained[0];
 
   // Order the displayed teams strongest-first for a stable, readable result.
   const ordered = [...best.teams].sort((a, b) => {
@@ -919,23 +1184,20 @@ export function recommendTeams(
     return a.heroes.map((h) => h.name).join(',').localeCompare(b.heroes.map((h) => h.name).join(','));
   });
 
+  // Build the positive per-team evidence only now, for the single winner.
   const teams: ProjectedTeam[] = ordered.map((t) => ({
     heroes: t.heroes,
     strength: displayScore(t.strength),
+    evidence: buildTeamEvidence(t.assigned, m),
   }));
-  const strengths = teams.map((t) => t.strength);
-  const aggregate = strengths.reduce((a, b) => a + b, 0);
-  const weakest = Math.min(...strengths);
-  const spread = Math.max(...strengths) - weakest;
+  const totalScore = roundTo(
+    teams.reduce((a, t) => a + t.strength, 0),
+    1
+  );
 
   return {
     teams,
-    // Return the exact selector value in display units. It may differ by 0.1
-    // from recomputing the formula over individually-rounded team labels.
-    objective: displayScore(best.objective),
-    aggregateStrength: roundTo(aggregate, 1),
-    weakestTeamStrength: weakest,
-    balanceSpread: roundTo(spread, 1),
+    totalScore,
     incomplete: false,
   };
 }

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -585,14 +585,24 @@ export interface ProjectedTeam {
   evidence: TeamEvidence;
 }
 
-export interface FormationRecommendation {
+/**
+ * One feasible formation option: three fully-assigned, disjoint 3-hero teams.
+ * Each team carries its own display-unit 评分 and compact positive evidence.
+ * No aggregate 总评分 or optimiser internals are surfaced.
+ */
+export interface FormationOption {
   teams: ProjectedTeam[];
+}
+
+export interface FormationRecommendation {
   /**
-   * The single summary shown to the user (总评分): the display-unit sum of all
-   * three fully-assigned team strengths. Optimiser internals (top-two/third
-   * sums, camp/core counts) are not surfaced.
+   * Up to three deterministic, distinct feasible formation options, ordered
+   * 方案一（推荐） / 方案二 / 方案三. Option one is the recommended winner; options
+   * two and three use different canonical hero partitions and are selected for
+   * diversity. Fewer than three are returned when fewer distinct feasible
+   * candidates exist.
    */
-  totalScore: number;
+  options: FormationOption[];
   /** True when the pool wasn't large enough for a full 3×3 formation. */
   incomplete: boolean;
 }
@@ -1175,9 +1185,91 @@ function compareCandidates(a: FormationCandidate, b: FormationCandidate): number
   return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
 }
 
+/** Number of formation options surfaced to the user (方案一/二/三). */
+const MAX_OPTIONS = 3;
+
+/**
+ * Order a candidate's fully-assigned teams strongest-first (stable, readable)
+ * and build its user-facing {@link ProjectedTeam}s (per-team display 评分 and
+ * compact positive evidence). No aggregate score is produced.
+ */
+function candidateToOption(candidate: FormationCandidate, m: PairedModel): FormationOption {
+  const ordered = [...candidate.teams].sort((a, b) => {
+    if (b.strength !== a.strength) return b.strength - a.strength;
+    return a.heroes
+      .map((h) => h.name)
+      .join(',')
+      .localeCompare(b.heroes.map((h) => h.name).join(','));
+  });
+  const teams: ProjectedTeam[] = ordered.map((t) => ({
+    heroes: t.heroes,
+    strength: displayScore(t.strength),
+    evidence: buildTeamEvidence(t.assigned, m),
+  }));
+  return { teams };
+}
+
+/**
+ * Number of heroes the two partitions place on the same canonical team. Used as
+ * an overlap proxy so diversity picks avoid trivial team-order variants of an
+ * already-selected option. Higher = more similar.
+ */
+function partitionSimilarity(a: FormationCandidate, b: FormationCandidate): number {
+  const aTeams = a.teams.map((t) => new Set(t.heroes.map((h) => h.name)));
+  const bTeams = b.teams.map((t) => t.heroes.map((h) => h.name));
+  // For each team in b, its best-matching team in a (max shared heroes).
+  return bTeams.reduce((sum, team) => {
+    const best = Math.max(...aTeams.map((s) => team.filter((h) => s.has(h)).length));
+    return sum + best;
+  }, 0);
+}
+
+/**
+ * Deterministically pick up to {@link MAX_OPTIONS} distinct feasible options
+ * from the already-scored candidates — with no additional partition evaluation.
+ *
+ * Option one is always the winner. Each subsequent option is chosen from the
+ * remaining candidates (distinct canonical partition keys only) to maximise
+ * diversity: minimise the maximum hero-overlap against any already-selected
+ * option, then prefer the candidate the ranking comparator likes best, then a
+ * deterministic canonical key. This yields meaningfully different formations
+ * rather than trivial team-order variants, with no randomness.
+ */
+function selectDiverseOptions(
+  ranked: FormationCandidate[],
+  m: PairedModel
+): FormationOption[] {
+  if (ranked.length === 0) return [];
+  const chosen: FormationCandidate[] = [ranked[0]];
+  const usedKeys = new Set<string>([ranked[0].key]);
+  while (chosen.length < MAX_OPTIONS) {
+    let best: FormationCandidate | null = null;
+    let bestOverlap = Infinity;
+    let bestRank = Infinity;
+    for (let idx = 0; idx < ranked.length; idx += 1) {
+      const c = ranked[idx];
+      if (usedKeys.has(c.key)) continue;
+      const overlap = Math.max(...chosen.map((s) => partitionSimilarity(s, c)));
+      if (
+        overlap < bestOverlap ||
+        (overlap === bestOverlap && idx < bestRank) ||
+        (overlap === bestOverlap && idx === bestRank && best !== null && c.key < best.key)
+      ) {
+        best = c;
+        bestOverlap = overlap;
+        bestRank = idx;
+      }
+    }
+    if (!best) break;
+    chosen.push(best);
+    usedKeys.add(best.key);
+  }
+  return chosen.map((c) => candidateToOption(c, m));
+}
+
 /**
  * Optimise all three disjoint 3-hero teams together with their unique 18-skill
- * assignment.
+ * assignment, then expose up to three distinct feasible formation options.
  *
  * Selection is driven by *fully skill-assigned* teams, not a hero-only proxy:
  *
@@ -1195,10 +1287,13 @@ function compareCandidates(a: FormationCandidate, b: FormationCandidate): number
  *     one 输出核心 per team, then exactly one 体系核心, then all-same-camp, then
  *     the stronger third team, total strength, and a deterministic key. Role/camp
  *     rules never override skill/signature feasibility and never widen the band.
+ *  4. Option one is that winner; options two and three are a deterministic
+ *     diversity selection over the *same already-scored candidates* (distinct
+ *     canonical partition keys, minimal hero-overlap) — no extra evaluation.
  *
- * Only the aggregate 总评分 (sum of all three team strengths, display units) is
- * returned as a user-facing summary. `heroMeta` carries the soft 阵营/定位 labels
- * from the database; when omitted the structural preferences are simply inert.
+ * No aggregate 总评分 is produced; each team carries its own display 评分.
+ * `heroMeta` carries the soft 阵营/定位 labels from the database; when omitted the
+ * structural preferences are simply inert.
  *
  * Deterministic and bounded for pools of 9–12 heroes. Larger pools are trimmed
  * to 12 heroes with a metadata-aware trim (see {@link trimPool}) that reserves
@@ -1216,8 +1311,7 @@ export function recommendTeams(
   const skills = [...new Set(skillPool)];
 
   const incompleteResult: FormationRecommendation = {
-    teams: [],
-    totalScore: 0,
+    options: [],
     incomplete: true,
   };
   if (heroes.length < 9 || skills.length < 18) return incompleteResult;
@@ -1274,28 +1368,21 @@ export function recommendTeams(
   const bandRaw = TOP_TWO_BAND / 10; // display points → raw units
   const retained = candidates.filter((c) => c.topTwoSum >= maxTopTwo - bandRaw - 1e-9);
   retained.sort(compareCandidates);
-  const best = retained[0];
 
-  // Order the displayed teams strongest-first for a stable, readable result.
-  const ordered = [...best.teams].sort((a, b) => {
-    if (b.strength !== a.strength) return b.strength - a.strength;
-    return a.heroes.map((h) => h.name).join(',').localeCompare(b.heroes.map((h) => h.name).join(','));
-  });
+  // Keep every surfaced option inside the same 2.5-display-point top-two band
+  // as the recommended winner. This avoids trading away meaningful main-team
+  // strength merely to make alternatives look different. The retained array is
+  // already comparator-ranked with the winner first.
+  const rankedFromWinner = retained;
 
-  // Build the positive per-team evidence only now, for the single winner.
-  const teams: ProjectedTeam[] = ordered.map((t) => ({
-    heroes: t.heroes,
-    strength: displayScore(t.strength),
-    evidence: buildTeamEvidence(t.assigned, m),
-  }));
-  const totalScore = roundTo(
-    teams.reduce((a, t) => a + t.strength, 0),
-    1
-  );
+  // Option one is the winner. Options two and three come from a deterministic
+  // diversity selection over the ranked set — distinct canonical partition keys,
+  // minimal hero overlap. When fewer than three distinct feasible candidates
+  // exist, only those available are returned.
+  const options = selectDiverseOptions(rankedFromWinner, m);
 
   return {
-    teams,
-    totalScore,
+    options,
     incomplete: false,
   };
 }

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -613,6 +613,18 @@ const SYSTEM_CORE_LABEL = '体系核心';
  */
 const TOP_TWO_BAND = 2.5;
 
+/**
+ * Hard upper bound on the number of hero partitions that are *fully* skill-
+ * assigned and scored (the expensive {@link projectFormation} pass). The beam
+ * unions a strength-ranked and a structure-ranked slice per level, so its
+ * worst-case product (~56·18·8) can exceed the pre-structure search size; this
+ * cap pulls the fully-evaluated set back near the previous ~1920 bound while a
+ * deterministic strength/structure interleave (see {@link capPartitions}) keeps
+ * a deliberate mix of both kinds of candidate. Pools of 9–11 heroes enumerate
+ * far fewer than this, so the cap only bites on the largest (12-hero) pools.
+ */
+export const PARTITION_EVAL_CAP = 1920;
+
 /** Hero-only strength (hero + internal hero-pair weights) of a trio. */
 function trioHeroStrength(trio: string[], m: PairedModel): number {
   let s = 0;
@@ -1014,6 +1026,112 @@ function beamTrios(
   return out;
 }
 
+/** Canonical, order-independent key for a hero partition (order trios & heroes). */
+function partitionKey(trios: string[][]): string {
+  return trios
+    .map((t) => [...t].sort().join('|'))
+    .sort()
+    .join('||');
+}
+
+/**
+ * Deterministically cap the fully-evaluated partition set at {@link PARTITION_EVAL_CAP}.
+ *
+ * The beam can enumerate more disjoint partitions than we want to skill-assign
+ * and score (that pass is the /team-builder compute cost). Rather than truncate
+ * in enumeration order — which would bias toward whichever trio happened to sort
+ * first — we rank every partition two ways and *interleave*: a strength proxy
+ * (top-two trio hero-strength, matching the top-two-sum selection goal) and a
+ * structure proxy (exactly-one-core / same-camp counts). Alternating one pick
+ * from each list preserves a deliberate mix of strong and structurally good
+ * partitions while bounding the count. Dedupe is by canonical key, so the result
+ * is total, transitive and order-independent.
+ */
+function capPartitions(
+  partitions: [string[], string[], string[]][],
+  m: PairedModel,
+  meta: HeroMeta,
+  cap: number
+): [string[], string[], string[]][] {
+  if (partitions.length <= cap) return partitions;
+  const decorated = partitions.map((trios) => {
+    const hs = trios.map((t) => trioHeroStrength(t, m)).sort((a, b) => b - a);
+    const ss = structureScore(trios, meta);
+    return {
+      trios,
+      strength: hs[0] + hs[1],
+      structure: ss.outputCoreTeams * 4 + ss.systemCoreTeams * 2 + ss.sameCampTeams,
+      key: partitionKey(trios),
+    };
+  });
+  const cmpKey = (a: { key: string }, b: { key: string }) =>
+    a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+  const byStrength = [...decorated].sort((a, b) =>
+    b.strength !== a.strength
+      ? b.strength - a.strength
+      : b.structure !== a.structure
+        ? b.structure - a.structure
+        : cmpKey(a, b)
+  );
+  const byStructure = [...decorated].sort((a, b) =>
+    b.structure !== a.structure
+      ? b.structure - a.structure
+      : b.strength !== a.strength
+        ? b.strength - a.strength
+        : cmpKey(a, b)
+  );
+  const picked: [string[], string[], string[]][] = [];
+  const seen = new Set<string>();
+  let i = 0;
+  let j = 0;
+  const take = (c: { trios: [string[], string[], string[]]; key: string }) => {
+    if (seen.has(c.key)) return;
+    seen.add(c.key);
+    picked.push(c.trios);
+  };
+  while (picked.length < cap && (i < byStrength.length || j < byStructure.length)) {
+    if (i < byStrength.length) take(byStrength[i++]);
+    if (picked.length >= cap) break;
+    if (j < byStructure.length) take(byStructure[j++]);
+  }
+  return picked;
+}
+
+/**
+ * Enumerate the bounded, deterministic beam of disjoint 3×3 hero partitions for
+ * a pool, then cap the fully-evaluated set at {@link PARTITION_EVAL_CAP}. Each
+ * level unions a strength-ranked and a structure-ranked slice so structurally
+ * good partitions survive the prune; {@link capPartitions} then interleaves the
+ * two rankings globally so the evaluated count stays bounded without biasing the
+ * mix. Exported for the evaluation-bound regression test.
+ */
+export function enumerateFormationPartitions(
+  pool: string[],
+  m: PairedModel,
+  heroMeta: HeroMeta
+): [string[], string[], string[]][] {
+  const partitions: [string[], string[], string[]][] = [];
+  const seen = new Set<string>();
+  const firstTrios = beamTrios(combinations3(pool), m, heroMeta, 40, 16);
+  for (const t1 of firstTrios) {
+    const used1 = new Set(t1);
+    const rest1 = pool.filter((h) => !used1.has(h));
+    const secondTrios = beamTrios(combinations3(rest1), m, heroMeta, 12, 6);
+    for (const t2 of secondTrios) {
+      const used2 = new Set([...t1, ...t2]);
+      const rest2 = pool.filter((h) => !used2.has(h));
+      const thirdTrios = beamTrios(combinations3(rest2), m, heroMeta, 4, 4);
+      for (const t3 of thirdTrios) {
+        const canon = partitionKey([t1, t2, t3]);
+        if (seen.has(canon)) continue;
+        seen.add(canon);
+        partitions.push([t1, t2, t3]);
+      }
+    }
+  }
+  return capPartitions(partitions, m, heroMeta, PARTITION_EVAL_CAP);
+}
+
 interface FormationCandidate {
   teams: DraftTeam[];
   /** Fully-assigned team strengths, sorted strongest-first. */
@@ -1119,32 +1237,12 @@ export function recommendTeams(
   });
   const pool = trimPool(rankedHeroes, heroMeta, 12);
 
-  // Build a bounded, deterministic beam of disjoint partitions. Each level
+  // Build a bounded, deterministic beam of disjoint partitions (each level
   // unions a strength-ranked and a structure-ranked slice so good structure
-  // survives the prune; the winner is chosen later by the full comparator.
-  const partitions: [string[], string[], string[]][] = [];
-  const seen = new Set<string>();
-  const firstTrios = beamTrios(combinations3(pool), m, heroMeta, 40, 16);
-  for (const t1 of firstTrios) {
-    const used1 = new Set(t1);
-    const rest1 = pool.filter((h) => !used1.has(h));
-    const secondTrios = beamTrios(combinations3(rest1), m, heroMeta, 12, 6);
-    for (const t2 of secondTrios) {
-      const used2 = new Set([...t1, ...t2]);
-      const rest2 = pool.filter((h) => !used2.has(h));
-      const thirdTrios = beamTrios(combinations3(rest2), m, heroMeta, 4, 4);
-      for (const t3 of thirdTrios) {
-        // Canonicalise the partition (order trios, order heroes) to dedupe.
-        const canon = [t1, t2, t3]
-          .map((t) => [...t].sort().join('|'))
-          .sort()
-          .join('||');
-        if (seen.has(canon)) continue;
-        seen.add(canon);
-        partitions.push([t1, t2, t3]);
-      }
-    }
-  }
+  // survives the prune), then cap the fully-evaluated set at PARTITION_EVAL_CAP
+  // with a deterministic strength/structure interleave. The winner is chosen
+  // later by the full comparator.
+  const partitions = enumerateFormationPartitions(pool, m, heroMeta);
 
   // Stage 1: score every feasible fully-assigned partition into candidates.
   const candidates: FormationCandidate[] = [];
@@ -1160,10 +1258,7 @@ export function recommendTeams(
       thirdStrength: sorted[2],
       totalStrength: strengths.reduce((a, b) => a + b, 0),
       structure: structureScore(trios, heroMeta),
-      key: trios
-        .map((t) => [...t].sort().join('|'))
-        .sort()
-        .join('||'),
+      key: partitionKey(trios),
     });
   }
 

--- a/web/src/services/recommendationModel.ts
+++ b/web/src/services/recommendationModel.ts
@@ -151,6 +151,39 @@ export interface EvidenceSummary {
   minSupport: number;
 }
 
+/** A single fitted feature that fired for a team, with its family + evidence. */
+export interface ActiveContribution {
+  /** Feature id (e.g. `HP|a|b`). */
+  featureId: string;
+  /** Feature family (H/S/HP/HS/SP). */
+  family: string;
+  /** Fitted weight (relative roster-strength contribution). */
+  weight: number;
+  /** Support/evidence: battles this feature was observed in. */
+  support: number;
+}
+
+/**
+ * All fitted (non-neutral) features that fire for a fully-assigned team, with
+ * their weight + support. This is the canonical source of per-team "why" — the
+ * engine's positive evidence display filters and groups these rather than
+ * re-deriving feature ids inline. Ordered by descending weight, then feature id
+ * for determinism.
+ */
+export function activeTeamContributions(
+  team: AssignedHero[],
+  model: PairedModel
+): ActiveContribution[] {
+  const out: ActiveContribution[] = [];
+  for (const fid of teamFeatureIds(team)) {
+    const w = model.weights[fid];
+    if (w === undefined || w === 0) continue;
+    out.push({ featureId: fid, family: fid.split('|')[0], weight: w, support: supportOf(model, fid) });
+  }
+  out.sort((a, b) => (b.weight !== a.weight ? b.weight - a.weight : a.featureId.localeCompare(b.featureId)));
+  return out;
+}
+
 export function evidenceFor(team: AssignedHero[], model: PairedModel): EvidenceSummary {
   let featureCount = 0;
   let totalSupport = 0;

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -300,11 +300,11 @@ test.describe('Team Builder (/team-builder) formation card', () => {
     await page.goto('/team-builder');
 
     // Wait for the formation card and for optimisation to complete (the
-    // completed result renders the single 总评分 summary chip).
+    // completed result renders per-team 评分 headers).
     await expect(
-      page.getByRole('heading', { name: '全局最优编排' })
+      page.getByRole('heading', { name: '推荐编排' })
     ).toBeVisible({ timeout: 30000 });
-    await expect(page.getByText(/总评分/)).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText(/评分：/).first()).toBeVisible({ timeout: 30000 });
 
     const flags = await page.evaluate(() => window.__teamBuilderFlashFlags);
     // The loading state must have been observed (proves the card was rendered
@@ -314,17 +314,37 @@ test.describe('Team Builder (/team-builder) formation card', () => {
     expect(flags.warningSeen).toBe(false);
   });
 
-  test('shows only the 总评分 summary — no optimizer internals or camp/role display', async ({
+  test('shows a 方案 selector with per-team 评分 and no 总评分 or optimizer internals', async ({
     page,
   }) => {
     await page.goto('/team-builder');
     await expect(
-      page.getByRole('heading', { name: '全局最优编排' })
+      page.getByRole('heading', { name: '推荐编排' })
     ).toBeVisible({ timeout: 30000 });
-    // The single total-score summary is present.
-    await expect(page.getByText(/总评分/)).toBeVisible({ timeout: 30000 });
+    // Per-team scores render once optimisation completes.
+    await expect(page.getByText(/评分：/).first()).toBeVisible({ timeout: 30000 });
+
+    // The compact segmented selector labels the options.
+    const optionOne = page.getByRole('button', { name: '方案一（推荐）' });
+    await expect(optionOne).toBeVisible();
+    // With a full 9-hero pool, all three options are offered.
+    await expect(page.getByRole('button', { name: '方案二' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '方案三' })).toBeVisible();
+
+    await expect(page.getByRole('heading', { name: /^队伍 [123]$/ })).toHaveCount(3);
+    const firstFormation = await page.getByRole('heading', { name: /^队伍 [123]$/ }).locator('..').locator('..').allInnerTexts();
+
+    // Switching to another option replaces the three visible team cards.
+    await page.getByRole('button', { name: '方案二' }).click();
+    await expect(page.getByRole('button', { name: '方案二' })).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByText(/评分：/).first()).toBeVisible();
+    await expect(page.getByRole('heading', { name: /^队伍 [123]$/ })).toHaveCount(3);
+    const secondFormation = await page.getByRole('heading', { name: /^队伍 [123]$/ }).locator('..').locator('..').allInnerTexts();
+    expect(secondFormation).not.toEqual(firstFormation);
 
     const body = await page.locator('body').innerText();
+    // The removed aggregate summary must never appear.
+    expect(body).not.toContain('总评分');
     // No optimizer internals / removed labels are surfaced.
     for (const forbidden of [
       '整体强度',

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -300,11 +300,11 @@ test.describe('Team Builder (/team-builder) formation card', () => {
     await page.goto('/team-builder');
 
     // Wait for the formation card and for optimisation to complete (the
-    // completed result renders the 整体强度 strength chip).
+    // completed result renders the single 总评分 summary chip).
     await expect(
       page.getByRole('heading', { name: '全局最优编排' })
     ).toBeVisible({ timeout: 30000 });
-    await expect(page.getByText(/整体强度/)).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText(/总评分/)).toBeVisible({ timeout: 30000 });
 
     const flags = await page.evaluate(() => window.__teamBuilderFlashFlags);
     // The loading state must have been observed (proves the card was rendered
@@ -312,5 +312,37 @@ test.describe('Team Builder (/team-builder) formation card', () => {
     // appeared at any point during the load.
     expect(flags.loadingSeen).toBe(true);
     expect(flags.warningSeen).toBe(false);
+  });
+
+  test('shows only the 总评分 summary — no optimizer internals or camp/role display', async ({
+    page,
+  }) => {
+    await page.goto('/team-builder');
+    await expect(
+      page.getByRole('heading', { name: '全局最优编排' })
+    ).toBeVisible({ timeout: 30000 });
+    // The single total-score summary is present.
+    await expect(page.getByText(/总评分/)).toBeVisible({ timeout: 30000 });
+
+    const body = await page.locator('body').innerText();
+    // No optimizer internals / removed labels are surfaced.
+    for (const forbidden of [
+      '整体强度',
+      '最弱一队',
+      '均衡差',
+      '目标值',
+      '火力',
+      '推荐理由',
+      '可能减分项',
+      '胜率',
+      '阵营',
+      '输出核心',
+      '体系核心',
+    ]) {
+      expect(body).not.toContain(forbidden);
+    }
+    // Positive evidence uses the approved plain wording and 加分/参考 rows.
+    expect(body).toContain('加分');
+    expect(body).toContain('参考');
   });
 });


### PR DESCRIPTION
## Intent

Improve /team-builder formation recommendations and UI in one replacement: build two strong main teams before the third; use database hero camp and labels as soft preferences so each team ideally has exactly one 输出核心, then one 体系核心, then same-camp composition without overriding meaningful strength; restore compact positive hero-pair, hero-skill, and skill-pair battle evidence; avoid the insufficient-pool warning flash while client state loads; show up to three deterministic and canonically distinct formation options labeled 方案一（推荐）, 方案二, 方案三, with only the selected option visible; keep every option within the same 2.5-display-point top-two strength band; show 评分：X.X on each team and remove 总评分, aggregate panels, fire bars, recommendation reasons, optimizer internals, camp/core badges, and confusing negative evidence; return the new options API without backward compatibility; preserve deterministic refresh behavior; and keep browser performance bounded by fully evaluating at most 1,920 formation partitions while deriving all three options from the already-scored retained candidates. Validate typecheck, full web unit tests, full Playwright E2E, build, documentation, push, PR, and CI with telemetry disabled.

## What Changed

- Reworked the final-formation optimizer in `recommendationEngine.ts` to prioritize the two strongest main teams before the third: it retains every partition within a fixed 2.5-display-point top-two strength band, then ranks the retained set by hidden soft preferences from `database.json` (one 输出核心, then one 体系核心, then same-camp composition) without overriding skill/signature feasibility, and caps full evaluation at 1,920 partitions via a deterministic strength/structure-ranked beam.
- Added a new options API that returns up to three deterministic, canonically distinct formations (方案一（推荐）, 方案二, 方案三) derived from the already-scored retained candidates by minimizing team overlap within the same band; supporting feature-id helpers were added to `recommendationModel.ts`. This replaces the prior single-winner API with no backward compatibility.
- Updated `TeamBuilder.tsx` to show only the selected option with per-team 评分：X.X and compact positive 武将配合 / 武将与战法 / 战法搭配 evidence, removing 总评分, aggregate panels, fire bars, recommendation reasons, camp/core badges, and negative evidence, and to avoid flashing the insufficient-pool warning while client state loads.
- Expanded unit and Playwright coverage for the options API, top-two band, soft camp/label preferences, and deterministic distinct output, and synced the README formation description.

## Risk Assessment

✅ Low: The change is web-only, confined to one page and two services with no other consumers of the redesigned API, is extensively covered by new unit and e2e tests, and its determinism/band/evidence logic checks out; only trivial informational observations remain.

## Testing

Ran the full web test surface for this web-only change under Node v22.17.1 (bundled Node 20.15.1 was too old): typecheck clean, 69 Vitest unit tests pass, all 26 Playwright E2E pass (including the two tests directly covering the new 方案 selector, per-team 评分, no-warning-flash, and removed aggregate/internals), and the production build succeeds. I also captured reviewer-visible screenshots of the actual rendered /team-builder page showing 方案一（推荐）/方案二/方案三 with distinct switchable formations, per-team 评分：X.X, and compact positive 武将配合/武将与战法 evidence (加分/参考), confirming the aggregate score, fire bars, reasons, and optimizer internals are gone. Setup-only fixes (sandbox-disabled git/node for OpenSSL and .git reads, installed the missing rolldown native binding, used Node 22) were required to run the toolchain and are not product issues. Working tree left clean.

- Evidence: 方案一（推荐） — recommended formation with per-team 评分 and positive evidence (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXNAF2VRA50VTDH62EWHMR2H/team-builder-option1-recommended.png</code>)
- Evidence: 方案二 — distinct formation after switching options (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXNAF2VRA50VTDH62EWHMR2H/team-builder-option2.png</code>)
- Evidence: 方案三 — third formation option (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXNAF2VRA50VTDH62EWHMR2H/team-builder-option3.png</code>)
- Evidence: Full /team-builder page (recommended option) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXNAF2VRA50VTDH62EWHMR2H/team-builder-fullpage.png</code>)
<details>
<summary>Evidence: Playwright E2E result (team-builder tests)</summary>

```text
✓ 22 buildATeam.spec.js › complete pool never flashes the insufficient warning before optimisation
✓ 24 buildATeam.spec.js › shows a 方案 selector with per-team 评分 and no 总评分 or optimizer internals
26 passed (15.8s)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `web/src/services/recommendationEngine.ts:1256` - In selectDiverseOptions the third tie-break clause `overlap === bestOverlap &amp;&amp; idx === bestRank &amp;&amp; ...` (line 1256) is unreachable: idx strictly increases each iteration and bestRank is always set to an earlier idx, so idx can never equal bestRank in a later iteration. Determinism is already fully provided by the preceding `idx &lt; bestRank` clause (ranked is comparator-ordered), so behavior is correct — the clause is just dead code that misrepresents the tie-break logic.
- ℹ️ `web/src/services/recommendationEngine.ts:290` - The DraftTeam doc comment says evidence is &#34;deferred to the single winning formation only,&#34; but candidateToOption now builds evidence for each of the up-to-three returned options (up to 9 buildTeamEvidence calls). Evidence is still correctly not built for the ~1920 discarded partitions, so this is only a slightly misleading comment, not a behavioral issue.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; npm run typecheck` (tsc --noEmit) — clean</code>
- <code>`cd web &amp;&amp; npx vitest run` — 69/69 unit tests pass, including recommendationEngine.test.ts options API / top-two band / soft camp+label preferences / deterministic distinct options</code>
- <code>`cd web &amp;&amp; npx playwright test` — 26/26 E2E pass, incl. &#39;complete pool never flashes the insufficient warning&#39; and &#39;shows a 方案 selector with per-team 评分 and no 总评分 or optimizer internals&#39;</code>
- <code>`cd web &amp;&amp; npm run build` (vite build) — succeeds</code>
- `Manual screenshot capture via a standalone Playwright script against the dev server: seeded a full 9-hero/18-skill pool, rendered /team-builder, captured 方案一（推荐）, 方案二, 方案三, and full-page; verified body text contains 推荐编排/方案 labels/评分/加分/参考 and excludes 总评分 and optimizer internals`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
