### PR TITLE
fix(web): clarify sidebar battle-count label and drop corpus hash

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -5,9 +5,6 @@ import { recommendationData } from '../../data';
 const Header = () => {
   const counts = recommendationData.battle_counts;
   const totalBattles = counts.total_battles ?? 0;
-  // The artifact is byte-reproducible (no build timestamp); the corpus content
-  // hash identifies which battles it was trained on.
-  const corpusVersion = counts.corpus_version ?? '';
 
   return (
     <Box
@@ -58,8 +55,7 @@ const Header = () => {
         }}
       >
         <UpdateIcon sx={{ fontSize: 14 }} />
-        {totalBattles > 0 && <span>{totalBattles} 场</span>}
-        {corpusVersion && <span>· {corpusVersion.slice(0, 8)}</span>}
+        {totalBattles > 0 && <span>已收集 {totalBattles} 场战报</span>}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Intent

In the web app (./web) left sidebar (Header.tsx), the metadata line under the app title showed '55950103', which the user mistook for a date. It was actually the first 8 chars of the corpus content hash (5595010354864ec9) rendered via corpusVersion.slice(0,8) — coincidentally date-like but meaningless to users. The user first asked to remove that hash, so we dropped the corpus-hash span and the unused corpusVersion variable, leaving just the battle count. The user then asked to expand the bare '2822 场' into a fuller phrase; we changed it to '已收集 {totalBattles} 场战报' ("collected N battle reports"). This is a UI-copy-only change in web/src/components/layout/Header.tsx — no data/artifact changes. Verified visually via Playwright screenshot (header renders '演武策牒' + '已收集 2822 场战报', vertical writing mode, layout intact) and tsc --noEmit passes.

## What Changed

- Removed the corpus-hash span (and the now-unused `corpusVersion` variable) from the sidebar metadata line in `web/src/components/layout/Header.tsx`, which had rendered a date-like but meaningless `55950103`.
- Expanded the bare battle count into the fuller phrase `已收集 {totalBattles} 场战报` ("collected N battle reports"). This is a UI-copy-only change with no data/artifact impact.

## Risk Assessment

✅ Low: A single-file, UI-copy-only change that removes a meaningless hash span and rewords the battle-count label, with no logic, data, or artifact changes and no leftover unused references.

## Testing

No existing test covers the header copy, so I drove the real app: served this worktree's source with the Vite dev server and used Playwright/chromium to render and screenshot the sidebar on desktop and mobile. Setup required working around environment issues (Node 20 too old for Vite → used the available Node 22; a missing rolldown native binding → installed it with --no-save so the lockfile stays unchanged). The header renders 演武策牒 + 已收集 2822 场战报 with the vertical writing mode and layout intact, the old date-like hash 55950103 is gone (0 occurrences), and 2822 matches the artifact's total_battles. Reviewer-visible screenshots were captured; working tree remains clean.

- Evidence: Desktop sidebar header (vertical writing mode) — 演武策牒 + 已收集 2822 场战报 (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXVW3CVCG3N92WHPRWSP6WJ1/header-sidebar-desktop.png</code>)
- Evidence: Mobile header (horizontal) — 演武策牒 + 已收集 2822 场战报 (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXVW3CVCG3N92WHPRWSP6WJ1/header-mobile.png</code>)
- Evidence: Full desktop app view (sidebar in context) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXVW3CVCG3N92WHPRWSP6WJ1/app-full-desktop.png</code>)
<details>
<summary>Evidence: Playwright render assertions</summary>

```text
DESKTOP header innerText: "演武策牒\n已收集 2822 场战报"
MOBILE header innerText: "演武策牒\n已收集 2822 场战报"
count of "55950103" on desktop page: 0
count of "已收集 2822 场战报": 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Read web/src/components/layout/Header.tsx — confirmed corpus-hash span and corpusVersion variable removed, copy is `已收集 {totalBattles} 场战报`</code>
- <code>Verified data: `total_battles=2822`, `corpus_version=5595010354864ec9` (first 8 chars = the removed `55950103`) in web/src/recommendation_data.json</code>
- `Served worktree source via Vite dev server (Node 22) on http://localhost:3000 and drove it with a Playwright/chromium script`
- <code>Desktop (1280x800) header innerText asserted == `演武策牒\n已收集 2822 场战报`; captured header-sidebar-desktop.png and app-full-desktop.png</code>
- <code>Mobile (390x844) header innerText asserted == `演武策牒\n已收集 2822 场战报`; captured header-mobile.png</code>
- <code>Asserted `55950103` appears 0 times and `已收集 2822 场战报` appears once on the rendered page</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
