### PR TITLE
feat(web): improve recommendation UI clarity and analytics presentation

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -12,7 +12,7 @@ data files are generated.
 - **Setup Phase**: Select starting heroes and skills with pinyin search support
 - **Game Flow**: Round-by-round draft with recommendations for optimal team building (see [GAME_RULE.md](../GAME_RULE.md))
 - **Manual Editing**: Edit team composition manually at any time
-- **Analytics Dashboard**: Player-friendly, question-led analytics — hero/skill rankings by 强度加成 (relative roster strength, with 胜率参考/参考场次 as supporting context), usage, top synergies, and optional (collapsed) model diagnostics
+- **Analytics Dashboard**: Player-friendly, question-led analytics — hero/skill rankings by 胜率参考 (smoothed win rate, with 参考场次 as supporting context), 组合分 synergy tables, usage, and optional (collapsed) model diagnostics
 - **Auto-save**: Progress automatically saved to cookies
 - **Responsive Design**: Works on desktop, tablet, and mobile devices
 
@@ -117,9 +117,10 @@ web/
 ### Analytics
 - **Analytics**: Player-friendly dashboard driven by the generated paired-model artifact
 - Question-led layout with a plain-language guide to the three player-facing measures:
-  胜率参考 (smoothed win rate), 强度加成 (relative roster strength / model weight), and
-  参考场次 (reference battles). Hero/skill tables are ranked by 强度加成 (descending, with
-  deterministic tie-breakers); usage and top synergies keep their own orderings.
+  胜率参考 (smoothed win rate), 组合分 (combo score — the model's extra pairing/hero-skill
+  bonus, shown only on the synergy tables), and 参考场次 (reference battles). Individual
+  hero/skill tables are ranked by 胜率参考 (descending, with deterministic tie-breakers);
+  usage and top synergies keep their own orderings.
 - In the 全部战法 skill ranking, a skill is labelled `影 · <name>` when it can only
   appear as a transferred/split (影) skill carried by another hero — either because
   it is an orange hero's innate (自带) skill (its carrier's own usage is excluded by

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -78,7 +78,7 @@ const AnalysisGrid = ({
     }
 
     const gain = setAnalysis?.final_score;
-    const comboSynergies = (setAnalysis?.synergies ?? []).filter((c) => c.family !== 'H' && c.family !== 'S');
+    const comboSynergies = setAnalysis?.combo_synergies ?? [];
 
     return (
       <Grid size={{ xs: 12, md: 4 }} key={setName} data-testid="analysis-set-card">

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -78,6 +78,7 @@ const AnalysisGrid = ({
     }
 
     const gain = setAnalysis?.final_score;
+    const comboSynergies = (setAnalysis?.synergies ?? []).filter((c) => c.family !== 'H' && c.family !== 'S');
 
     return (
       <Grid size={{ xs: 12, md: 4 }} key={setName} data-testid="analysis-set-card">
@@ -144,7 +145,7 @@ const AnalysisGrid = ({
             </Box>
 
             <ResponsiveDisclosure label={`第${index + 1}组详细分析`}>
-              {renderContributions('主要加分项:', setAnalysis?.synergies ?? []) ?? (
+              {renderContributions('组合加分项:', comboSynergies) ?? (
                 <Typography variant="body2" color="text.secondary">
                   暂无明显加分项。
                 </Typography>

--- a/web/src/components/game/CurrentTeam.tsx
+++ b/web/src/components/game/CurrentTeam.tsx
@@ -154,23 +154,54 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
 
   return (
     <Paper sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2, flexWrap: 'wrap', gap: 1 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-          <Box sx={{ mr: 1 }}>
+      <Box sx={{ mb: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 2 }}>
+          <Box sx={{ minWidth: 0 }}>
             <Typography variant="overline" color="error.main" sx={{ display: 'block', lineHeight: 1.2 }}>CURRENT ROSTER</Typography>
-            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, flexWrap: 'wrap' }}>
-              <Typography component="h2" variant="h5">当前阵容</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, flexWrap: 'nowrap', minWidth: 0 }}>
+              <Typography
+                component="h2"
+                variant="h5"
+                sx={{ fontSize: { xs: '1.25rem', sm: '1.5rem' }, lineHeight: 1.25, whiteSpace: 'nowrap' }}
+              >
+                当前阵容
+              </Typography>
               <Typography
                 component="span"
                 variant="subtitle1"
                 color="text.secondary"
                 data-testid="current-roster-score"
-                sx={{ fontVariantNumeric: 'tabular-nums' }}
+                sx={{ fontVariantNumeric: 'tabular-nums', fontSize: { xs: '0.9rem', sm: '1rem' }, whiteSpace: 'nowrap' }}
               >
                 评分：{rosterScore.toFixed(1)}
               </Typography>
             </Box>
           </Box>
+
+          {editable && availableHeroes && availableSkills && onUpdateTeam && (
+            <Box sx={{ display: 'flex', gap: 1, flexShrink: 0 }}>
+              {editMode && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={handleCancelEdit}
+                >
+                  取消
+                </Button>
+              )}
+              <Button
+                size="small"
+                variant={editMode ? "contained" : "outlined"}
+                startIcon={editMode ? <CheckIcon /> : <EditIcon />}
+                onClick={handleEditToggle}
+              >
+                {editMode ? '保存修改' : '编辑队伍'}
+              </Button>
+            </Box>
+          )}
+        </Box>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mt: 1.5 }}>
           {heroes.length <= 10 && !hasSupportHero && (
             <Button
               size="small"
@@ -196,28 +227,16 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
             </Button>
           )}
         </Box>
-        
-        {editable && availableHeroes && availableSkills && onUpdateTeam && (
-          <Box sx={{ display: 'flex', gap: 1 }}>
-            {editMode && (
-              <Button
-                size="small"
-                variant="outlined"
-                onClick={handleCancelEdit}
-              >
-                取消
-              </Button>
-            )}
-            <Button
-              size="small"
-              variant={editMode ? "contained" : "outlined"}
-              startIcon={editMode ? <CheckIcon /> : <EditIcon />}
-              onClick={handleEditToggle}
-            >
-              {editMode ? '保存修改' : '编辑队伍'}
-            </Button>
-          </Box>
-        )}
+
+        <Alert
+          severity="info"
+          variant="outlined"
+          sx={{ mt: 1.25, py: 0.5, alignItems: 'center' }}
+        >
+          <Typography variant="body2" fontWeight={600}>
+            提示：建议先确认核心武将，再围绕核心挑选其余武将与战法。请尽早确认自选武将，AI 才能据此给出更精准的推荐。
+          </Typography>
+        </Alert>
       </Box>
       
       <Collapse in={editMode}>

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -196,8 +196,17 @@ const Analytics = () => {
   const hasHeroFilter = selectedHeroes.length > 0;
   const hasSkillFilter = selectedSkills.length > 0;
 
-  const filteredHeroes = hasHeroFilter ? data.heroes.filter((h) => heroFilterSet.has(h.name)) : data.heroes;
-  const filteredSkills = hasSkillFilter ? data.skills.filter((s) => skillFilterSet.has(s.name)) : data.skills;
+  // Rank the individual hero/skill tables by 胜率参考 (smoothed win rate) descending,
+  // with deterministic tie-breakers (reference battles desc, then name). This is a
+  // display-only ordering; the underlying data.heroes/data.skills stay untouched.
+  const byWinRate = <T extends { smoothedWinRate: number; total: number; name: string }>(a: T, b: T): number =>
+    b.smoothedWinRate - a.smoothedWinRate || b.total - a.total || a.name.localeCompare(b.name, 'zh-Hans-CN');
+  const filteredHeroes = (hasHeroFilter ? data.heroes.filter((h) => heroFilterSet.has(h.name)) : data.heroes)
+    .slice()
+    .sort(byWinRate);
+  const filteredSkills = (hasSkillFilter ? data.skills.filter((s) => skillFilterSet.has(s.name)) : data.skills)
+    .slice()
+    .sort(byWinRate);
   const filteredHeroUsage = hasHeroFilter ? data.hero_usage.filter(([h]) => heroFilterSet.has(h)) : data.hero_usage;
   const filteredSkillUsage = hasSkillFilter ? data.skill_usage.filter(([s]) => skillFilterSet.has(s)) : data.skill_usage;
   const filteredHeroPairs = hasHeroFilter
@@ -235,9 +244,9 @@ const Analytics = () => {
                 </Typography>
               </Grid>
               <Grid size={{ xs: 12, md: 4 }}>
-                <Typography variant="subtitle2" gutterBottom>2. 强度加成</Typography>
+                <Typography variant="subtitle2" gutterBottom>2. 组合分</Typography>
                 <Typography variant="body2" color="text.secondary">
-                  模型认为它对整体阵容的帮助有多大，数值越高越好、带 + 号表示加分。它<strong>不是</strong>胜率百分比，只用来横向比较谁更强。
+                  仅用于下面的搭配榜，表示武将配对、武将战法组合在一起时的额外帮助。它<strong>不是</strong>胜率百分比。
                 </Typography>
               </Grid>
               <Grid size={{ xs: 12, md: 4 }}>
@@ -308,7 +317,7 @@ const Analytics = () => {
           <Typography component="h2" variant="h5">先看谁更值得选</Typography>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          单个武将、战法的历史表现与强度加成排名。想快速挑人挑战法，从这里开始。
+          单个武将、战法按胜率参考排名。想快速挑人挑战法，从这里开始。
         </Typography>
         <Grid container spacing={3} sx={{ mb: 4 }}>
           <Grid size={{ xs: 12, md: 6 }}>
@@ -316,7 +325,7 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography component="h3" variant="h6">全部武将（按强度加成排序）</Typography>
+                  <Typography component="h3" variant="h6">全部武将（按胜率参考排序）</Typography>
                 </Box>
                 <ResponsiveDisclosure label="全部武将排名">
                 <ScrollableAnalyticsTable label="全部武将排名">
@@ -326,7 +335,6 @@ const Analytics = () => {
                         <TableCell>排名</TableCell>
                         <TableCell>武将</TableCell>
                         <TableCell align="right">胜率参考</TableCell>
-                        <TableCell align="right">强度加成</TableCell>
                         <TableCell align="right">参考场次</TableCell>
                       </TableRow>
                     </TableHead>
@@ -336,7 +344,6 @@ const Analytics = () => {
                           <TableCell>{index + 1}</TableCell>
                           <TableCell><Chip label={h.name} color="primary" size="small" /></TableCell>
                           <TableCell align="right">{pct(h.smoothedWinRate)}</TableCell>
-                          <TableCell align="right">{fmtStrength(h.strength)}</TableCell>
                           <TableCell align="right">{h.total}</TableCell>
                         </TableRow>
                       ))}
@@ -353,7 +360,7 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography component="h3" variant="h6">全部战法（按强度加成排序）</Typography>
+                  <Typography component="h3" variant="h6">全部战法（按胜率参考排序）</Typography>
                 </Box>
                 <ResponsiveDisclosure label="全部战法排名">
                 <ScrollableAnalyticsTable label="全部战法排名">
@@ -363,7 +370,6 @@ const Analytics = () => {
                         <TableCell>排名</TableCell>
                         <TableCell>战法</TableCell>
                         <TableCell align="right">胜率参考</TableCell>
-                        <TableCell align="right">强度加成</TableCell>
                         <TableCell align="right">参考场次</TableCell>
                       </TableRow>
                     </TableHead>
@@ -379,7 +385,6 @@ const Analytics = () => {
                             />
                           </TableCell>
                           <TableCell align="right">{pct(s.smoothedWinRate)}</TableCell>
-                          <TableCell align="right">{fmtStrength(s.strength)}</TableCell>
                           <TableCell align="right">{s.total}</TableCell>
                         </TableRow>
                       ))}
@@ -398,7 +403,7 @@ const Analytics = () => {
           <Typography component="h2" variant="h5">再看哪些搭配效果好</Typography>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          放在一起会互相加成的组合。强度加成越高，同队时对整体阵容的帮助越大。
+          放在一起会互相加分的组合。组合分越高，同队时对整体阵容的帮助越大。
         </Typography>
         <Card sx={{ mb: 4 }}>
           <CardContent>
@@ -407,12 +412,12 @@ const Analytics = () => {
               <Typography component="h3" variant="h6">最搭的武将组合</Typography>
             </Box>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              这些武将同队时，模型给出的额外强度加成最高。
+              这些武将同队时，模型给出的额外组合分最高。
             </Typography>
             <ResponsiveDisclosure label="最强武将配对">
             <ScrollableAnalyticsTable label="最强武将配对">
               <Table size="small" stickyHeader>
-                <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将配对</TableCell><TableCell align="right">强度加成</TableCell><TableCell align="right">参考场次</TableCell></TableRow></TableHead>
+                <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将配对</TableCell><TableCell align="right">组合分</TableCell><TableCell align="right">参考场次</TableCell></TableRow></TableHead>
                 <TableBody>
                   {filteredHeroPairs.map((p, index) => (
                     <TableRow key={p.label}>
@@ -440,12 +445,12 @@ const Analytics = () => {
               <Typography component="h3" variant="h6">最搭的武将与战法</Typography>
             </Box>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              某个武将带上某个战法时，模型给出的额外强度加成最高。
+              某个武将带上某个战法时，模型给出的额外组合分最高。
             </Typography>
             <ResponsiveDisclosure label="最强武将战法组合">
             <ScrollableAnalyticsTable label="最强武将战法组合">
               <Table size="small" stickyHeader>
-                <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将</TableCell><TableCell>战法</TableCell><TableCell align="right">强度加成</TableCell><TableCell align="right">参考场次</TableCell></TableRow></TableHead>
+                <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将</TableCell><TableCell>战法</TableCell><TableCell align="right">组合分</TableCell><TableCell align="right">参考场次</TableCell></TableRow></TableHead>
                 <TableBody>
                   {filteredHeroSkills.map((p, index) => {
                     const [hero, skill] = p.label.split(' · ');
@@ -543,8 +548,7 @@ const Analytics = () => {
           <AccordionDetails id="data-algo-details-content">
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
               推荐来自一个成对（对手感知）逻辑回归模型，并在按时间留出的一批对局上做过检验。
-              这里的“强度加成”是<strong>相对阵容强度</strong>，用来横向比较不同选择，
-              <strong>不是</strong>对某个特定对手的胜率。
+              搭配榜里的“组合分”用来横向比较不同组合，<strong>不是</strong>对某个特定对手的胜率。
             </Typography>
 
             <Box sx={{ mb: 2 }}>

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -62,6 +62,12 @@ export interface OptionAnalysis {
   item_scores: { item: string; score: number; support: number }[];
   /** Strongest positive synergies this option unlocks with the current pool. */
   synergies: Contribution[];
+  /**
+   * Strongest positive *combo* synergies only (pair/hero-skill families:
+   * HP/HS/SP), computed from the full contribution list before truncation so
+   * dominant single-item H/S weights can never crowd real combos out.
+   */
+  combo_synergies: Contribution[];
   /** Notable negative contributions (tradeoffs) this option brings. */
   tradeoffs: Contribution[];
   /** Aggregate evidence behind the option's score. */
@@ -138,6 +144,15 @@ const roundTo = (x: number, dp = 2): number => {
 
 /** Scale a raw roster-strength delta to a friendlier 0-ish..N display number. */
 const displayScore = (x: number): number => roundTo(x * 10, 1);
+
+/**
+ * Top positive *combo* contributions (pair/hero-skill families) from the full,
+ * already-weight-sorted contribution list. Single-item hero (`H`) and skill
+ * (`S`) contributions are excluded here so they cannot displace real combos when
+ * they dominate the overall top ranks. Applied before slicing.
+ */
+const topComboSynergies = (contributions: Contribution[]): Contribution[] =>
+  contributions.filter((c) => c.weight > 0 && c.family !== 'H' && c.family !== 'S').slice(0, 5);
 
 /**
  * Route a non-default skill to the current hero that maximises its
@@ -250,6 +265,7 @@ export function recommendHeroSet(
       rank: 0,
       item_scores,
       synergies: contributions.filter((c) => c.weight > 0).slice(0, 5),
+      combo_synergies: topComboSynergies(contributions),
       tradeoffs: contributions.filter((c) => c.weight < 0).slice(0, 3),
       evidence: ev,
     };
@@ -308,6 +324,7 @@ export function recommendSkillSet(
       rank: 0,
       item_scores,
       synergies: contributions.filter((c) => c.weight > 0).slice(0, 5),
+      combo_synergies: topComboSynergies(contributions),
       tradeoffs: contributions.filter((c) => c.weight < 0).slice(0, 3),
       evidence: {
         featureCount: contributions.length,

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -64,10 +64,10 @@ test.describe('Accessibility and responsive layout', () => {
     await expect(page.getByTestId('option-score-0')).toBeVisible();
     await expect(page.getByText(/火力/)).toHaveCount(0);
 
-    // Expanding reveals the compact 主要加分项 detail (or its empty-state).
+    // Expanding reveals the compact 组合加分项 detail (or its empty-state).
     await firstDetails.click();
     await expect(
-      page.getByText('主要加分项:').first().or(page.getByText('暂无明显加分项。').first()),
+      page.getByText('组合加分项:').or(page.getByText('暂无明显加分项。')).first(),
     ).toBeVisible();
     await expect(page.getByText('推荐理由:')).toHaveCount(0);
     await expect(page.getByText('可能减分项:')).toHaveCount(0);
@@ -95,8 +95,9 @@ test.describe('Accessibility and responsive layout', () => {
     // Plain-language guide explaining the three key numbers in player terms.
     await expect(page.getByRole('heading', { name: '三步看懂这些数字' })).toBeVisible();
     await expect(page.getByText('胜率参考')).not.toHaveCount(0);
-    await expect(page.getByText('强度加成')).not.toHaveCount(0);
+    await expect(page.getByText('组合分')).not.toHaveCount(0);
     await expect(page.getByText('参考场次')).not.toHaveCount(0);
+    await expect(page.getByText('强度加成')).toHaveCount(0);
 
     // Actionable sections come before the optional diagnostics section.
     await expect(page.getByRole('heading', { name: '先看谁更值得选' })).toBeVisible();


### PR DESCRIPTION
## Intent

Improve the recommendation UI clarity and alignment. The user asked to: make the Current Roster panel more prominent and aligned, with the edit controls pinned at the top right and cancel/save staying on the same row in edit mode; keep the recommendation buttons and a prominent Chinese notice below the header explaining that users should confirm core heroes early so AI recommendations are more accurate; rename the detailed contribution label from the English 'combo加分项' to Chinese '组合加分项' and hide single-item H/S contributions from that section so it only shows true combo contributions; in /analytics remove user-facing '强度加成', sort individual hero/skill tables by 胜率参考, remove the individual strength column, and rename remaining combo metrics to 组合分. We already validated with web typecheck, unit tests, e2e, build, and Playwright screenshot inspection.

## What Changed

- Restructured the Current Roster panel: edit controls pinned top-right with cancel/save on the same row in edit mode, recommendation buttons retained, and a prominent Chinese notice added below the header advising users to confirm core heroes early for more accurate AI recommendations.
- Renamed the detailed contribution label from English `combo加分项` to Chinese `组合加分项` and now surface only true combo contributions (HP/HS/SP) in that section, computing combo synergies upstream in `recommendationEngine.ts` before the top-5 truncation so single-item hero/skill contributions no longer crowd out real combos.
- Reworked `/analytics`: removed the user-facing `强度加成` and the individual strength column, sorted the per-hero/skill tables by `胜率参考`, and renamed the remaining combo metrics to `组合分`; updated `web/README.md` and the `accessibilityLayout` e2e assertions to match.

## Risk Assessment

✅ Low: The only new change since the prior review is a well-scoped upstream fix that correctly computes combo synergies before truncation, resolving the earlier finding with no new risks and complete interface coverage.

## Testing

Ran under Node 22 (the repo-pinned version; Node 20 in PATH failed Vite's ESM load, an environment issue not a product bug). Web typecheck, 70 Vitest unit tests, and the full 32-test Playwright e2e suite all pass, including the author's updated accessibilityLayout assertions. To demonstrate the end-user surface I drove the live dev server with a throwaway Playwright script and captured six screenshots showing the redesigned Current Roster panel (view + edit mode), the 组合加分项 recommendation detail (single-item H/S correctly hidden from the combo section), and the /analytics tables (胜率参考-sorted, strength column removed, 组合分 labels, no 强度加成). All evidence matches the intent; the transient spec and test-results were removed so the worktree is clean.

- Evidence: Current Roster panel (view mode): edit control top-right, notice + recommendation buttons below header (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXSFZ9W42JV36P8XPHN6FR85/01-current-roster-view.png</code>)
- Evidence: Current Roster panel (edit mode): 取消/保存修改 on same top-right row (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXSFZ9W42JV36P8XPHN6FR85/02-current-roster-edit.png</code>)
- Evidence: Recommendation option detail: 组合加分项 shows only true combo (hero pair), single H/S under 单项加分 (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXSFZ9W42JV36P8XPHN6FR85/03-recommendation-combo-label.png</code>)
- Evidence: Analytics hero table: sorted by 胜率参考, no 强度加成 column (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXSFZ9W42JV36P8XPHN6FR85/05-analytics-hero-table.png</code>)
- Evidence: Analytics combo section: 组合分 column header and description (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXSFZ9W42JV36P8XPHN6FR85/06-analytics-combo-section.png</code>)
- Evidence: Analytics full page (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXSFZ9W42JV36P8XPHN6FR85/04-analytics-full.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `web/src/components/game/AnalysisGrid.tsx:81` - comboSynergies filters family H/S off setAnalysis.synergies, but synergies is already `contributions.filter(w&gt;0).slice(0,5)` upstream (recommendationEngine.ts:252 and :310), computed over the mixed (single-item + combo) contribution list sorted by weight. Single-item H/S contributions frequently dominate the top-5 (heroes/skills carry strong standalone weights), so after the family filter the &#39;组合加分项&#39; section can show fewer combos than actually exist — or be empty and fall back to &#39;暂无明显加分项&#39; — even when real HP/HS/SP combos rank 6th or lower. This under-reports the combos the section is meant to surface. Consider filtering before/independent of the top-5 slice (e.g. filter the full contribution list to combo families, then take the top N).

🔧 Fix: Compute combo synergies upstream before top-5 truncation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; npm run typecheck` (Go-native tsc) — clean</code>
- <code>`npx vitest run` — 70 unit tests passed (6 files)</code>
- <code>`npx playwright test accessibilityLayout` — 6 passed (asserts 强度加成 absent, 组合分 present, 组合加分项 detail label)</code>
- <code>`npx playwright test` — full e2e suite, 32 passed</code>
- `Temporary Playwright screenshot spec against the live Vite dev server (localhost:3000) driving /team-builder and /analytics; spec removed and worktree left clean afterward`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
