### PR TITLE
fix(telemetry): accept signature skills in normal pool validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,5 +109,5 @@ bilibili/
 # Playwright test output
 test-results/
 
-# Lavish review artifacts (scratch)
-.lavish/
+# Wrangler local state
+.wrangler/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,11 +13,10 @@ working tree; steps 4–5 go through the `no-mistakes` gate.
 1. **Requirement.** Start from what the user wants to accomplish — the goal, not a
    diff. Capture it in the user's own words; it becomes the `--intent` later.
 
-2. **Discuss & plan (`lavish`).** Turn the proposed approach into a reviewable
-   artifact with the **`lavish`** skill (installed at `~/.claude/skills/lavish`)
-   and share it: the plan, trade-offs, affected files, and the tests you intend to
-   run. Iterate on the artifact until the user **explicitly approves**.
-   **Do not start implementing before approval.**
+2. **Discuss & plan.** Turn the proposed approach into a reviewable plan and
+   share it: the trade-offs, affected files, and the tests you intend to run.
+   Iterate on the plan until the user **explicitly approves**. **Do not start
+   implementing before approval.**
 
 3. **Implement.** Create a feature branch (never work on `master`), make the
    change, and run the **scoped tests** for the area you touched (see

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ in the browser:
   unit tests in `web/src/services/__tests__/` (paired feature extraction, model
   scoring, global optimisation, deterministic output, no runtime opponent).
 - Regenerable/scratch dirs are gitignored: `extracted_results/`, `tmp_crops/`,
-  `test-results/`, `.lavish/`, plus `study-battle-report/battles/*/` OCR artifacts.
+  `test-results/`, plus `study-battle-report/battles/*/` OCR artifacts.
 
 ---
 

--- a/data/build_telemetry_data.py
+++ b/data/build_telemetry_data.py
@@ -90,6 +90,7 @@ class RecommendationModel:
 class TelemetryContract:
     catalog_version: str
     hero_names: frozenset[str]
+    pool_skill_names: frozenset[str]
     round_skill_names: frozenset[str]
     support_skill_names: frozenset[str]
     models: Mapping[str, RecommendationModel]
@@ -264,6 +265,7 @@ def load_catalog(
     return TelemetryContract(
         catalog_version=catalog_version,
         hero_names=frozenset(heroes),
+        pool_skill_names=frozenset(skills),
         round_skill_names=frozenset(round_skill_names),
         support_skill_names=frozenset(support_skill_names),
         models=models,
@@ -553,7 +555,7 @@ def _validate_event(
         pool["heroes"], "pool heroes", 20, set(contract.hero_names)
     )
     pool_skills = _validate_item_list(
-        pool["skills"], "pool skills", 32, set(contract.support_skill_names)
+        pool["skills"], "pool skills", 32, set(contract.pool_skill_names)
     )
     if len(pool_heroes) != len(set(pool_heroes)):
         raise InvalidTelemetryError("pool heroes contains duplicates")

--- a/data/test_build_telemetry_data.py
+++ b/data/test_build_telemetry_data.py
@@ -415,6 +415,20 @@ class TelemetryBuilderTests(unittest.TestCase):
         _write_export(self.export_path, [tuple(row)])
         self.assertEqual(self._build()["summary"]["event_count"], 1)
 
+    def test_normal_pool_accepts_signature_skill_but_rejects_unknown_skill(self) -> None:
+        row = list(_event(self.catalog_version, round_number=2))
+        pool = json.loads(row[9])
+        pool["skills"] = ["sig-A", "j"]
+        row[9] = json.dumps(pool)
+        _write_export(self.export_path, [tuple(row)])
+        self.assertEqual(self._build()["summary"]["event_count"], 1)
+
+        pool["skills"] = ["unknown", "j"]
+        row[9] = json.dumps(pool)
+        _write_export(self.export_path, [tuple(row)])
+        with self.assertRaisesRegex(InvalidTelemetryError, "unknown or invalid item"):
+            self._build()
+
     def test_future_preference_probabilities_are_validated_and_counted(self) -> None:
         row = list(_event(self.catalog_version))
         row[14] = "preference-v1"


### PR DESCRIPTION
## Intent

Fix the telemetry aggregate build failure caused by valid hero-signature skills in the normal starting skill pool. Normal pool validation must accept every known catalog skill, while round offers and support selections must keep their existing stricter eligibility rules and unknown skills must still fail closed; preserve all existing D1 telemetry rather than deleting rows. Add regression coverage for the valid signature-skill case and continued unknown-skill rejection. Remove all lavish references from the repository and replace the obsolete local artifact ignore with an ignore for Wrangler local state.

## What Changed

- Validate the normal starting skill pool (`pool_before_json.skills`) against the full catalog skill set instead of the narrower eligibility list, so valid hero-signature skills no longer abort the aggregate build; round offers and support selections keep their stricter eligibility rules and unknown skills still fail closed, with no existing D1 telemetry rows deleted.
- Add regression coverage in `data/test_build_telemetry_data.py` (`test_normal_pool_accepts_signature_skill_but_rejects_unknown_skill`) asserting a signature skill in the normal pool is accepted while an unknown pool skill is still rejected.
- Remove all `lavish` references from the repository and replace the obsolete `.lavish/` gitignore entry with an ignore for Wrangler local state (`.wrangler/`), with matching doc touch-ups in `README.md` and `DEVELOPMENT.md`.

## Risk Assessment

✅ Low: A tightly-scoped validation fix that correctly widens only the normal-pool skill set at the contract boundary while preserving stricter round/support rules and fail-closed rejection of unknown skills, backed by targeted regression tests and matching all doc/gitignore intent items.

## Testing

Ran the targeted telemetry builder suite (17 passed, including the new signature-vs-unknown regression test) and drove the actual builder CLI end-to-end: a real export carrying a hero-signature skill in the normal pool now builds a valid aggregate artifact, whereas the base-commit builder rejected the identical export — directly demonstrating the failure the change fixes. Verified the stricter path is intact (unknown pool skill still fails closed), that no destructive SQL touches D1 rows, that all `lavish` references are gone from tracked files, and that `.gitignore` now ignores `.wrangler/`. No UI surface is involved (offline Python builder), so evidence is a CLI transcript rather than a screenshot. All checks passed; no findings.

<details>
<summary>Evidence: Telemetry signature-skill fix — before/after CLI transcript</summary>

```text
Telemetry aggregate build — signature-skill-in-normal-pool fix
================================================================

Scenario: a real D1 export where the NORMAL starting skill pool contains a valid
hero-signature skill (sig-A). Fixtures + export built via the telemetry test
helpers so paired scores stay model-consistent; the ACTUAL builder CLI is driven
against isolated fixtures/output (repo artifacts untouched).

BEFORE FIX (base commit 327d4241):
  $ build_telemetry_data.py <export with sig-A in pool>
  Telemetry build failed: pool skills contains an unknown or invalid item
  exit code: 1        <- the aggregate-build failure this change resolves

AFTER FIX (target commit 815199cf):
  $ build_telemetry_data.py <same export>
  Wrote telemetry_data.json from 1 validated events
  exit code: 0
  artifact: event_count=1, session_count=1,
            round2 chosen_position_counts=[0,1,0], preference_model=None

AFTER FIX — unknown skill in normal pool STILL fails closed:
  $ build_telemetry_data.py <export with "totally-unknown-skill" in pool>
  Telemetry build failed: pool skills contains an unknown or invalid item
  exit code: 1        <- unknown items still rejected (stricter offer/support
                         eligibility rules unchanged)

Existing D1 rows preserved: builder contains no DELETE/DROP/TRUNCATE.

Regression coverage:
  data/test_build_telemetry_data.py::TelemetryBuilderTests
  ::test_normal_pool_accepts_signature_skill_but_rejects_unknown_skill  PASSED
  (full suite: 17 passed, 15 subtests passed)

Repository hygiene:
  - `git grep -ni lavish` -> no matches in tracked files.
  - .gitignore: `.lavish/` replaced with `.wrangler/` (Wrangler local state).
```
</details>
<details>
<summary>Evidence: Before vs after fix (same signature-skill export)</summary>

```text
BEFORE FIX (327d4241): Telemetry build failed: pool skills contains an unknown or invalid item [exit 1]
AFTER FIX (815199cf): Wrote telemetry_data.json from 1 validated events [exit 0] -> event_count=1, session_count=1, round2 chosen_position_counts=[0,1,0]
AFTER FIX, unknown skill: Telemetry build failed: pool skills contains an unknown or invalid item [exit 1]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run python -m pytest data/test_build_telemetry_data.py -v` — 17 passed incl. new `test_normal_pool_accepts_signature_skill_but_rejects_unknown_skill` (15 subtests passed)</code>
- <code>End-to-end CLI: built a real D1-style SQL export with a hero-signature skill (`sig-A`) in the normal pool and ran the actual `data/build_telemetry_data.py` against isolated fixtures/output → exit 0, wrote artifact from 1 validated event</code>
- <code>Before/after: ran the base-commit (327d4241) builder on the SAME export with explicit `--migration` → failed `pool skills contains an unknown or invalid item`; fixed builder succeeds — proving the resolved failure</code>
- <code>Fail-closed regression: fixed CLI on an export with an unknown pool skill → exit 1, `pool skills contains an unknown or invalid item`</code>
- <code>`grep -niE &#39;delete from|drop table|truncate&#39; data/build_telemetry_data.py` → none (existing D1 rows preserved)</code>
- <code>`git grep -ni lavish` → no matches in tracked files; confirmed `.gitignore` now ignores `.wrangler/` instead of `.lavish/`</code>
- <code>`git status --porcelain` clean; `.venv`/`.pytest_cache` confirmed gitignored</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
