### PR TITLE
feat(analytics): tag non-catalog skills as 影 in 全部战法

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -120,6 +120,10 @@ web/
   胜率参考 (smoothed win rate), 强度加成 (relative roster strength / model weight), and
   参考场次 (reference battles). Hero/skill tables are ranked by 强度加成 (descending, with
   deterministic tie-breakers); usage and top synergies keep their own orderings.
+- In the 全部战法 skill ranking, a skill that is some hero's innate (自带) skill is
+  labelled `影 · <name>` — its stats reflect only its use as a transferred/split (影)
+  skill on other heroes, since the innate carrier's own usage is excluded by the
+  data builder.
 - Technical model diagnostics (accuracy vs baseline, log loss, Brier, backtest sample/feature
   counts) live in an optional, collapsed accordion so they don't get in a casual player's way.
 

--- a/web/README.md
+++ b/web/README.md
@@ -120,10 +120,13 @@ web/
   胜率参考 (smoothed win rate), 强度加成 (relative roster strength / model weight), and
   参考场次 (reference battles). Hero/skill tables are ranked by 强度加成 (descending, with
   deterministic tie-breakers); usage and top synergies keep their own orderings.
-- In the 全部战法 skill ranking, a skill that is some hero's innate (自带) skill is
-  labelled `影 · <name>` — its stats reflect only its use as a transferred/split (影)
-  skill on other heroes, since the innate carrier's own usage is excluded by the
-  data builder.
+- In the 全部战法 skill ranking, a skill is labelled `影 · <name>` when it can only
+  appear as a transferred/split (影) skill carried by another hero — either because
+  it is an orange hero's innate (自带) skill (its carrier's own usage is excluded by
+  the data builder) or because it is absent from the catalog entirely (only orange
+  heroes and their orange skills are catalogued, so an uncatalogued skill belongs to
+  a non-orange hero and can only surface here as a transfer). Its stats then reflect
+  only that transferred usage.
 - Technical model diagnostics (accuracy vs baseline, log loss, Brier, backtest sample/feature
   counts) live in an optional, collapsed accordion so they don't get in a casual player's way.
 

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -105,16 +105,31 @@ const Analytics = () => {
     Object.entries(database.skills || {}).map(([name, skill]) => [name, { tier: skill.tier, note: skill.note }])
   ), []);
 
-  // Names of skills that are some hero's innate (自带) skill. When such a skill
-  // shows up in 全部战法 it is being used as a *transferred/split* (影) skill by
-  // a different hero — the innate carrier's own usage is excluded from the
-  // stats. We tag these rows with an "影" chip so it's clear the count reflects
+  // A skill shown in 全部战法 is a 影 (transferred/split) skill — i.e. it is
+  // being carried by a hero for whom it is *not* an equippable draft skill —
+  // in either of two cases:
+  //
+  //   1. It is an orange hero's innate (自带) skill: database.heroes[*].skill
+  //      records these. Its own carrier's usage is already excluded by the data
+  //      builder, so any appearance here is a transfer onto another hero.
+  //   2. It is not present in database.skills at all. The database only catalogs
+  //      orange heroes and their orange skills; a skill missing from the catalog
+  //      therefore belongs to a non-orange (uncatalogued) hero, which means it
+  //      can only be appearing here as a transferred 影 skill (e.g. 曲辞谄媚,
+  //      猿臂善射).
+  //
+  // We tag these rows with a "影 ·" prefix so it is clear the count reflects
   // only the draftable (non-innate) usage.
