### PR TITLE
feat(analytics): make hero/skill analytics page player-friendly and rank by 强度加成

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -12,7 +12,7 @@ data files are generated.
 - **Setup Phase**: Select starting heroes and skills with pinyin search support
 - **Game Flow**: Round-by-round draft with recommendations for optimal team building (see [GAME_RULE.md](../GAME_RULE.md))
 - **Manual Editing**: Edit team composition manually at any time
-- **Analytics Dashboard**: Model-driven analytics — hero/skill win rates, usage, top synergies, and backtest quality
+- **Analytics Dashboard**: Player-friendly, question-led analytics — hero/skill rankings by 强度加成 (relative roster strength, with 胜率参考/参考场次 as supporting context), usage, top synergies, and optional (collapsed) model diagnostics
 - **Auto-save**: Progress automatically saved to cookies
 - **Responsive Design**: Works on desktop, tablet, and mobile devices
 
@@ -115,8 +115,13 @@ web/
 - **AnalysisGrid**: Show 3 option sets, each with its marginal 评分/score and key point breakdown
 
 ### Analytics
-- **Analytics**: Dashboard driven by the generated paired-model artifact
-- Summary stats, hero/skill win rates + model weights, usage, top synergies, and backtest quality
+- **Analytics**: Player-friendly dashboard driven by the generated paired-model artifact
+- Question-led layout with a plain-language guide to the three player-facing measures:
+  胜率参考 (smoothed win rate), 强度加成 (relative roster strength / model weight), and
+  参考场次 (reference battles). Hero/skill tables are ranked by 强度加成 (descending, with
+  deterministic tie-breakers); usage and top synergies keep their own orderings.
+- Technical model diagnostics (accuracy vs baseline, log loss, Brier, backtest sample/feature
+  counts) live in an optional, collapsed accordion so they don't get in a casual player's way.
 
 ### Common
 - **ErrorBoundary**: Global error handling

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -290,7 +290,7 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography component="h3" variant="h6">全部武将（按胜率参考排序）</Typography>
+                  <Typography component="h3" variant="h6">全部武将（按强度加成排序）</Typography>
                 </Box>
                 <ResponsiveDisclosure label="全部武将排名">
                 <ScrollableAnalyticsTable label="全部武将排名">
@@ -327,7 +327,7 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography component="h3" variant="h6">全部战法（按胜率参考排序）</Typography>
+                  <Typography component="h3" variant="h6">全部战法（按强度加成排序）</Typography>
                 </Box>
                 <ResponsiveDisclosure label="全部战法排名">
                 <ScrollableAnalyticsTable label="全部战法排名">

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -17,11 +17,20 @@ import {
   CircularProgress,
   Paper,
   IconButton,
+  Tooltip,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
 } from '@mui/material';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import LinkIcon from '@mui/icons-material/Link';
 import ClearIcon from '@mui/icons-material/Clear';
 import InsightsIcon from '@mui/icons-material/Insights';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import GroupsIcon from '@mui/icons-material/Groups';
+import BarChartIcon from '@mui/icons-material/BarChart';
 import { api } from '../services/api';
 import { database } from '../data';
 import { tierRank } from '../utils/tiers';
