### PR TITLE
fix(web): keep true 排名 in analytics tables when a search filter is applied

### DIFF
--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -201,12 +201,21 @@ const Analytics = () => {
   // display-only ordering; the underlying data.heroes/data.skills stay untouched.
   const byWinRate = <T extends { smoothedWinRate: number; total: number; name: string }>(a: T, b: T): number =>
     b.smoothedWinRate - a.smoothedWinRate || b.total - a.total || a.name.localeCompare(b.name, 'zh-Hans-CN');
-  const filteredHeroes = (hasHeroFilter ? data.heroes.filter((h) => heroFilterSet.has(h.name)) : data.heroes)
-    .slice()
-    .sort(byWinRate);
-  const filteredSkills = (hasSkillFilter ? data.skills.filter((s) => skillFilterSet.has(s.name)) : data.skills)
-    .slice()
-    .sort(byWinRate);
+  // Ranks (排名) are always computed against the *full* sorted list so that when a
+  // search filter is applied the rows keep their true position (e.g. 排名 42) instead
+  // of restarting at 1. We build a name/label -> rank lookup from the full ordering,
+  // then filter for display without disturbing the rank shown per row.
+  const sortedHeroes = data.heroes.slice().sort(byWinRate);
+  const sortedSkills = data.skills.slice().sort(byWinRate);
+  const heroRankMap = new Map(sortedHeroes.map((h, i) => [h.name, i + 1]));
+  const skillRankMap = new Map(sortedSkills.map((s, i) => [s.name, i + 1]));
+  const heroUsageRankMap = new Map(data.hero_usage.map(([h], i) => [h, i + 1]));
+  const skillUsageRankMap = new Map(data.skill_usage.map(([s], i) => [s, i + 1]));
+  const heroPairRankMap = new Map(data.top_hero_pairs.map((p, i) => [p.label, i + 1]));
+  const heroSkillRankMap = new Map(data.top_hero_skills.map((p, i) => [p.label, i + 1]));
+
+  const filteredHeroes = hasHeroFilter ? sortedHeroes.filter((h) => heroFilterSet.has(h.name)) : sortedHeroes;
+  const filteredSkills = hasSkillFilter ? sortedSkills.filter((s) => skillFilterSet.has(s.name)) : sortedSkills;
   const filteredHeroUsage = hasHeroFilter ? data.hero_usage.filter(([h]) => heroFilterSet.has(h)) : data.hero_usage;
   const filteredSkillUsage = hasSkillFilter ? data.skill_usage.filter(([s]) => skillFilterSet.has(s)) : data.skill_usage;
   const filteredHeroPairs = hasHeroFilter
@@ -339,9 +348,9 @@ const Analytics = () => {
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      {filteredHeroes.map((h, index) => (
+                      {filteredHeroes.map((h) => (
                         <TableRow key={h.name}>
-                          <TableCell>{index + 1}</TableCell>
+                          <TableCell>{heroRankMap.get(h.name)}</TableCell>
                           <TableCell><Chip label={h.name} color="primary" size="small" /></TableCell>
                           <TableCell align="right">{pct(h.smoothedWinRate)}</TableCell>
                           <TableCell align="right">{h.total}</TableCell>
@@ -374,9 +383,9 @@ const Analytics = () => {
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      {filteredSkills.map((s, index) => (
+                      {filteredSkills.map((s) => (
                         <TableRow key={s.name}>
-                          <TableCell>{index + 1}</TableCell>
+                          <TableCell>{skillRankMap.get(s.name)}</TableCell>
                           <TableCell>
                             <Chip
                               label={isShadowSkill(s.name) ? `影 · ${s.name}` : s.name}
@@ -419,9 +428,9 @@ const Analytics = () => {
               <Table size="small" stickyHeader>
                 <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将配对</TableCell><TableCell align="right">组合分</TableCell><TableCell align="right">参考场次</TableCell></TableRow></TableHead>
                 <TableBody>
-                  {filteredHeroPairs.map((p, index) => (
+                  {filteredHeroPairs.map((p) => (
                     <TableRow key={p.label}>
-                      <TableCell>{index + 1}</TableCell>
+                      <TableCell>{heroPairRankMap.get(p.label)}</TableCell>
                       <TableCell>
                         <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
                           {p.label.split(' + ').map((n, i) => <Chip key={i} label={n} color="primary" size="small" />)}
@@ -452,11 +461,11 @@ const Analytics = () => {
               <Table size="small" stickyHeader>
                 <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将</TableCell><TableCell>战法</TableCell><TableCell align="right">组合分</TableCell><TableCell align="right">参考场次</TableCell></TableRow></TableHead>
                 <TableBody>
-                  {filteredHeroSkills.map((p, index) => {
+                  {filteredHeroSkills.map((p) => {
                     const [hero, skill] = p.label.split(' · ');
                     return (
                       <TableRow key={p.label}>
-                        <TableCell>{index + 1}</TableCell>
+                        <TableCell>{heroSkillRankMap.get(p.label)}</TableCell>
                         <TableCell><Chip label={hero} color="primary" size="small" /></TableCell>
                         <TableCell><Chip label={skill} color="secondary" size="small" variant="outlined" /></TableCell>
                         <TableCell align="right" sx={{ color: 'success.main', fontWeight: 'bold' }}>{fmtStrength(p.weight)}</TableCell>
@@ -489,9 +498,9 @@ const Analytics = () => {
                   <Table size="small" stickyHeader>
                     <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将</TableCell><TableCell align="right">使用次数</TableCell></TableRow></TableHead>
                     <TableBody>
-                      {filteredHeroUsage.map(([hero, count], index) => (
+                      {filteredHeroUsage.map(([hero, count]) => (
                         <TableRow key={hero}>
-                          <TableCell>{index + 1}</TableCell>
+                          <TableCell>{heroUsageRankMap.get(hero)}</TableCell>
                           <TableCell><Chip label={hero} color="primary" size="small" /></TableCell>
                           <TableCell align="right">{count}</TableCell>
                         </TableRow>
@@ -512,9 +521,9 @@ const Analytics = () => {
                   <Table size="small" stickyHeader>
                     <TableHead><TableRow><TableCell>排名</TableCell><TableCell>战法</TableCell><TableCell align="right">使用次数</TableCell></TableRow></TableHead>
                     <TableBody>
-                      {filteredSkillUsage.map(([skill, count], index) => (
+                      {filteredSkillUsage.map(([skill, count]) => (
                         <TableRow key={skill}>
-                          <TableCell>{index + 1}</TableCell>
+                          <TableCell>{skillUsageRankMap.get(skill)}</TableCell>
                           <TableCell><Chip label={skill} color="secondary" size="small" /></TableCell>
                           <TableCell align="right">{count}</TableCell>
                         </TableRow>

--- a/web/tests/analyticsSearchKeepsTrueRank.spec.js
+++ b/web/tests/analyticsSearchKeepsTrueRank.spec.js
@@ -1,0 +1,149 @@
+const { test, expect } = require('@playwright/test');
+
+// Evidence-producing e2e for the 排名 (rank) fix on /analytics.
+//
+// Bug: applying a hero/skill search filter renumbered the 排名 column starting at
+// 1 for the surviving rows. Fix: rank is looked up from the *full* (unfiltered)
+// ordering, so a filtered row keeps its true position. This spec exercises all
+// six 排名 tables — for each it (1) records the full-list rank of every row, then
+// (2) applies a filter and asserts each surviving row still shows its true rank
+// (never renumbered to 1..n). It also captures screenshots for visual review.
+const EVIDENCE_DIR =
+  '/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXVWZ55AJHR68TTDBNJQ4RKK';
+
+// Locate a ranking table by its ScrollableAnalyticsTable aria-label region.
+const region = (page, label) =>
+  page.getByRole('region', { name: `${label}表格，可滚动` });
+
+// Read [{ rank, key }] for every body row, with a table-specific key extractor.
+async function readRows(page, label, keyOf) {
+  const rows = region(page, label).locator('tbody tr');
+  const n = await rows.count();
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const row = rows.nth(i);
+    const rankText = (await row.locator('td').first().innerText()).trim();
+    out.push({ rank: Number(rankText), key: await keyOf(row) });
+  }
+  return out;
+}
+
+// Key extractors per table.
+const firstChip = async (row) => (await row.locator('td').nth(1).innerText()).trim();
+const stripShadow = (s) => s.replace(/^影 · /, '');
+const skillKey = async (row) => stripShadow(await firstChip(row));
+const pairKey = async (row) => {
+  const chips = row.locator('td').nth(1).locator('.MuiChip-label');
+  const names = await chips.allInnerTexts();
+  return names.map((s) => s.trim()).join(' + ');
+};
+const heroSkillKey = async (row) => {
+  const hero = (await row.locator('td').nth(1).innerText()).trim();
+  const skill = (await row.locator('td').nth(2).innerText()).trim();
+  return `${hero} · ${skill}`;
+};
+
+async function addFilter(page, placeholder, typed, optionText) {
+  const input = page.getByPlaceholder(placeholder);
+  await input.click();
+  await input.fill(typed);
+  await page.getByRole('option').filter({ hasText: optionText }).first().click();
+}
+
+const HERO_PH = '输入武将名或拼音...';
+const SKILL_PH = '输入战法名或拼音...';
+
+// For a table: read the full ordering, pick a target row whose true rank > 1,
+// apply the given filter, then assert every surviving row keeps its full-list
+// rank (and specifically that the target's true rank is shown, not 1).
+async function verifyTableKeepsTrueRank(page, { label, keyOf, filter, screenshot }) {
+  await page.goto('/analytics');
+  await expect(region(page, label)).toBeVisible();
+
+  const full = await readRows(page, label, keyOf);
+  expect(full.length).toBeGreaterThan(3);
+  const fullRank = new Map(full.map((r) => [r.key, r.rank]));
+  // Full ordering must be a clean 1..n so "restart at 1" is the only failure mode.
+  full.forEach((r, i) => expect(r.rank).toBe(i + 1));
+
+  // Pick a mid-list target (rank clearly > 1) to filter down to.
+  const target = full[Math.min(4, full.length - 1)];
+  expect(target.rank).toBeGreaterThan(1);
+
+  await filter(page, target);
+
+  const filtered = await readRows(page, label, keyOf);
+  expect(filtered.length).toBeGreaterThan(0);
+  // The fix: each surviving row shows its true (full-list) rank, not a 1..n restart.
+  for (const r of filtered) {
+    expect(r.rank, `row ${r.key} in ${label}`).toBe(fullRank.get(r.key));
+  }
+  // The target survived and shows its real rank (which is > 1) — the exact regression.
+  const shown = filtered.find((r) => r.key === target.key);
+  expect(shown, `target ${target.key} present after filter`).toBeTruthy();
+  expect(shown.rank).toBe(target.rank);
+
+  const card = region(page, label).locator('xpath=ancestor::*[contains(@class,"MuiCard-root")][1]');
+  await card.scrollIntoViewIfNeeded();
+  await card.screenshot({ path: `${EVIDENCE_DIR}/${screenshot}` });
+  return { target, filtered };
+}
+
+test('全部武将 / 全部战法 keep true 排名 under a search filter', async ({ page }) => {
+  const hero = await verifyTableKeepsTrueRank(page, {
+    label: '全部武将排名',
+    keyOf: firstChip,
+    filter: (p, t) => addFilter(p, HERO_PH, t.key, t.key),
+    screenshot: 'analytics-rank-heroes.png',
+  });
+  // A single mid-ranked hero -> exactly one row, showing its true rank (> 1).
+  expect(hero.filtered.length).toBe(1);
+  expect(hero.filtered[0].rank).toBe(hero.target.rank);
+
+  const skill = await verifyTableKeepsTrueRank(page, {
+    label: '全部战法排名',
+    keyOf: skillKey,
+    filter: (p, t) => addFilter(p, SKILL_PH, t.key, t.key),
+    screenshot: 'analytics-rank-skills.png',
+  });
+  expect(skill.filtered.length).toBe(1);
+  expect(skill.filtered[0].rank).toBe(skill.target.rank);
+});
+
+test('武将使用排行 / 战法使用排行 keep true 排名 under a search filter', async ({ page }) => {
+  await verifyTableKeepsTrueRank(page, {
+    label: '武将使用排行',
+    keyOf: firstChip,
+    filter: (p, t) => addFilter(p, HERO_PH, t.key, t.key),
+    screenshot: 'analytics-rank-hero-usage.png',
+  });
+  await verifyTableKeepsTrueRank(page, {
+    label: '战法使用排行',
+    keyOf: skillKey,
+    filter: (p, t) => addFilter(p, SKILL_PH, t.key, t.key),
+    screenshot: 'analytics-rank-skill-usage.png',
+  });
+});
+
+test('最强武将配对 / 最强武将战法组合 keep true 排名 under a search filter', async ({ page }) => {
+  // Pairs: filter by one hero of the target pair; all surviving pairs keep true rank.
+  await verifyTableKeepsTrueRank(page, {
+    label: '最强武将配对',
+    keyOf: pairKey,
+    filter: (p, t) => {
+      const hero = t.key.split(' + ')[0];
+      return addFilter(p, HERO_PH, hero, hero);
+    },
+    screenshot: 'analytics-rank-hero-pairs.png',
+  });
+  // Hero+skill combos: filter by the target's hero.
+  await verifyTableKeepsTrueRank(page, {
+    label: '最强武将战法组合',
+    keyOf: heroSkillKey,
+    filter: (p, t) => {
+      const hero = t.key.split(' · ')[0];
+      return addFilter(p, HERO_PH, hero, hero);
+    },
+    screenshot: 'analytics-rank-hero-skills.png',
+  });
+});


### PR DESCRIPTION
## Intent

On the /analytics page in the web/ React app, when a user applies a hero/skill search filter, the 排名 (rank) column in the ranking tables was restarting at 1 for the filtered rows instead of showing each item's true rank within the full list. The user asked that search results keep the true 排名 rather than always showing 1. Fix: in web/src/pages/Analytics.tsx, compute each row's rank from the full (unfiltered) sorted list via name/label -> rank lookup Maps, then filter only for display. Applied consistently to all six 排名 tables: 全部武将, 全部战法, 最强武将配对, 最强武将战法组合, 武将使用排行, 战法使用排行. Rank maps are derived from the same orderings the tables already used (byWinRate for hero/skill; the already-sorted data arrays for pairs/hero-skill/usage), so unfiltered behavior is unchanged. Verified with the four required web checks: npm run typecheck, npm test (70 unit tests), npm run test:e2e (29 Playwright tests), npm run build.

## What Changed

- In `web/src/pages/Analytics.tsx`, each ranking row's 排名 is now computed from the full unfiltered sorted list via name/label → rank lookup Maps, and the search filter is applied only for display — so filtered rows show their true rank instead of restarting at 1.
- Applied consistently across all six 排名 tables (全部武将, 全部战法, 最强武将配对, 最强武将战法组合, 武将使用排行, 战法使用排行), deriving rank maps from the same orderings the tables already used so unfiltered output is unchanged.
- Added `web/tests/analyticsSearchKeepsTrueRank.spec.js`, a Playwright spec covering the true-rank-under-filter behavior.

## Risk Assessment

✅ Low: A small, display-only web change that derives rank lookups from the exact orderings the six tables already used, filtering only for display, so unfiltered behavior is preserved and every rendered row is guaranteed a defined rank.

## Testing

Placeholder testing summary.

- Outcome: ⚠️ 1 info across 1 run (8m16s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `web/tests/analyticsSearchKeepsTrueRank.spec.js` - new test file written by agent: web/tests/analyticsSearchKeepsTrueRank.spec.js
- `typecheck`
- `unit tests`
- `e2e`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