-  const innateSkillSet = useMemo<Set<string>>(() => new Set(
+  const innateOrangeSkillSet = useMemo<Set<string>>(() => new Set(
     Object.values(database.heroes || {})
       .map((hero) => hero.skill)
       .filter((s): s is string => Boolean(s))
   ), []);
+  const isShadowSkill = useMemo(
+    () => (name: string): boolean =>
+      innateOrangeSkillSet.has(name) || !(name in (database.skills || {})),
+    [innateOrangeSkillSet]
+  );
 
   useEffect(() => {
     (async () => {
@@ -358,7 +373,7 @@ const Analytics = () => {
                           <TableCell>{index + 1}</TableCell>
                           <TableCell>
                             <Chip
-                              label={innateSkillSet.has(s.name) ? `影 · ${s.name}` : s.name}
+                              label={isShadowSkill(s.name) ? `影 · ${s.name}` : s.name}
                               color="secondary"
                               size="small"
                             />

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -105,6 +105,17 @@ const Analytics = () => {
     Object.entries(database.skills || {}).map(([name, skill]) => [name, { tier: skill.tier, note: skill.note }])
   ), []);
 
+  // Names of skills that are some hero's innate (自带) skill. When such a skill
+  // shows up in 全部战法 it is being used as a *transferred/split* (影) skill by
+  // a different hero — the innate carrier's own usage is excluded from the
+  // stats. We tag these rows with an "影" chip so it's clear the count reflects
+  // only the draftable (non-innate) usage.
+  const innateSkillSet = useMemo<Set<string>>(() => new Set(
+    Object.values(database.heroes || {})
+      .map((hero) => hero.skill)
+      .filter((s): s is string => Boolean(s))
+  ), []);
+
   useEffect(() => {
     (async () => {
       try {
@@ -345,7 +356,13 @@ const Analytics = () => {
                       {filteredSkills.map((s, index) => (
                         <TableRow key={s.name}>
                           <TableCell>{index + 1}</TableCell>
-                          <TableCell><Chip label={s.name} color="secondary" size="small" /></TableCell>
+                          <TableCell>
+                            <Chip
+                              label={innateSkillSet.has(s.name) ? `影 · ${s.name}` : s.name}
+                              color="secondary"
+                              size="small"
+                            />
+                          </TableCell>
                           <TableCell align="right">{pct(s.smoothedWinRate)}</TableCell>
                           <TableCell align="right">{fmtStrength(s.strength)}</TableCell>
                           <TableCell align="right">{s.total}</TableCell>

--- a/web/tests/analyticsShadowSkillLabel.spec.js
+++ b/web/tests/analyticsShadowSkillLabel.spec.js
@@ -1,0 +1,56 @@
+const { test, expect } = require('@playwright/test');
+
+// Evidence-producing e2e for the 全部战法 '影' (transferred/split skill) labelling.
+//
+// A skill row is tagged `影 · <name>` when the skill is a 影战法 — either an
+// orange hero's innate (自带) skill, OR a skill absent from database.skills
+// (uncatalogued → belongs to a non-orange hero, so it can only appear here as a
+// transfer). This test filters the ranking to a representative mix and both
+// asserts the rendered chip labels and captures a screenshot for review.
+const EVIDENCE_DIR =
+  '/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXS48D0MPF4P8BGG6F2JG4PP';
+
+// Two NON-orange (not-in-catalog) skills — the new behaviour under test.
+const NOT_IN_CATALOG = ['曲辞谄媚', '猿臂善射'];
+// An orange hero's innate skill — already tagged by prior work.
+const INNATE_ORANGE = '十二奇策';
+// A normal draftable skill (in catalog, not innate) — must stay unlabelled.
+const CONTROL_PLAIN = '折冲御侮';
+
+async function addSkillFilter(page, name) {
+  const input = page.getByPlaceholder('输入战法名或拼音...');
+  await input.click();
+  await input.fill(name);
+  // MUI Autocomplete: pick the matching option from the popup listbox.
+  await page.getByRole('option').filter({ hasText: name }).first().click();
+}
+
+test('全部战法 tags 影 (shadow) skills and leaves normal skills unlabelled', async ({ page }) => {
+  await page.goto('/analytics');
+
+  // The skill-ranking card. On desktop the disclosure is expanded by default.
+  const heading = page.getByRole('heading', { name: /全部战法/ });
+  await expect(heading).toBeVisible();
+
+  // Narrow the ranking to a clean, representative set so the contrast is legible.
+  for (const name of [CONTROL_PLAIN, INNATE_ORANGE, ...NOT_IN_CATALOG]) {
+    await addSkillFilter(page, name);
+  }
+
+  const card = page.locator('.MuiCard-root', { has: heading });
+  const table = card.getByRole('table');
+
+  // The two newly-covered non-catalog skills render with the 影 prefix.
+  for (const name of NOT_IN_CATALOG) {
+    await expect(table.getByText(`影 · ${name}`, { exact: true })).toBeVisible();
+  }
+  // The innate-orange skill (prior behaviour) is still tagged.
+  await expect(table.getByText(`影 · ${INNATE_ORANGE}`, { exact: true })).toBeVisible();
+
+  // A normal draftable skill keeps its bare name — no false positive.
+  await expect(table.getByText(CONTROL_PLAIN, { exact: true })).toBeVisible();
+  await expect(table.getByText(`影 · ${CONTROL_PLAIN}`, { exact: true })).toHaveCount(0);
+
+  await card.scrollIntoViewIfNeeded();
+  await card.screenshot({ path: `${EVIDENCE_DIR}/analytics-shadow-skill-labels.png` });
+});


### PR DESCRIPTION
## Intent

Extend the /analytics 全部战法 '影' (transferred/split skill) labelling. Prior work already tagged orange heroes' innate (自带) skills (e.g. 十二奇策) as '影 · <name>'. The user pointed out that some NON-orange skills (e.g. 曲辞谄媚, 猿臂善射) are also 影战法 but were being missed, because database.json only catalogs orange heroes and their orange skills. The user's chosen heuristic: if a skill shown in 全部战法 is not present in database.skills at all, it must belong to a non-orange (uncatalogued) hero and is therefore only appearing as a transferred 影 skill. Implementation: replaced innateSkillSet with an isShadowSkill(name) helper returning true when the name is an orange hero's innate skill (database.heroes[*].skill) OR the name is not a key in database.skills; the 全部战法 chip label uses this to render '影 · <name>'. Verified against current data: newly tags exactly 曲辞谄媚 and 猿臂善射 (the 2 not-in-catalog analytics skills), no false positives, alongside the 20 orange-innate ones already tagged. Display-only change; no data-pipeline/logic changes. All four web gates pass locally (typecheck, vitest 70, playwright e2e 28, vite build). NOTE: this branch builds on an earlier no-mistakes(document) commit that added 4 lines to web/README.md documenting the 影 marker — that commit is intentionally preserved.

## What Changed

- Replaced the `innateSkillSet` lookup in `web/src/pages/Analytics.tsx` with an `isShadowSkill(name)` helper that returns true when a skill is an orange hero's innate skill (`database.heroes[*].skill`) **or** is absent from `database.skills` entirely, and used it to render the `影 · <name>` chip label in 全部战法.
- Extends 影 (transferred/split skill) labelling to non-orange skills that only appear as transferred 影 战法 (e.g. 曲辞谄媚, 猿臂善射), which were previously missed because `database.json` only catalogs orange heroes and their orange skills.
- Added a Playwright screenshot spec (`web/tests/analyticsShadowSkillLabel.spec.js`) and documented the non-catalog 影 case in `web/README.md`. Display-only change; no data-pipeline or scoring logic was touched.

## Risk Assessment

✅ Low: A ~37-line display-only change adding a 影 chip label via a pure, correctly-typed helper that matches the authoritative intent exactly, with no logic/data-pipeline changes and no dangling references.

## Testing

Baseline setup: reinstalled web deps under node v22.17.1 because the active v20.15.1 was below the required engine and left rolldown's native binding missing. Ran the full web gate — typecheck (clean), vitest (70 pass), Playwright e2e (29 pass, including a new spec I added since none covered the analytics page), and the vite production build (success). Beyond green tests, I independently confirmed the author's data claim in Python (exactly 曲辞谄媚 and 猿臂善射 newly tagged alongside the 20 orange-innate skills, no false positives) and drove the real /analytics UI to capture a screenshot of the 全部战法 table showing 影·曲辞谄媚, 影·猿臂善射, 影·十二奇策 and an unlabelled control 折冲御侮 — directly demonstrating the intended end-user behavior. No issues found.

- Evidence: 全部战法 shadow-skill (影) labels — filtered ranking screenshot (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXS48D0MPF4P8BGG6F2JG4PP/analytics-shadow-skill-labels.png</code>)
<details>
<summary>Evidence: Data verification (shadow-skill classification)</summary>

```text
total analytics skills: 138
shadow-tagged count: 22
not-in-catalog tagged: ['曲辞谄媚', '猿臂善射']
innate-orange tagged count: 20
in both innate and not-in-cat: []
```
</details>
- Outcome: ⚠️ 1 info across 1 run (8m41s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `web/tests/analyticsShadowSkillLabel.spec.js` - new test file written by agent: web/tests/analyticsShadowSkillLabel.spec.js
- `Verified data claim with Python against database.json + recommendation_data.json`
- `npm run typecheck`
- `npm test (vitest, 70 pass)`
- `npx playwright test tests/analyticsShadowSkillLabel.spec.js (new screenshot spec)`
- `npx playwright test (full suite, 29 pass)`
- `npm run build (vite)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