@@ -58,6 +67,29 @@ const ScrollableAnalyticsTable = ({ children, label }: ScrollableAnalyticsTableP
 
 const pct = (x: number | null | undefined): string =>
   x == null ? '-' : `${(x * 100).toFixed(1)}%`;
+
+/**
+ * Format a relative roster-strength contribution (a model coefficient, NOT a
+ * percentage). Positive values get a leading '+' so players can read "helps"
+ * vs "hurts" at a glance; the underlying value and precision are unchanged.
+ */
+const fmtStrength = (x: number, dp = 3): string => {
+  const s = x.toFixed(dp);
+  return x > 0 ? `+${s}` : s;
+};
+
+/** Small keyboard/touch-accessible help affordance next to a label. */
+const HelpTip = ({ title, label }: { title: string; label: string }) => (
+  <Tooltip title={title} enterTouchDelay={0} leaveTouchDelay={4000}>
+    <IconButton
+      size="small"
+      aria-label={label}
+      sx={{ ml: 0.5, color: 'text.secondary' }}
+    >
+      <HelpOutlineIcon fontSize="inherit" />
+    </IconButton>
+  </Tooltip>
+);
 
 const Analytics = () => {
   const [data, setData] = useState<AnalyticsResult | null>(null);
@@ -160,36 +192,33 @@ const Analytics = () => {
         <Typography variant="overline" color="error.main">BATTLE ARCHIVE</Typography>
         <Typography component="h1" variant="h3" gutterBottom>数据洞察</Typography>
         <Typography variant="body1" color="text.secondary" paragraph>
-          战斗统计与模型表现（共 {data.summary.total_battles} 场对局）
+          这里帮你回答两个问题：<strong>哪些武将、战法更值得选</strong>，以及<strong>哪些搭配放在一起更好用</strong>。
+          所有结论都来自已记录的 {data.summary.total_battles} 场对局，是历史经验的参考，
+          <strong>并不保证</strong>在某一场对特定对手时一定获胜。
         </Typography>
 
-        {/* Model quality */}
-        <Card sx={{ mb: 4, borderTop: '3px solid', borderTopColor: 'info.main' }}>
+        {/* Plain-language guide: how to read the numbers */}
+        <Card sx={{ mb: 4, borderTop: '3px solid', borderTopColor: 'primary.main' }}>
           <CardContent>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1, gap: 1 }}>
-              <InsightsIcon sx={{ color: 'info.main' }} />
-              <Typography component="h2" variant="h6">模型质量（留出回测）</Typography>
-            </Box>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              成对（对手感知）逻辑回归模型，在按时间留出的测试集上评估。分数代表相对阵容强度，非对特定对手的胜率。
-            </Typography>
+            <Typography component="h2" variant="h6" gutterBottom>三步看懂这些数字</Typography>
             <Grid container spacing={2}>
-              <Grid size={{ xs: 6, md: 3 }}>
-                <Typography variant="overline" color="text.secondary">准确率</Typography>
-                <Typography variant="h5">{pct(mq.accuracy)}</Typography>
-                <Typography variant="caption" color="text.secondary">基线 {pct(mq.baseline_accuracy)}</Typography>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <Typography variant="subtitle2" gutterBottom>1. 胜率参考</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  经过校正、平滑处理后的历史表现，不是直接的胜负计数。场次少时会更贴近整体平均，避免被个别对局误导。
+                </Typography>
               </Grid>
-              <Grid size={{ xs: 6, md: 3 }}>
-                <Typography variant="overline" color="text.secondary">对数损失</Typography>
-                <Typography variant="h5">{mq.log_loss ?? '-'}</Typography>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <Typography variant="subtitle2" gutterBottom>2. 强度加成</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  模型认为它对整体阵容的帮助有多大，数值越高越好、带 + 号表示加分。它<strong>不是</strong>胜率百分比，只用来横向比较谁更强。
+                </Typography>
               </Grid>
-              <Grid size={{ xs: 6, md: 3 }}>
-                <Typography variant="overline" color="text.secondary">Brier 分数</Typography>
-                <Typography variant="h5">{mq.brier ?? '-'}</Typography>
-              </Grid>
-              <Grid size={{ xs: 6, md: 3 }}>
-                <Typography variant="overline" color="text.secondary">测试样本 / 特征数</Typography>
-                <Typography variant="h5">{mq.n_test} / {mq.n_features}</Typography>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <Typography variant="subtitle2" gutterBottom>3. 参考场次</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  这条结论背后有多少场对局。场次越多，通常说明证据越稳、越可信。
+                </Typography>
               </Grid>
             </Grid>
           </CardContent>
@@ -197,14 +226,22 @@ const Analytics = () => {
 
         {/* Filters */}
         <Paper sx={{ p: { xs: 2, sm: 2.5 }, mb: 4, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', mb: 1, gap: 1 }}>
-            <Typography component="h2" variant="h6">筛选名册</Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 0.5, gap: 1 }}>
+            <Typography component="h2" variant="h6">只看我关心的武将和战法</Typography>
             {(hasHeroFilter || hasSkillFilter) && (
-              <IconButton size="small" onClick={() => { setSelectedHeroes([]); setSelectedSkills([]); }} title="清除所有筛选">
+              <IconButton
+                size="small"
+                onClick={() => { setSelectedHeroes([]); setSelectedSkills([]); }}
+                title="清除所有筛选"
+                aria-label="清除所有筛选"
+              >
                 <ClearIcon fontSize="small" />
               </IconButton>
             )}
           </Box>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+            输入你手上或想了解的武将、战法，下面所有的排名和搭配都会只显示相关内容。
+          </Typography>
           <Grid container spacing={2} sx={{ mb: 1 }}>
             <Grid size={{ xs: 12, md: 6 }}>
               <AutocompleteInput
@@ -239,14 +276,21 @@ const Analytics = () => {
           </Grid>
         </Paper>
 
-        {/* Rankings */}
+        {/* Section 1: who is worth picking */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+          <TrendingUpIcon sx={{ color: 'warning.main' }} />
+          <Typography component="h2" variant="h5">先看谁更值得选</Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          单个武将、战法的历史表现与强度加成排名。想快速挑人挑战法，从这里开始。
+        </Typography>
         <Grid container spacing={3} sx={{ mb: 4 }}>
           <Grid size={{ xs: 12, md: 6 }}>
             <Card>
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography component="h2" variant="h6">全部武将（按平滑胜率排序）</Typography>
+                  <Typography component="h3" variant="h6">全部武将（按胜率参考排序）</Typography>
                 </Box>
                 <ResponsiveDisclosure label="全部武将排名">
                 <ScrollableAnalyticsTable label="全部武将排名">
@@ -255,9 +299,9 @@ const Analytics = () => {
                       <TableRow>
                         <TableCell>排名</TableCell>
                         <TableCell>武将</TableCell>
-                        <TableCell align="right">平滑胜率</TableCell>
-                        <TableCell align="right">模型权重</TableCell>
-                        <TableCell align="right">场次</TableCell>
+                        <TableCell align="right">胜率参考</TableCell>
+                        <TableCell align="right">强度加成</TableCell>
+                        <TableCell align="right">参考场次</TableCell>
                       </TableRow>
                     </TableHead>
                     <TableBody>
@@ -266,7 +310,7 @@ const Analytics = () => {
                           <TableCell>{index + 1}</TableCell>
                           <TableCell><Chip label={h.name} color="primary" size="small" /></TableCell>
                           <TableCell align="right">{pct(h.smoothedWinRate)}</TableCell>
-                          <TableCell align="right">{h.strength.toFixed(3)}</TableCell>
+                          <TableCell align="right">{fmtStrength(h.strength)}</TableCell>
                           <TableCell align="right">{h.total}</TableCell>
                         </TableRow>
                       ))}
@@ -283,7 +327,7 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography component="h2" variant="h6">全部战法（按平滑胜率排序）</Typography>
+                  <Typography component="h3" variant="h6">全部战法（按胜率参考排序）</Typography>
                 </Box>
                 <ResponsiveDisclosure label="全部战法排名">
                 <ScrollableAnalyticsTable label="全部战法排名">
@@ -292,9 +336,9 @@ const Analytics = () => {
                       <TableRow>
                         <TableCell>排名</TableCell>
                         <TableCell>战法</TableCell>
-                        <TableCell align="right">平滑胜率</TableCell>
-                        <TableCell align="right">模型权重</TableCell>
-                        <TableCell align="right">场次</TableCell>
+                        <TableCell align="right">胜率参考</TableCell>
+                        <TableCell align="right">强度加成</TableCell>
+                        <TableCell align="right">参考场次</TableCell>
                       </TableRow>
                     </TableHead>
                     <TableBody>
@@ -303,7 +347,7 @@ const Analytics = () => {
                           <TableCell>{index + 1}</TableCell>
                           <TableCell><Chip label={s.name} color="secondary" size="small" /></TableCell>
                           <TableCell align="right">{pct(s.smoothedWinRate)}</TableCell>
-                          <TableCell align="right">{s.strength.toFixed(3)}</TableCell>
+                          <TableCell align="right">{fmtStrength(s.strength)}</TableCell>
                           <TableCell align="right">{s.total}</TableCell>
                         </TableRow>
                       ))}
@@ -316,12 +360,93 @@ const Analytics = () => {
           </Grid>
         </Grid>
 
-        {/* Usage */}
+        {/* Section 2: which combinations work well */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+          <GroupsIcon sx={{ color: 'info.main' }} />
+          <Typography component="h2" variant="h5">再看哪些搭配效果好</Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          放在一起会互相加成的组合。强度加成越高，同队时对整体阵容的帮助越大。
+        </Typography>
+        <Card sx={{ mb: 4 }}>
+          <CardContent>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+              <LinkIcon sx={{ mr: 1, color: 'info.main' }} />
+              <Typography component="h3" variant="h6">最搭的武将组合</Typography>
+            </Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              这些武将同队时，模型给出的额外强度加成最高。
+            </Typography>
+            <ResponsiveDisclosure label="最强武将配对">
+            <ScrollableAnalyticsTable label="最强武将配对">
+              <Table size="small" stickyHeader>
+                <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将配对</TableCell><TableCell align="right">强度加成</TableCell><TableCell align="right">参考场次</TableCell></TableRow></TableHead>
+                <TableBody>
+                  {filteredHeroPairs.map((p, index) => (
+                    <TableRow key={p.label}>
+                      <TableCell>{index + 1}</TableCell>
+                      <TableCell>
+                        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                          {p.label.split(' + ').map((n, i) => <Chip key={i} label={n} color="primary" size="small" />)}
+                        </Box>
+                      </TableCell>
+                      <TableCell align="right" sx={{ color: 'success.main', fontWeight: 'bold' }}>{fmtStrength(p.weight)}</TableCell>
+                      <TableCell align="right">{p.support}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </ScrollableAnalyticsTable>
+            </ResponsiveDisclosure>
+          </CardContent>
+        </Card>
+
+        <Card sx={{ mb: 4 }}>
+          <CardContent>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+              <LinkIcon sx={{ mr: 1, color: 'secondary.main' }} />
+              <Typography component="h3" variant="h6">最搭的武将与战法</Typography>
+            </Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              某个武将带上某个战法时，模型给出的额外强度加成最高。
+            </Typography>
+            <ResponsiveDisclosure label="最强武将战法组合">
+            <ScrollableAnalyticsTable label="最强武将战法组合">
+              <Table size="small" stickyHeader>
+                <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将</TableCell><TableCell>战法</TableCell><TableCell align="right">强度加成</TableCell><TableCell align="right">参考场次</TableCell></TableRow></TableHead>
+                <TableBody>
+                  {filteredHeroSkills.map((p, index) => {
+                    const [hero, skill] = p.label.split(' · ');
+                    return (
+                      <TableRow key={p.label}>
+                        <TableCell>{index + 1}</TableCell>
+                        <TableCell><Chip label={hero} color="primary" size="small" /></TableCell>
+                        <TableCell><Chip label={skill} color="secondary" size="small" variant="outlined" /></TableCell>
+                        <TableCell align="right" sx={{ color: 'success.main', fontWeight: 'bold' }}>{fmtStrength(p.weight)}</TableCell>
+                        <TableCell align="right">{p.support}</TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </ScrollableAnalyticsTable>
+            </ResponsiveDisclosure>
+          </CardContent>
+        </Card>
+
+        {/* Section 3: what everyone uses */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+          <BarChartIcon sx={{ color: 'text.secondary' }} />
+          <Typography component="h2" variant="h5">看看大家常用什么</Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          出场次数最多的武将和战法。常用不一定最强，但能反映当前流行的选择。
+        </Typography>
         <Grid container spacing={3} sx={{ mb: 4 }}>
           <Grid size={{ xs: 12, md: 6 }}>
             <Card>
               <CardContent>
-                <Typography component="h2" variant="h6" gutterBottom>武将使用排行</Typography>
+                <Typography component="h3" variant="h6" gutterBottom>武将使用排行</Typography>
                 <ResponsiveDisclosure label="武将使用排行">
                 <ScrollableAnalyticsTable label="武将使用排行">
                   <Table size="small" stickyHeader>
@@ -344,7 +469,7 @@ const Analytics = () => {
           <Grid size={{ xs: 12, md: 6 }}>
             <Card>
               <CardContent>
-                <Typography component="h2" variant="h6" gutterBottom>战法使用排行</Typography>
+                <Typography component="h3" variant="h6" gutterBottom>战法使用排行</Typography>
                 <ResponsiveDisclosure label="战法使用排行">
                 <ScrollableAnalyticsTable label="战法使用排行">
                   <Table size="small" stickyHeader>
@@ -366,72 +491,66 @@ const Analytics = () => {
           </Grid>
         </Grid>
 
-        {/* Model synergies */}
-        <Card sx={{ mb: 4 }}>
-          <CardContent>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-              <LinkIcon sx={{ mr: 1, color: 'info.main' }} />
-              <Typography component="h2" variant="h6">最强武将配对（模型权重）</Typography>
+        {/* Section 4 (optional, collapsed): data & algorithm details */}
+        <Accordion defaultExpanded={false} sx={{ mb: 4 }}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="data-algo-details-content"
+            id="data-algo-details-header"
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <InsightsIcon sx={{ color: 'info.main' }} />
+              <Box>
+                <Typography component="h2" variant="h6">数据与算法说明</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  选看内容：了解这些推荐有多可靠，不影响日常挑人挑战法。
+                </Typography>
+              </Box>
             </Box>
+          </AccordionSummary>
+          <AccordionDetails id="data-algo-details-content">
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              模型学到的武将配对相对强度贡献。权重越高，同队时对整体阵容强度的提升越大。
+              推荐来自一个成对（对手感知）逻辑回归模型，并在按时间留出的一批对局上做过检验。
+              这里的“强度加成”是<strong>相对阵容强度</strong>，用来横向比较不同选择，
+              <strong>不是</strong>对某个特定对手的胜率。
             </Typography>
-            <ResponsiveDisclosure label="最强武将配对">
-            <ScrollableAnalyticsTable label="最强武将配对">
-              <Table size="small" stickyHeader>
-                <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将配对</TableCell><TableCell align="right">模型权重</TableCell><TableCell align="right">证据(场)</TableCell></TableRow></TableHead>
-                <TableBody>
-                  {filteredHeroPairs.map((p, index) => (
-                    <TableRow key={p.label}>
-                      <TableCell>{index + 1}</TableCell>
-                      <TableCell>
-                        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-                          {p.label.split(' + ').map((n, i) => <Chip key={i} label={n} color="primary" size="small" />)}
-                        </Box>
-                      </TableCell>
-                      <TableCell align="right" sx={{ color: 'success.main', fontWeight: 'bold' }}>{p.weight.toFixed(3)}</TableCell>
-                      <TableCell align="right">{p.support}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </ScrollableAnalyticsTable>
-            </ResponsiveDisclosure>
-          </CardContent>
-        </Card>
 
-        <Card>
-          <CardContent>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-              <LinkIcon sx={{ mr: 1, color: 'secondary.main' }} />
-              <Typography component="h2" variant="h6">最强武将-战法组合（模型权重）</Typography>
+            <Box sx={{ mb: 2 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <Typography variant="subtitle2">预测准确率</Typography>
+                <HelpTip
+                  label="预测准确率说明"
+                  title="在模型没见过的历史对局上，它猜对胜负方的比例。"
+                />
+              </Box>
+              <Typography variant="h5">{pct(mq.accuracy)}</Typography>
+              <Typography variant="body2" color="text.secondary">
+                作为对照，如果每次都猜更常赢的一方，正确率约为 {pct(mq.baseline_accuracy)}。
+                高于这个基线，说明模型确实学到了有用的规律。
+              </Typography>
             </Box>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              模型学到的武将携带某战法时的相对强度贡献。
-            </Typography>
-            <ResponsiveDisclosure label="最强武将战法组合">
-            <ScrollableAnalyticsTable label="最强武将战法组合">
-              <Table size="small" stickyHeader>
-                <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将</TableCell><TableCell>战法</TableCell><TableCell align="right">模型权重</TableCell><TableCell align="right">证据(场)</TableCell></TableRow></TableHead>
-                <TableBody>
-                  {filteredHeroSkills.map((p, index) => {
-                    const [hero, skill] = p.label.split(' · ');
-                    return (
-                      <TableRow key={p.label}>
-                        <TableCell>{index + 1}</TableCell>
-                        <TableCell><Chip label={hero} color="primary" size="small" /></TableCell>
-                        <TableCell><Chip label={skill} color="secondary" size="small" variant="outlined" /></TableCell>
-                        <TableCell align="right" sx={{ color: 'success.main', fontWeight: 'bold' }}>{p.weight.toFixed(3)}</TableCell>
-                        <TableCell align="right">{p.support}</TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </ScrollableAnalyticsTable>
-            </ResponsiveDisclosure>
-          </CardContent>
-        </Card>
+
+            <Typography variant="overline" color="text.secondary">技术指标</Typography>
+            <Grid container spacing={2} sx={{ mt: 0 }}>
+              <Grid size={{ xs: 6, md: 3 }}>
+                <Typography variant="overline" color="text.secondary">对数损失 (log loss)</Typography>
+                <Typography variant="h6">{mq.log_loss ?? '-'}</Typography>
+              </Grid>
+              <Grid size={{ xs: 6, md: 3 }}>
+                <Typography variant="overline" color="text.secondary">Brier 分数</Typography>
+                <Typography variant="h6">{mq.brier ?? '-'}</Typography>
+              </Grid>
+              <Grid size={{ xs: 6, md: 3 }}>
+                <Typography variant="overline" color="text.secondary">测试样本数</Typography>
+                <Typography variant="h6">{mq.n_test}</Typography>
+              </Grid>
+              <Grid size={{ xs: 6, md: 3 }}>
+                <Typography variant="overline" color="text.secondary">特征数</Typography>
+                <Typography variant="h6">{mq.n_features}</Typography>
+              </Grid>
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
       </Box>
     </Container>
   );

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -716,6 +716,37 @@ describe('integration with the real generated artifact', () => {
     expect(a.summary.total_battles).toBe(recommendationData.battle_counts.total_battles);
   });
 
+  test('getAnalytics ranks heroes and skills by 强度加成 (strength) descending', () => {
+    const a = getAnalytics(recommendationData, database);
+
+    const isNonIncreasing = (xs: number[]) =>
+      xs.every((v, i) => i === 0 || xs[i - 1] >= v);
+    const heroStrengths = a.heroes.map((h) => h.strength);
+    const skillStrengths = a.skills.map((s) => s.strength);
+    expect(isNonIncreasing(heroStrengths)).toBe(true);
+    expect(isNonIncreasing(skillStrengths)).toBe(true);
+
+    // Not vacuously sorted: the real artifact must actually exercise the
+    // ordering, i.e. there is a strictly decreasing step in each list, and the
+    // strength order genuinely differs from a smoothed-win-rate ordering.
+    expect(heroStrengths.some((v, i) => i > 0 && heroStrengths[i - 1] > v)).toBe(true);
+    expect(skillStrengths.some((v, i) => i > 0 && skillStrengths[i - 1] > v)).toBe(true);
+
+    const byWinRateDesc = (
+      xs: ReturnType<typeof getAnalytics>['heroes'],
+    ) =>
+      [...xs]
+        .sort(
+          (p, q) =>
+            q.smoothedWinRate - p.smoothedWinRate ||
+            q.total - p.total ||
+            p.name.localeCompare(q.name),
+        )
+        .map((e) => e.name);
+    expect(a.heroes.map((h) => h.name)).not.toEqual(byWinRateDesc(a.heroes));
+    expect(a.skills.map((s) => s.name)).not.toEqual(byWinRateDesc(a.skills));
+  });
+
   test('recommendHeroSet on the real artifact ranks all three offered sets', () => {
     const r = recommendHeroSet(
       [['孙权', '陆抗', '陆逊'], ['祝融', '孟获', '甘夫人'], ['张宁', '左慈', '孙坚']],

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -1441,9 +1441,15 @@ export interface AnalyticsResult {
 }
 
 /**
- * Build the Analytics-page payload from the generated artifact. Rankings use the
- * builder's smoothed win rates; the model column exposes each item's relative
- * roster-strength weight. Backtest metrics surface model quality.
+ * Build the Analytics-page payload from the generated artifact. The `heroes` and
+ * `skills` rankings are returned sorted by descending relative roster-strength
+ * (`强度加成`), with deterministic tie-breakers (descending smoothed win rate,
+ * then descending reference battles, then name) so consumers can render them
+ * directly. The model column still exposes each item's relative roster-strength
+ * weight, and the smoothed-win-rate / reference-battle columns remain available.
+ * Usage and synergy rankings keep their own orderings. Backtest metrics surface
+ * model quality. No values or model semantics are changed — only the order of
+ * the hero/skill arrays.
  */
 export function getAnalytics(data: RecommendationData, database: Database): AnalyticsResult {
   const m = model(data);
@@ -1459,8 +1465,16 @@ export function getAnalytics(data: RecommendationData, database: Database): Anal
     strength: roundTo(weightOf(m, `${family}|${row.name}`), 4),
   });
 
-  const heroes = a.heroes.map((r) => toEntity(r, 'H'));
-  const skills = a.skills.map((r) => toEntity(r, 'S'));
+  // Rank both lists by 强度加成 (relative roster strength) descending, with
+  // deterministic tie-breakers so equal-strength rows are stably ordered.
+  const byStrength = (x: AnalyticsEntity, y: AnalyticsEntity): number =>
+    y.strength - x.strength ||
+    y.smoothedWinRate - x.smoothedWinRate ||
+    y.total - x.total ||
+    x.name.localeCompare(y.name);
+
+  const heroes = a.heroes.map((r) => toEntity(r, 'H')).sort(byStrength);
+  const skills = a.skills.map((r) => toEntity(r, 'S')).sort(byStrength);
 
   const hero_usage: [string, number][] = [...a.heroes]
     .sort((x, y) => y.total - x.total || x.name.localeCompare(y.name))

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -85,4 +85,44 @@ test.describe('Accessibility and responsive layout', () => {
     await expect(tableRegion).toBeVisible();
     await expect(tableRegion).toHaveAttribute('tabindex', '0');
   });
+
+  test('analytics leads with a player-friendly intro and how-to-read guide', async ({ page }) => {
+    await page.goto('/analytics');
+
+    // The single level-one heading is preserved.
+    await expect(page.getByRole('heading', { level: 1, name: '数据洞察' })).toBeVisible({ timeout: 15000 });
+
+    // Plain-language guide explaining the three key numbers in player terms.
+    await expect(page.getByRole('heading', { name: '三步看懂这些数字' })).toBeVisible();
+    await expect(page.getByText('胜率参考')).not.toHaveCount(0);
+    await expect(page.getByText('强度加成')).not.toHaveCount(0);
+    await expect(page.getByText('参考场次')).not.toHaveCount(0);
+
+    // Actionable sections come before the optional diagnostics section.
+    await expect(page.getByRole('heading', { name: '先看谁更值得选' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '再看哪些搭配效果好' })).toBeVisible();
+
+    // The action-oriented filter section replaces the old "筛选名册" wording.
+    await expect(page.getByRole('heading', { name: '只看我关心的武将和战法' })).toBeVisible();
+  });
+
+  test('data-and-algorithm details start collapsed and expand by keyboard', async ({ page }) => {
+    await page.goto('/analytics');
+
+    const summary = page.getByRole('button', { name: /数据与算法说明/ });
+    await expect(summary).toBeVisible({ timeout: 15000 });
+
+    // Collapsed by default: the accordion summary reports aria-expanded=false and
+    // the technical details inside are not yet visible.
+    await expect(summary).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.getByText('技术指标')).not.toBeVisible();
+
+    // Keyboard-accessible: focus and activate the summary to expand it.
+    await summary.focus();
+    await page.keyboard.press('Enter');
+    await expect(summary).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByText('技术指标')).toBeVisible();
+    // Original technical metrics remain available under the technical subheading.
+    await expect(page.getByText(/对数损失/)).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Intent

Make the web analytics page easy for ordinary 三国谋定天下 players without data knowledge. Lead with actionable questions, explain the three player-facing measures in plain language, keep technical model diagnostics optional, and preserve truthful semantics, filters, mobile behavior, and accessibility. Rank both hero and skill tables by 强度加成 as the user explicitly requested, while retaining 胜率参考 and 参考场次 as supporting context. Validate the change, push the codex/player-friendly-analytics branch, create a pull request, and wait for CI; do not use Lavish.

## What Changed

- Reworked the web Analytics page to lead with plain-language actionable questions and a "how to read" guide, explaining the three player-facing measures while collapsing the technical model diagnostics (对数损失 / pairwise logistic-regression narrative) into an optional expandable section.
- Ranked both the hero and skill tables by 强度加成 (strength contribution) in descending order in `recommendationEngine`, while retaining 胜率参考 and 参考场次 as supporting context.
- Updated the web README Analytics section and added accessibility layout specs plus recommendationEngine tests covering the new strength-descending ordering and collapsed/keyboard-expandable diagnostics.

## Risk Assessment

✅ Low: The change is a well-bounded, semantics-preserving UI copy/layout refactor plus a deterministic strength-based sort in getAnalytics, both covered by new unit and Playwright tests, with only one minor cosmetic formatting quirk found.

## Testing

Ran the smallest relevant Vitest unit test plus the full Playwright accessibilityLayout suite (all green) under the project's required Node 22 after fixing two setup issues (installed web deps, restored the missing @rolldown/binding-darwin-arm64 optional binary, and switched from Node 20 to the required Node 22), then captured reviewer-visible screenshots of the actual rendered Analytics page confirming the plain-language guide, 强度加成-ranked hero/skill tables with retained 胜率参考/参考场次, truthful semantics, and the collapsed/keyboard-expandable technical diagnostics; transient test artifacts were removed and the worktree left clean.

- Evidence: Analytics page — player-friendly redesign, full desktop view (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXQVFN2VHWDVC3Q7VQ6P89PP/analytics_desktop_full.png</code>)
- Evidence: Hero and skill tables ranked by 强度加成 (按强度加成排序) with 胜率参考 and 参考场次 retained (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXQVFN2VHWDVC3Q7VQ6P89PP/analytics_strength_tables.png</code>)
- Evidence: Diagnostics accordion collapsed by default (数据与算法说明, aria-expanded=false) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXQVFN2VHWDVC3Q7VQ6P89PP/analytics_diagnostics_collapsed.png</code>)
- Evidence: Diagnostics accordion expanded via keyboard, technical model metrics retained (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXQVFN2VHWDVC3Q7VQ6P89PP/analytics_diagnostics_expanded.png</code>)
<details>
<summary>Evidence: Playwright accessibility suite result</summary>

```text
6 passed (accessibilityLayout.spec.js) — includes 'analytics leads with a player-friendly intro and how-to-read guide' and 'data-and-algorithm details start collapsed and expand by keyboard'
```
</details>
<details>
<summary>Evidence: Vitest recommendationEngine result</summary>

```text
41 passed — includes 'getAnalytics ranks heroes and skills by 强度加成 (strength) descending'
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `web/src/pages/Analytics.tsx:80` - fmtStrength renders a misleading &#39;-0.000&#39; for tiny negative strength values (e.g. -0.0001 -&gt; &#39;-0.000&#39;) and &#39;+0.000&#39; for tiny positives, because it formats to 3dp and only branches on the raw sign. Consider normalizing near-zero values (e.g. round to dp first, then decide the sign) so a coefficient that displays as zero is shown as a plain &#39;0.000&#39;. Purely cosmetic; underlying values are unaffected.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx vitest run recommendationEngine` (41 passed, incl. new `getAnalytics ranks heroes and skills by 强度加成 descending`)</code>
- <code>`npx playwright test accessibilityLayout.spec.js` (6 passed, incl. new player-friendly intro/how-to-read guide and collapsed→keyboard-expand diagnostics specs)</code>
- `Manual visual verification via temporary Playwright screenshot spec capturing desktop full page, strength-ranked hero/skill tables, and collapsed vs expanded diagnostics accordion`
- `Confirmed rendered tables ordered by descending 强度加成 (heroes +0.942,+0.775,+0.735...; skills +0.916,+0.869,+0.807...) with 胜率参考 and 参考场次 retained`
- `Confirmed expanded diagnostics still surfaces the technical model explanation (对数损失 / pairwise logistic-regression narrative)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
