### PR TITLE
feat(telemetry): add Phase 3 player-preference model and analytics

### DIFF
--- a/.github/workflows/update-telemetry-data.yml
+++ b/.github/workflows/update-telemetry-data.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - name: Check out master
         uses: actions/checkout@v6
@@ -64,6 +64,17 @@ jobs:
             "$RUNNER_TEMP/round_telemetry.sql" \
             --output web/public/game-data/telemetry_data.json
           git diff --check
+
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Validate Phase 3 web consumer
+        working-directory: web
+        run: |
+          npm run typecheck
+          npm test
+          npm run build
 
       - name: Commit changed artifact to master
         env:

--- a/README.md
+++ b/README.md
@@ -94,8 +94,11 @@ in the browser:
   be verified; individual malformed or impossible events are quarantined and
   exposed only as an aggregate `invalid_event_count`. Valid rows are reduced
   atomically to `web/public/game-data/telemetry_data.json` after UI eligibility
-  and recorded-score verification. The raw export remains outside the
-  repository and the Phase 2 preference model is explicitly `null`. Before
+  and recorded-score verification. Schema v3 adds offer/pick, round, position,
+  score-margin, and model-disagreement aggregates plus a deterministic,
+  regularized conditional-choice model. The model remains unavailable until
+  explicit event/session/disagreement/held-out evidence gates and a held-out
+  quality gate pass. The raw export remains outside the repository. Before
   publishing a new recommendation model, archive the previous artifact in
   `data/recommendation_models/` so historical scores remain verifiable.
 - `web/` — React (Vite) + MUI; recommendation is client-side, with an isolated
@@ -113,7 +116,8 @@ in the browser:
   - `src/data.ts` — the central typed boundary that imports and casts the bundled JSON once.
 - `web/public/game-data/database.json` — source data for heroes, skills, and hero↔skill mappings.
 - `web/public/game-data/telemetry_data.json` — generated, aggregate-only
-  telemetry metadata/counts; updated weekly by GitHub Actions.
+  player-choice analytics and gated preference-model artifact; updated weekly
+  by GitHub Actions.
 - `web/src/recommendation_data.json` — **generated** by `build_recommendation_data.py`; don't hand-edit.
 - `autojs/` — AutoJS (Android) scripts that capture the screenshots. Device-specific.
 

--- a/TELEMETRY_IMPLEMENTATION_PLAN.md
+++ b/TELEMETRY_IMPLEMENTATION_PLAN.md
@@ -73,7 +73,8 @@ interface RoundTelemetryEvent {
 
 The preference fields are `null` until the later preference-model phase. Once
 `P` is displayed, those fields record exactly which probabilities were shown so
-the weekly builder can measure calibration and feedback effects.
+retained preference models can later reproduce them for calibration and
+feedback analysis without trusting client-reported probabilities directly.
 
 ## Phase 1 — collection foundation
 
@@ -99,7 +100,7 @@ Status: implemented.
 
 ## Phase 2 — weekly GitHub builder
 
-Status: implemented.
+Status: complete.
 
 - Add `.github/workflows/update-telemetry-data.yml` with weekly schedule and
   manual dispatch triggers only.
@@ -126,11 +127,14 @@ Status: implemented.
 - Retain immutable historical model artifacts before a recommendation-model
   rollout.
 
-The Phase 2 artifact contains only aggregate event/session/version/round and
-position counts. `preference_model` is explicitly `null` until Phase 3 adds the
-regularized conditional-choice model and its held-out validation metrics.
+The Phase 2 schema contains only aggregate event/session/version/round and
+position counts, with `preference_model` explicitly `null`. Phase 3 upgrades
+the artifact to schema v3 and adds the regularized conditional-choice model,
+held-out validation metrics, and privacy-preserving choice aggregates.
 
 ## Phase 3 — player preference and Analytics
+
+Status: in progress.
 
 - Train a regularized conditional-choice model over each three-option round.
 - Predict `P(option | current pool, all offers, round, paired scores)` and
@@ -146,6 +150,21 @@ regularized conditional-choice model and its held-out validation metrics.
   model–player disagreements to Analytics.
 - Suppress low-support percentages and publish held-out quality/calibration
   metrics in the generated artifact.
+
+Implementation thresholds are explicit and deterministic: at least 240 valid
+choices, 40 anonymous game sessions, 30 choices that differ from the paired
+recommendation, and 36 events in the session-grouped holdout. Public
+percentages require at least 10 supporting observations. Until every evidence
+gate and the held-out quality gate passes, the artifact reports
+`insufficient_evidence` or `quality_gate_failed`, publishes no coefficients,
+and the option cards show only the paired-model score.
+
+The held-out quality gate requires conditional-choice log loss to improve over
+the uniform three-option baseline by at least 0.01. Display probabilities are
+quantized together to one decimal percent while retaining an exact 100.0% sum;
+those exact values are recorded with the model version. Client-reported
+probabilities remain version-counted but are not treated as trusted calibration
+metrics until retained preference models can independently reproduce them.
 
 ## Phase 4 — operations and retention
 
@@ -180,3 +199,14 @@ Phase 2 must additionally pass:
 - Workflow review confirming that the raw SQL export stays under
   `$RUNNER_TEMP`, only the generated JSON is staged, and malformed input or test
   failures prevent a commit.
+
+Phase 3 must additionally pass:
+
+- No-signal, insufficient-evidence, low-support-feature, malformed-artifact,
+  deterministic ready-model, and session-held-out quality-gate builder tests.
+- TypeScript feature-parity, exact displayed-probability normalization,
+  non-blocking telemetry reads, ready schema-v3 parsing, and telemetry feedback
+  tests.
+- The full web type-check, unit, end-to-end, and production-build gates. The
+  weekly workflow reruns the type-check, unit suite, and production build
+  against each newly generated public artifact before committing it.

--- a/TELEMETRY_IMPLEMENTATION_PLAN.md
+++ b/TELEMETRY_IMPLEMENTATION_PLAN.md
@@ -140,14 +140,19 @@ Status: in progress.
 - Predict `P(option | current pool, all offers, round, paired scores)` and
   normalize the three probabilities to 100%.
 - Keep the paired-model maximum as the sole AI recommendation.
-- Show paired score and player `P` together on every option once evidence is
-  sufficient.
+- Show paired score and `玩家选择概率` together on every option once evidence
+  is sufficient, marking the highest-probability option as `玩家选择最高`.
 - Highlight **model–player disagreement** when their top options differ and the
-  player-probability margin is meaningful. Do not subtract paired scores and
-  probabilities directly because they use different units.
-- Add offer count/rate, picked-when-offered rate, recommendation acceptance,
-  round agreement, position bias, score-margin behavior, and largest
-  model–player disagreements to Analytics.
+  player-probability margin is meaningful, with a brief non-causal explanation
+  derived from the strongest player-readable model contributions. Do not
+  subtract paired scores and probabilities directly because they use different
+  units.
+- Publish offer/pick, recommendation-acceptance, round, position, score-margin,
+  and model-disagreement aggregates in the artifact. Player-facing Analytics
+  emphasizes two 武将/战法 rankings: `系统最常提供` by offer count and
+  `玩家最常选择` by pick count, with offer and picked-when-offered rates.
+  Round, position, and score-margin aggregates remain available for diagnostics
+  rather than occupying the main player view.
 - Suppress low-support percentages and publish held-out quality/calibration
   metrics in the generated artifact.
 

--- a/data/build_telemetry_data.py
+++ b/data/build_telemetry_data.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
-"""Build the deterministic public aggregate from a D1 telemetry export.
+"""Build the deterministic public analytics/model artifact from a D1 export.
 
 The input is the SQL file produced by ``wrangler d1 export --table
 round_telemetry``.  It is loaded into an in-memory SQLite database, validated
 against the schema-v1 browser contract and current game catalog, and reduced to
-counts that are safe to publish.  Raw events are never written by this script.
-
-Phase 2 deliberately publishes no player-preference model.  The explicit
-``preference_model: null`` field is the stable hand-off point for Phase 3.
+counts and, once evidence is sufficient, a regularized conditional-choice
+model that are safe to publish. Raw events are never written by this script.
 """
 from __future__ import annotations
 
@@ -21,16 +19,33 @@ import sqlite3
 import sys
 import tempfile
 import uuid
-from collections import Counter
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 
-ARTIFACT_SCHEMA_VERSION = 2
+ARTIFACT_SCHEMA_VERSION = 3
 EVENT_SCHEMA_VERSION = 1
 MAX_MODEL_VERSIONS = 32
+MAX_PUBLISHED_PREFERENCE_MODEL_VERSIONS = 32
+PREFERENCE_VERSION_OTHER_BUCKET = "other"
+MIN_RATE_SUPPORT = 10
+MIN_MODEL_EVENTS = 240
+MIN_MODEL_SESSIONS = 40
+MIN_MODEL_DISAGREEMENTS = 30
+MIN_HOLDOUT_EVENTS = 36
+MIN_FEATURE_SUPPORT = 10
+MAX_PREFERENCE_FEATURES = 5_000
+PREFERENCE_FEATURE_SCHEMA_VERSION = 1
+PREFERENCE_MODEL_FAMILY = "conditional-choice-logit"
+PREFERENCE_L2 = 0.05
+PREFERENCE_ITERATIONS = 200
+MEANINGFUL_PREFERENCE_MARGIN = 0.10
+MIN_HELD_OUT_LOG_LOSS_IMPROVEMENT = 0.01
+PREFERENCE_QUALITY_DECIMAL_PLACES = 12
+HOLDOUT_BUCKETS = 5
 ROUND_TYPES = {
     1: "hero",
     2: "skill",
@@ -71,7 +86,10 @@ _ISO_UTC_MILLIS_RE = re.compile(
 _CORPUS_VERSION_RE = re.compile(r"^[0-9a-f]{16}$")
 _MODEL_VERSION_RE = re.compile(r"^[1-9]\d*:[0-9a-f]{16}$")
 _PREFERENCE_MODEL_VERSION_RE = re.compile(
-    r"^preference-v[1-9]\d*(?::[0-9a-f]{16})?$"
+    r"^preference-v[1-9]\d*:[0-9a-f]{16}$"
+)
+_READY_PREFERENCE_MODEL_VERSION_RE = re.compile(
+    r"^preference-v1:[0-9a-f]{16}$"
 )
 
 
@@ -676,7 +694,7 @@ def _validate_event_fields(
     if preference_version is None and preference_raw is None:
         preference_probabilities = None
     elif (
-        isinstance(preference_version, str)
+        _is_short_string(preference_version)
         and _PREFERENCE_MODEL_VERSION_RE.fullmatch(preference_version)
         and isinstance(preference_raw, str)
     ):
@@ -710,9 +728,18 @@ def _validate_event_fields(
         "round_number": round_number,
         "round_type": round_type,
         "model_version": model_version,
+        "pool_before": {
+            "heroes": list(pool_heroes),
+            "skills": list(pool_skills),
+            **({"hero_support": hero_support} if hero_support else {}),
+            **({"skills_support": list(skills_support)} if skills_support else {}),
+        },
+        "offered_sets": [list(offered_set) for offered_set in offered_sets],
+        "paired_scores": [float(score) for score in paired_scores],
         "recommended_index": recommended_index,
         "chosen_index": chosen_index,
         "preference_model_version": preference_version,
+        "preference_probabilities": preference_probabilities,
     }
 
 
@@ -746,7 +773,6 @@ def load_events(
     events: list[dict[str, Any]] = []
     event_ids: set[str] = set()
     session_rounds: set[tuple[str, int]] = set()
-    preference_versions: set[str] = set()
     invalid_event_count = 0
     for row in rows:
         try:
@@ -761,13 +787,6 @@ def load_events(
             raise InvalidTelemetryError("duplicate session_id/round_number in D1 export")
         event_ids.add(event["event_id"])
         session_rounds.add(session_round)
-        preference_version = event["preference_model_version"]
-        if isinstance(preference_version, str):
-            preference_versions.add(preference_version)
-            if len(preference_versions) > MAX_MODEL_VERSIONS:
-                raise InvalidTelemetryError(
-                    "too many preference model versions in D1 export"
-                )
         events.append(event)
     return events, invalid_event_count
 
@@ -779,11 +798,443 @@ def _version_counts(counts: Mapping[str, int]) -> list[dict[str, Any]]:
     ]
 
 
+def _published_preference_version_counts(
+    counts: Mapping[str, int],
+) -> list[dict[str, Any]]:
+    """Bound untrusted client labels and suppress one-off version fingerprints."""
+    candidates = sorted(
+        (
+            (version, count)
+            for version, count in counts.items()
+            if count >= MIN_RATE_SUPPORT
+        ),
+        key=lambda item: (-item[1], item[0]),
+    )
+    total_count = sum(counts.values())
+    all_candidates_publishable = (
+        len(candidates) <= MAX_PUBLISHED_PREFERENCE_MODEL_VERSIONS
+        and sum(count for _, count in candidates) == total_count
+    )
+    published_limit = (
+        MAX_PUBLISHED_PREFERENCE_MODEL_VERSIONS
+        if all_candidates_publishable
+        else MAX_PUBLISHED_PREFERENCE_MODEL_VERSIONS - 1
+    )
+    published = candidates[:published_limit]
+    omitted_count = total_count - sum(count for _, count in published)
+    rows = [
+        {"version": version, "event_count": count}
+        for version, count in published
+    ]
+    if omitted_count:
+        rows.append(
+            {
+                "version": PREFERENCE_VERSION_OTHER_BUCKET,
+                "event_count": omitted_count,
+            }
+        )
+    return sorted(rows, key=lambda row: row["version"])
+
+
+def _preference_feature_id(*parts: object) -> str:
+    """Use JSON arrays so catalog names cannot collide with key separators."""
+    return json.dumps(list(parts), ensure_ascii=False, separators=(",", ":"))
+
+
+def _preference_features(
+    event: Mapping[str, Any],
+    option_index: int,
+) -> dict[str, float]:
+    round_number = int(event["round_number"])
+    round_type = str(event["round_type"])
+    scores = [float(score) for score in event["paired_scores"]]
+    centered_score = (scores[option_index] - sum(scores) / 3) / 10
+    features = {
+        _preference_feature_id("score"): centered_score,
+        _preference_feature_id("round_score", round_number): centered_score,
+        _preference_feature_id("position", option_index): 1.0,
+    }
+
+    offered_items = event["offered_sets"][option_index]
+    pool = event["pool_before"]
+    pool_items = [
+        *[("hero", item) for item in pool["heroes"]],
+        *[("skill", item) for item in pool["skills"]],
+        *(
+            [("hero", pool["hero_support"])]
+            if isinstance(pool.get("hero_support"), str)
+            else []
+        ),
+        *[("skill", item) for item in pool.get("skills_support", [])],
+    ]
+    for item in offered_items:
+        features[_preference_feature_id("item", round_type, item)] = 1.0
+        for pool_type, pool_item in pool_items:
+            features[
+                _preference_feature_id(
+                    "pool_item",
+                    pool_type,
+                    pool_item,
+                    round_type,
+                    item,
+                )
+            ] = 1.0
+    return features
+
+
+def _feature_support(
+    events: Iterable[Mapping[str, Any]],
+) -> Counter[str]:
+    support: Counter[str] = Counter()
+    for event in events:
+        for option_index in range(3):
+            support.update(_preference_features(event, option_index).keys())
+    return support
+
+
+def _selected_features(
+    events: list[Mapping[str, Any]],
+) -> tuple[list[str], dict[str, int]]:
+    support = _feature_support(events)
+    eligible = sorted(
+        (
+            feature_id
+            for feature_id, count in support.items()
+            if count >= (
+                MIN_RATE_SUPPORT * 3
+                if json.loads(feature_id)[0] == "round_score"
+                else MIN_FEATURE_SUPPORT
+            )
+        ),
+        key=lambda feature_id: (-support[feature_id], feature_id),
+    )
+    selected = sorted(eligible[:MAX_PREFERENCE_FEATURES])
+    return selected, {feature_id: support[feature_id] for feature_id in selected}
+
+
+def _softmax(values: list[float]) -> list[float]:
+    maximum = max(values)
+    exponentials = [math.exp(max(-700, min(700, value - maximum))) for value in values]
+    total = sum(exponentials)
+    return [value / total for value in exponentials]
+
+
+def _quantize_preference_probabilities(
+    probabilities: list[float],
+) -> list[float]:
+    """Match the browser's largest-remainder one-decimal-percent display."""
+    scaled = [probability * 1000 for probability in probabilities]
+    units = [math.floor(value) for value in scaled]
+    remainder = 1000 - sum(units)
+    order = sorted(
+        range(3),
+        key=lambda index: (-(scaled[index] - units[index]), index),
+    )
+    for index in range(remainder):
+        units[order[index % len(order)]] += 1
+    remainder = 1000 - sum(units)
+    if remainder:
+        units[0] += remainder
+    return [value / 1000 for value in units]
+
+
+def _predict_preference(
+    event: Mapping[str, Any],
+    weights: Mapping[str, float],
+) -> list[float]:
+    utilities = []
+    for option_index in range(3):
+        utilities.append(
+            sum(
+                weights.get(feature_id, 0.0) * value
+                for feature_id, value in _preference_features(
+                    event, option_index
+                ).items()
+            )
+        )
+    return _softmax(utilities)
+
+
+def _fit_preference_model(
+    events: list[Mapping[str, Any]],
+    selected_features: list[str],
+) -> dict[str, float]:
+    weights = {feature_id: 0.0 for feature_id in selected_features}
+    selected = set(selected_features)
+    prepared = [
+        (
+            [
+                {
+                    feature_id: value
+                    for feature_id, value in _preference_features(
+                        event, option_index
+                    ).items()
+                    if feature_id in selected
+                }
+                for option_index in range(3)
+            ],
+            int(event["chosen_index"]),
+        )
+        for event in events
+    ]
+    for iteration in range(PREFERENCE_ITERATIONS):
+        gradient = {feature_id: 0.0 for feature_id in selected_features}
+        for option_features, chosen_index in prepared:
+            probabilities = _softmax(
+                [
+                    sum(weights[feature_id] * value for feature_id, value in features.items())
+                    for features in option_features
+                ]
+            )
+            for option_index, features in enumerate(option_features):
+                residual = (1.0 if option_index == chosen_index else 0.0) - probabilities[
+                    option_index
+                ]
+                for feature_id, value in features.items():
+                    gradient[feature_id] += residual * value
+
+        learning_rate = 0.25 / math.sqrt(1 + iteration / 100)
+        event_count = max(1, len(prepared))
+        for feature_id in selected_features:
+            regularized_gradient = (
+                gradient[feature_id] / event_count
+                - PREFERENCE_L2 * weights[feature_id]
+            )
+            weights[feature_id] += learning_rate * regularized_gradient
+    return {
+        feature_id: round(weights[feature_id], 12)
+        for feature_id in selected_features
+    }
+
+
+def _prediction_metrics(
+    events: list[Mapping[str, Any]],
+    probabilities: list[list[float]],
+) -> dict[str, Any]:
+    if not events:
+        return {
+            "event_count": 0,
+            "accuracy": None,
+            "log_loss": None,
+            "brier": None,
+            "calibration_error": None,
+        }
+    correct = 0
+    log_loss = 0.0
+    brier = 0.0
+    calibration_bins: dict[int, list[tuple[float, float]]] = defaultdict(list)
+    for event, event_probabilities in zip(events, probabilities, strict=True):
+        chosen_index = int(event["chosen_index"])
+        top_index = min(
+            range(3),
+            key=lambda index: (-event_probabilities[index], index),
+        )
+        correct += int(top_index == chosen_index)
+        log_loss -= math.log(max(event_probabilities[chosen_index], 1e-15))
+        brier += sum(
+            (
+                probability
+                - (1.0 if option_index == chosen_index else 0.0)
+            )
+            ** 2
+            for option_index, probability in enumerate(event_probabilities)
+        ) / 3
+        confidence = event_probabilities[top_index]
+        calibration_bins[min(9, int(confidence * 10))].append(
+            (confidence, 1.0 if top_index == chosen_index else 0.0)
+        )
+
+    count = len(events)
+    calibration_error = 0.0
+    for values in calibration_bins.values():
+        calibration_error += (
+            len(values)
+            / count
+            * abs(
+                sum(confidence for confidence, _ in values) / len(values)
+                - sum(outcome for _, outcome in values) / len(values)
+            )
+        )
+    return {
+        "event_count": count,
+        "accuracy": round(correct / count, 6),
+        "log_loss": round(
+            log_loss / count,
+            PREFERENCE_QUALITY_DECIMAL_PLACES,
+        ),
+        "brier": round(brier / count, 6),
+        "calibration_error": round(calibration_error, 6),
+    }
+
+
+def _preference_quality_gate_passes(
+    log_loss: float,
+    uniform_log_loss: float,
+) -> bool:
+    return (
+        uniform_log_loss - log_loss
+        >= MIN_HELD_OUT_LOG_LOSS_IMPROVEMENT
+    )
+
+
+def _session_is_holdout(session_id: str) -> bool:
+    digest = hashlib.sha256(session_id.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") % HOLDOUT_BUCKETS == 0
+
+
+def _preference_corpus_version(events: list[Mapping[str, Any]]) -> str:
+    payload = [
+        {
+            "event_id": event["event_id"],
+            "round_number": event["round_number"],
+            "pool_before": event["pool_before"],
+            "offered_sets": event["offered_sets"],
+            "paired_scores": event["paired_scores"],
+            "chosen_index": event["chosen_index"],
+        }
+        for event in sorted(events, key=lambda event: str(event["event_id"]))
+    ]
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def _build_preference_model(
+    events: list[Mapping[str, Any]],
+) -> tuple[dict[str, Any], dict[str, list[float]]]:
+    sessions = {str(event["session_id"]) for event in events}
+    disagreements = sum(
+        int(event["recommended_index"] != event["chosen_index"])
+        for event in events
+    )
+    train_events = [
+        event
+        for event in events
+        if not _session_is_holdout(str(event["session_id"]))
+    ]
+    holdout_events = [
+        event
+        for event in events
+        if _session_is_holdout(str(event["session_id"]))
+    ]
+    evidence = {
+        "event_count": len(events),
+        "session_count": len(sessions),
+        "recommendation_disagreement_count": disagreements,
+        "minimum_event_count": MIN_MODEL_EVENTS,
+        "minimum_session_count": MIN_MODEL_SESSIONS,
+        "minimum_recommendation_disagreement_count": MIN_MODEL_DISAGREEMENTS,
+        "holdout_event_count": len(holdout_events),
+        "minimum_holdout_event_count": MIN_HOLDOUT_EVENTS,
+    }
+    base = {
+        "model_type": PREFERENCE_MODEL_FAMILY,
+        "feature_schema_version": PREFERENCE_FEATURE_SCHEMA_VERSION,
+        "meaningful_probability_margin": MEANINGFUL_PREFERENCE_MARGIN,
+        "l2": PREFERENCE_L2,
+        "evidence": evidence,
+    }
+    sufficient = (
+        len(events) >= MIN_MODEL_EVENTS
+        and len(sessions) >= MIN_MODEL_SESSIONS
+        and disagreements >= MIN_MODEL_DISAGREEMENTS
+        and len(holdout_events) >= MIN_HOLDOUT_EVENTS
+        and bool(train_events)
+    )
+    if not sufficient:
+        return (
+            {
+                **base,
+                "status": "insufficient_evidence",
+                "version": None,
+                "held_out": None,
+                "weights": {},
+                "support": {},
+            },
+            {},
+        )
+
+    train_features, _ = _selected_features(train_events)
+    train_weights = _fit_preference_model(train_events, train_features)
+    holdout_probabilities = [
+        _predict_preference(event, train_weights) for event in holdout_events
+    ]
+    held_out = {
+        **_prediction_metrics(holdout_events, holdout_probabilities),
+        "train_event_count": len(train_events),
+        "paired_accuracy": round(
+            sum(
+                int(event["recommended_index"] == event["chosen_index"])
+                for event in holdout_events
+            )
+            / len(holdout_events),
+            6,
+        ),
+        "uniform_log_loss": round(
+            math.log(3),
+            PREFERENCE_QUALITY_DECIMAL_PLACES,
+        ),
+    }
+    if not _preference_quality_gate_passes(
+        held_out["log_loss"],
+        held_out["uniform_log_loss"],
+    ):
+        return (
+            {
+                **base,
+                "status": "quality_gate_failed",
+                "version": None,
+                "held_out": held_out,
+                "weights": {},
+                "support": {},
+            },
+            {},
+        )
+
+    selected_features, support = _selected_features(events)
+    weights = _fit_preference_model(events, selected_features)
+    version = f"preference-v1:{_preference_corpus_version(events)}"
+    predictions = {
+        str(event["event_id"]): _quantize_preference_probabilities(
+            _predict_preference(event, weights)
+        )
+        for event in events
+    }
+    return (
+        {
+            **base,
+            "status": "ready",
+            "version": version,
+            "held_out": held_out,
+            "weights": weights,
+            "support": support,
+        },
+        predictions,
+    )
+
+
+def _score_margin_bucket(margin: float) -> str:
+    if math.isclose(margin, 0.0, abs_tol=1e-9):
+        return "tie"
+    if margin <= 1:
+        return "0_to_1"
+    if margin <= 3:
+        return "1_to_3"
+    return "over_3"
+
+
 def build_artifact(
     events: Iterable[Mapping[str, Any]],
     catalog_version: str,
     invalid_event_count: int = 0,
 ) -> dict[str, Any]:
+    event_rows = list(events)
+    preference_model, preference_predictions = _build_preference_model(event_rows)
+    preference_ready = preference_model["status"] == "ready"
     round_rows = {
         number: {
             "round_number": number,
@@ -792,15 +1243,30 @@ def build_artifact(
             "recommendation_accepted_count": 0,
             "chosen_position_counts": [0, 0, 0],
             "recommended_position_counts": [0, 0, 0],
+            "rate_suppressed": True,
+            "preference_top_disagreement_count": 0 if preference_ready else None,
+            "meaningful_preference_disagreement_count": 0
+            if preference_ready
+            else None,
+            "player_preference_agreement_count": 0 if preference_ready else None,
+            "average_meaningful_preference_disagreement_margin": None,
         }
         for number, round_type in ROUND_TYPES.items()
     }
+    meaningful_disagreement_margin_totals: dict[int, float] = defaultdict(float)
+    item_counts: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    opportunity_counts: Counter[str] = Counter()
+    score_margin_counts = {
+        key: {"event_count": 0, "recommendation_accepted_count": 0}
+        for key in ("tie", "0_to_1", "1_to_3", "over_3")
+    }
     event_count = 0
+    accepted_count = 0
     sessions: set[str] = set()
     model_versions: Counter[str] = Counter()
     preference_versions: Counter[str] = Counter()
 
-    for event in events:
+    for event in event_rows:
         event_count += 1
         sessions.add(str(event["session_id"]))
         model_versions[str(event["model_version"])] += 1
@@ -816,6 +1282,96 @@ def build_artifact(
         row["chosen_position_counts"][chosen_index] += 1
         if recommended_index == chosen_index:
             row["recommendation_accepted_count"] += 1
+            accepted_count += 1
+
+        round_type = str(event["round_type"])
+        opportunity_counts[round_type] += 1
+        for offered_set in event["offered_sets"]:
+            for item in offered_set:
+                item_counts[(round_type, str(item))][0] += 1
+        for item in event["offered_sets"][chosen_index]:
+            item_counts[(round_type, str(item))][1] += 1
+
+        paired_scores = [float(score) for score in event["paired_scores"]]
+        margin = paired_scores[recommended_index] - max(
+            score
+            for index, score in enumerate(paired_scores)
+            if index != recommended_index
+        )
+        margin_row = score_margin_counts[_score_margin_bucket(max(0.0, margin))]
+        margin_row["event_count"] += 1
+        if recommended_index == chosen_index:
+            margin_row["recommendation_accepted_count"] += 1
+
+        probabilities = preference_predictions.get(str(event["event_id"]))
+        if probabilities is not None:
+            top_index = min(
+                range(3),
+                key=lambda index: (-probabilities[index], index),
+            )
+            sorted_probabilities = sorted(probabilities, reverse=True)
+            probability_margin = sorted_probabilities[0] - sorted_probabilities[1]
+            row["preference_top_disagreement_count"] += int(
+                top_index != recommended_index
+            )
+            row["meaningful_preference_disagreement_count"] += int(
+                top_index != recommended_index
+                and probability_margin >= MEANINGFUL_PREFERENCE_MARGIN
+            )
+            if (
+                top_index != recommended_index
+                and probability_margin >= MEANINGFUL_PREFERENCE_MARGIN
+            ):
+                meaningful_disagreement_margin_totals[int(event["round_number"])] += (
+                    probability_margin
+                )
+            row["player_preference_agreement_count"] += int(
+                top_index == chosen_index
+            )
+
+    for row in round_rows.values():
+        row["rate_suppressed"] = row["event_count"] < MIN_RATE_SUPPORT
+        meaningful_count = row["meaningful_preference_disagreement_count"]
+        if (
+            preference_ready
+            and isinstance(meaningful_count, int)
+            and meaningful_count >= MIN_RATE_SUPPORT
+        ):
+            row["average_meaningful_preference_disagreement_margin"] = round(
+                meaningful_disagreement_margin_totals[row["round_number"]]
+                / meaningful_count,
+                6,
+            )
+
+    items = {"heroes": [], "skills": []}
+    for (round_type, item), (offer_count, picked_count) in sorted(item_counts.items()):
+        family = "heroes" if round_type == "hero" else "skills"
+        items[family].append(
+            {
+                "name": item,
+                "offer_count": offer_count,
+                "opportunity_count": opportunity_counts[round_type],
+                "picked_count": picked_count,
+                "rate_suppressed": offer_count < MIN_RATE_SUPPORT,
+            }
+        )
+
+    score_margins = []
+    for key, label in (
+        ("tie", "并列"),
+        ("0_to_1", "0–1 分"),
+        ("1_to_3", "1–3 分"),
+        ("over_3", "超过 3 分"),
+    ):
+        counts = score_margin_counts[key]
+        score_margins.append(
+            {
+                "key": key,
+                "label": label,
+                **counts,
+                "rate_suppressed": counts["event_count"] < MIN_RATE_SUPPORT,
+            }
+        )
 
     artifact = {
         "schema": {
@@ -827,24 +1383,84 @@ def build_artifact(
             "event_count": event_count,
             "invalid_event_count": invalid_event_count,
             "session_count": len(sessions),
+            "recommendation_accepted_count": accepted_count,
             "preference_event_count": sum(preference_versions.values()),
             "model_versions": _version_counts(model_versions),
-            "preference_model_versions": _version_counts(preference_versions),
+            "preference_model_versions": _published_preference_version_counts(
+                preference_versions
+            ),
         },
         "rounds": list(round_rows.values()),
-        "preference_model": None,
+        "analytics": {
+            "minimum_rate_support": MIN_RATE_SUPPORT,
+            "items": items,
+            "score_margins": score_margins,
+        },
+        "preference_model": preference_model,
     }
     validate_artifact(artifact)
     return artifact
 
 
+def _preference_feature_parts(feature_id: Any) -> list[Any] | None:
+    if not _is_short_string(feature_id, 512):
+        return None
+    try:
+        parts = json.loads(feature_id)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parts, list) or not parts:
+        return None
+    if _preference_feature_id(*parts) != feature_id:
+        return None
+    kind = parts[0]
+    if parts == ["score"]:
+        return parts
+    if (
+        kind == "round_score"
+        and len(parts) == 2
+        and _is_int(parts[1])
+        and parts[1] in ROUND_TYPES
+    ):
+        return parts
+    if (
+        kind == "position"
+        and len(parts) == 2
+        and _is_int(parts[1])
+        and parts[1] in range(3)
+    ):
+        return parts
+    if (
+        kind == "item"
+        and len(parts) == 3
+        and parts[1] in {"hero", "skill"}
+        and _is_short_string(parts[2], 64)
+    ):
+        return parts
+    if (
+        kind == "pool_item"
+        and len(parts) == 5
+        and parts[1] in {"hero", "skill"}
+        and _is_short_string(parts[2], 64)
+        and parts[3] in {"hero", "skill"}
+        and _is_short_string(parts[4], 64)
+    ):
+        return parts
+    return None
+
+
+def _minimum_preference_feature_support(parts: list[Any]) -> int:
+    return MIN_RATE_SUPPORT * 3 if parts[0] == "round_score" else MIN_FEATURE_SUPPORT
+
+
 def validate_artifact(artifact: Mapping[str, Any]) -> None:
-    """Fail closed if aggregation or future model wiring emits bad output."""
+    """Fail closed if aggregation or preference-model wiring emits bad output."""
     if set(artifact) != {
         "schema",
         "catalog_version",
         "summary",
         "rounds",
+        "analytics",
         "preference_model",
     }:
         raise InvalidTelemetryError("telemetry artifact has unexpected fields")
@@ -855,8 +1471,34 @@ def validate_artifact(artifact: Mapping[str, Any]) -> None:
         raise InvalidTelemetryError("telemetry artifact schema is invalid")
     if not _is_short_string(artifact["catalog_version"]):
         raise InvalidTelemetryError("telemetry artifact catalog_version is invalid")
-    if artifact["preference_model"] is not None:
-        raise InvalidTelemetryError("Phase 2 preference_model must be null")
+
+    preference_model = artifact["preference_model"]
+    preference_model_keys = {
+        "model_type",
+        "feature_schema_version",
+        "meaningful_probability_margin",
+        "l2",
+        "evidence",
+        "status",
+        "version",
+        "held_out",
+        "weights",
+        "support",
+    }
+    if (
+        not isinstance(preference_model, dict)
+        or set(preference_model) != preference_model_keys
+        or preference_model["model_type"] != PREFERENCE_MODEL_FAMILY
+        or preference_model["feature_schema_version"]
+        != PREFERENCE_FEATURE_SCHEMA_VERSION
+        or preference_model["meaningful_probability_margin"]
+        != MEANINGFUL_PREFERENCE_MARGIN
+        or preference_model["l2"] != PREFERENCE_L2
+        or preference_model["status"]
+        not in {"insufficient_evidence", "quality_gate_failed", "ready"}
+    ):
+        raise InvalidTelemetryError("telemetry preference_model contract is invalid")
+    preference_ready = preference_model["status"] == "ready"
 
     summary = artifact["summary"]
     rounds = artifact["rounds"]
@@ -875,6 +1517,11 @@ def validate_artifact(artifact: Mapping[str, Any]) -> None:
             "recommendation_accepted_count",
             "chosen_position_counts",
             "recommended_position_counts",
+            "rate_suppressed",
+            "preference_top_disagreement_count",
+            "meaningful_preference_disagreement_count",
+            "player_preference_agreement_count",
+            "average_meaningful_preference_disagreement_margin",
         } or row["round_type"] != ROUND_TYPES[number]:
             raise InvalidTelemetryError(f"telemetry artifact round {number} is invalid")
         event_count = row["event_count"]
@@ -892,14 +1539,65 @@ def validate_artifact(artifact: Mapping[str, Any]) -> None:
             or any(not _is_int(count) or count < 0 for count in chosen_counts + recommended_counts)
             or sum(chosen_counts) != event_count
             or sum(recommended_counts) != event_count
+            or row["rate_suppressed"] != (event_count < MIN_RATE_SUPPORT)
         ):
             raise InvalidTelemetryError(f"telemetry artifact round {number} counts are invalid")
+        preference_counts = (
+            row["preference_top_disagreement_count"],
+            row["meaningful_preference_disagreement_count"],
+            row["player_preference_agreement_count"],
+        )
+        if preference_ready:
+            if any(
+                not _is_int(count) or not 0 <= count <= event_count
+                for count in preference_counts
+            ):
+                raise InvalidTelemetryError(
+                    f"telemetry artifact round {number} preference counts are invalid"
+                )
+            if (
+                row["meaningful_preference_disagreement_count"]
+                > row["preference_top_disagreement_count"]
+            ):
+                raise InvalidTelemetryError(
+                    f"telemetry artifact round {number} preference counts are inconsistent"
+                )
+            meaningful_count = row[
+                "meaningful_preference_disagreement_count"
+            ]
+            average_margin = row[
+                "average_meaningful_preference_disagreement_margin"
+            ]
+            if meaningful_count >= MIN_RATE_SUPPORT:
+                if (
+                    isinstance(average_margin, bool)
+                    or not isinstance(average_margin, (int, float))
+                    or not MEANINGFUL_PREFERENCE_MARGIN
+                    <= average_margin
+                    <= 1
+                ):
+                    raise InvalidTelemetryError(
+                        f"telemetry artifact round {number} disagreement margin is invalid"
+                    )
+            elif average_margin is not None:
+                raise InvalidTelemetryError(
+                    f"telemetry artifact round {number} low-support disagreement margin must be null"
+                )
+        elif any(count is not None for count in preference_counts):
+            raise InvalidTelemetryError(
+                f"telemetry artifact round {number} preference counts must be null"
+            )
+        elif row["average_meaningful_preference_disagreement_margin"] is not None:
+            raise InvalidTelemetryError(
+                f"telemetry artifact round {number} preference margin must be null"
+            )
         total_events += event_count
 
     required_summary = {
         "event_count",
         "invalid_event_count",
         "session_count",
+        "recommendation_accepted_count",
         "preference_event_count",
         "model_versions",
         "preference_model_versions",
@@ -916,6 +1614,14 @@ def validate_artifact(artifact: Mapping[str, Any]) -> None:
     for field in ("session_count", "preference_event_count"):
         if not _is_int(summary[field]) or not 0 <= summary[field] <= total_events:
             raise InvalidTelemetryError(f"telemetry artifact {field} is invalid")
+    if (
+        not _is_int(summary["recommendation_accepted_count"])
+        or summary["recommendation_accepted_count"]
+        != sum(row["recommendation_accepted_count"] for row in rounds)
+    ):
+        raise InvalidTelemetryError(
+            "telemetry artifact recommendation_accepted_count is invalid"
+        )
     for field, expected_total in (
         ("model_versions", total_events),
         ("preference_model_versions", summary["preference_event_count"]),
@@ -933,9 +1639,262 @@ def validate_artifact(artifact: Mapping[str, Any]) -> None:
                 for entry in versions
             )
             or sum(entry["event_count"] for entry in versions) != expected_total
+            or len({entry["version"] for entry in versions}) != len(versions)
+        ):
+            raise InvalidTelemetryError(f"telemetry artifact {field} is invalid")
+        if field == "model_versions" and (
+            len(versions) > MAX_MODEL_VERSIONS
+            or any(
+                not _MODEL_VERSION_RE.fullmatch(entry["version"])
+                for entry in versions
+            )
+        ):
+            raise InvalidTelemetryError(f"telemetry artifact {field} is invalid")
+        if field == "preference_model_versions" and (
+            len(versions) > MAX_PUBLISHED_PREFERENCE_MODEL_VERSIONS
+            or any(
+                entry["version"] != PREFERENCE_VERSION_OTHER_BUCKET
+                and (
+                    not _PREFERENCE_MODEL_VERSION_RE.fullmatch(entry["version"])
+                    or entry["event_count"] < MIN_RATE_SUPPORT
+                )
+                for entry in versions
+            )
         ):
             raise InvalidTelemetryError(f"telemetry artifact {field} is invalid")
 
+    evidence = preference_model["evidence"]
+    required_evidence = {
+        "event_count",
+        "session_count",
+        "recommendation_disagreement_count",
+        "minimum_event_count",
+        "minimum_session_count",
+        "minimum_recommendation_disagreement_count",
+        "holdout_event_count",
+        "minimum_holdout_event_count",
+    }
+    if (
+        not isinstance(evidence, dict)
+        or set(evidence) != required_evidence
+        or any(not _is_int(value) or value < 0 for value in evidence.values())
+        or evidence["event_count"] != total_events
+        or evidence["session_count"] != summary["session_count"]
+        or evidence["recommendation_disagreement_count"]
+        != total_events - summary["recommendation_accepted_count"]
+        or evidence["minimum_event_count"] != MIN_MODEL_EVENTS
+        or evidence["minimum_session_count"] != MIN_MODEL_SESSIONS
+        or evidence["minimum_recommendation_disagreement_count"]
+        != MIN_MODEL_DISAGREEMENTS
+        or evidence["minimum_holdout_event_count"] != MIN_HOLDOUT_EVENTS
+        or evidence["holdout_event_count"] > total_events
+    ):
+        raise InvalidTelemetryError("telemetry preference evidence is invalid")
+    evidence_sufficient = (
+        evidence["event_count"] >= evidence["minimum_event_count"]
+        and evidence["session_count"] >= evidence["minimum_session_count"]
+        and evidence["recommendation_disagreement_count"]
+        >= evidence["minimum_recommendation_disagreement_count"]
+        and evidence["holdout_event_count"]
+        >= evidence["minimum_holdout_event_count"]
+    )
+
+    weights = preference_model["weights"]
+    support = preference_model["support"]
+    held_out = preference_model["held_out"]
+    if not isinstance(weights, dict) or not isinstance(support, dict):
+        raise InvalidTelemetryError("telemetry preference coefficients are invalid")
+    if preference_ready:
+        if (
+            not isinstance(preference_model["version"], str)
+            or not _READY_PREFERENCE_MODEL_VERSION_RE.fullmatch(
+                preference_model["version"]
+            )
+            or not weights
+            or len(weights) > MAX_PREFERENCE_FEATURES
+            or set(weights) != set(support)
+            or any(
+                _preference_feature_parts(feature_id) is None
+                or isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+                for feature_id, value in weights.items()
+            )
+            or any(
+                (parts := _preference_feature_parts(feature_id)) is None
+                or not _is_int(value)
+                or value < _minimum_preference_feature_support(parts)
+                for feature_id, value in support.items()
+            )
+        ):
+            raise InvalidTelemetryError("telemetry ready preference model is invalid")
+    elif preference_model["version"] is not None or weights or support:
+        raise InvalidTelemetryError(
+            "telemetry unavailable preference model must not publish coefficients"
+        )
+
+    if preference_model["status"] == "insufficient_evidence":
+        if held_out is not None or (
+            evidence_sufficient
+            and evidence["holdout_event_count"] != evidence["event_count"]
+        ):
+            raise InvalidTelemetryError(
+                "insufficient preference model status is inconsistent"
+            )
+    else:
+        required_held_out = {
+            "event_count",
+            "accuracy",
+            "log_loss",
+            "brier",
+            "calibration_error",
+            "train_event_count",
+            "paired_accuracy",
+            "uniform_log_loss",
+        }
+        if (
+            not isinstance(held_out, dict)
+            or set(held_out) != required_held_out
+            or held_out["event_count"] != evidence["holdout_event_count"]
+            or not _is_int(held_out["train_event_count"])
+            or held_out["train_event_count"] <= 0
+            or held_out["train_event_count"] + held_out["event_count"] != total_events
+            or any(
+                isinstance(held_out[field], bool)
+                or not isinstance(held_out[field], (int, float))
+                or not math.isfinite(held_out[field])
+                for field in (
+                    "accuracy",
+                    "log_loss",
+                    "brier",
+                    "calibration_error",
+                    "paired_accuracy",
+                    "uniform_log_loss",
+                )
+            )
+            or any(
+                not 0 <= held_out[field] <= 1
+                for field in (
+                    "accuracy",
+                    "brier",
+                    "calibration_error",
+                    "paired_accuracy",
+                )
+            )
+            or held_out["log_loss"] < 0
+            or held_out["log_loss"]
+            != round(
+                held_out["log_loss"],
+                PREFERENCE_QUALITY_DECIMAL_PLACES,
+            )
+            or held_out["uniform_log_loss"] < 0
+            or held_out["uniform_log_loss"]
+            != round(math.log(3), PREFERENCE_QUALITY_DECIMAL_PLACES)
+            or not evidence_sufficient
+        ):
+            raise InvalidTelemetryError(
+                "telemetry preference held-out metrics are invalid"
+            )
+        quality_passed = _preference_quality_gate_passes(
+            held_out["log_loss"],
+            held_out["uniform_log_loss"],
+        )
+        if preference_ready != quality_passed:
+            raise InvalidTelemetryError(
+                "telemetry preference model status does not match its quality gate"
+            )
+
+    analytics = artifact["analytics"]
+    if (
+        not isinstance(analytics, dict)
+        or set(analytics)
+        != {
+            "minimum_rate_support",
+            "items",
+            "score_margins",
+        }
+        or analytics["minimum_rate_support"] != MIN_RATE_SUPPORT
+    ):
+        raise InvalidTelemetryError("telemetry analytics contract is invalid")
+
+    items = analytics["items"]
+    if not isinstance(items, dict) or set(items) != {"heroes", "skills"}:
+        raise InvalidTelemetryError("telemetry item analytics are invalid")
+    type_event_counts = {
+        "heroes": sum(
+            row["event_count"] for row in rounds if row["round_type"] == "hero"
+        ),
+        "skills": sum(
+            row["event_count"] for row in rounds if row["round_type"] == "skill"
+        ),
+    }
+    for family in ("heroes", "skills"):
+        rows = items[family]
+        if (
+            not isinstance(rows, list)
+            or rows != sorted(rows, key=lambda row: row.get("name", ""))
+            or len({row.get("name") for row in rows if isinstance(row, dict)})
+            != len(rows)
+        ):
+            raise InvalidTelemetryError(f"telemetry {family} analytics are invalid")
+        for row in rows:
+            if (
+                not isinstance(row, dict)
+                or set(row)
+                != {
+                    "name",
+                    "offer_count",
+                    "opportunity_count",
+                    "picked_count",
+                    "rate_suppressed",
+                }
+                or not _is_short_string(row["name"], 64)
+                or not _is_int(row["offer_count"])
+                or row["offer_count"] <= 0
+                or not _is_int(row["opportunity_count"])
+                or row["opportunity_count"] != type_event_counts[family]
+                or row["offer_count"] > row["opportunity_count"]
+                or not _is_int(row["picked_count"])
+                or not 0 <= row["picked_count"] <= row["offer_count"]
+                or row["rate_suppressed"]
+                != (row["offer_count"] < MIN_RATE_SUPPORT)
+            ):
+                raise InvalidTelemetryError(
+                    f"telemetry {family} item row is invalid"
+                )
+
+    margin_rows = analytics["score_margins"]
+    margin_keys = ["tie", "0_to_1", "1_to_3", "over_3"]
+    if (
+        not isinstance(margin_rows, list)
+        or [row.get("key") for row in margin_rows if isinstance(row, dict)]
+        != margin_keys
+        or sum(row["event_count"] for row in margin_rows) != total_events
+        or sum(row["recommendation_accepted_count"] for row in margin_rows)
+        != summary["recommendation_accepted_count"]
+    ):
+        raise InvalidTelemetryError("telemetry score-margin analytics are invalid")
+    for row in margin_rows:
+        if (
+            set(row)
+            != {
+                "key",
+                "label",
+                "event_count",
+                "recommendation_accepted_count",
+                "rate_suppressed",
+            }
+            or not _is_short_string(row["label"])
+            or not _is_int(row["event_count"])
+            or row["event_count"] < 0
+            or not _is_int(row["recommendation_accepted_count"])
+            or not 0
+            <= row["recommendation_accepted_count"]
+            <= row["event_count"]
+            or row["rate_suppressed"]
+            != (row["event_count"] < MIN_RATE_SUPPORT)
+        ):
+            raise InvalidTelemetryError("telemetry score-margin row is invalid")
 
 def write_artifact(artifact: Mapping[str, Any], output_path: Path) -> None:
     """Atomically write canonical JSON after every validation has passed."""

--- a/data/test_build_telemetry_data.py
+++ b/data/test_build_telemetry_data.py
@@ -3,16 +3,26 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import sqlite3
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from build_telemetry_data import (  # noqa: E402
     InvalidTelemetryError,
+    MAX_PUBLISHED_PREFERENCE_MODEL_VERSIONS,
+    MAX_PREFERENCE_FEATURES,
+    PREFERENCE_QUALITY_DECIMAL_PLACES,
+    PREFERENCE_VERSION_OTHER_BUCKET,
+    _build_preference_model,
+    _published_preference_version_counts,
+    _quantize_preference_probabilities,
+    _session_is_holdout,
     build,
     build_artifact,
     load_catalog,
@@ -212,7 +222,20 @@ class TelemetryBuilderTests(unittest.TestCase):
         )
         self.assertEqual(artifact["rounds"][0]["recommendation_accepted_count"], 1)
         self.assertEqual(artifact["rounds"][1]["chosen_position_counts"], [0, 1, 0])
-        self.assertIsNone(artifact["preference_model"])
+        self.assertEqual(
+            artifact["preference_model"]["status"], "insufficient_evidence"
+        )
+        self.assertIsNone(artifact["preference_model"]["version"])
+        self.assertEqual(artifact["summary"]["recommendation_accepted_count"], 1)
+        self.assertEqual(artifact["analytics"]["minimum_rate_support"], 10)
+        self.assertTrue(
+            artifact["analytics"]["items"]["heroes"][0]["rate_suppressed"]
+        )
+        invalid_offer_count = json.loads(json.dumps(artifact))
+        invalid_item = invalid_offer_count["analytics"]["items"]["heroes"][0]
+        invalid_item["offer_count"] = invalid_item["opportunity_count"] + 1
+        with self.assertRaisesRegex(InvalidTelemetryError, "item row"):
+            validate_artifact(invalid_offer_count)
         serialized = first_bytes.decode("utf-8")
         self.assertNotIn("event_id", serialized)
         self.assertNotIn("session_id", serialized)
@@ -449,16 +472,83 @@ class TelemetryBuilderTests(unittest.TestCase):
         self.assertEqual(artifact["summary"]["event_count"], 0)
         self.assertEqual(artifact["summary"]["invalid_event_count"], 1)
 
-    def test_future_preference_probabilities_are_validated_and_counted(self) -> None:
+    def test_future_preference_probabilities_are_validated_and_privately_counted(
+        self,
+    ) -> None:
         row = list(_event(self.catalog_version))
-        row[14] = "preference-v1"
+        row[14] = "preference-v1:0000000000000001"
         row[15] = json.dumps([0.2, 0.3, 0.5])
         _write_export(self.export_path, [tuple(row)])
         artifact = self._build()
         self.assertEqual(artifact["summary"]["preference_event_count"], 1)
         self.assertEqual(
             artifact["summary"]["preference_model_versions"],
-            [{"version": "preference-v1", "event_count": 1}],
+            [{"version": PREFERENCE_VERSION_OTHER_BUCKET, "event_count": 1}],
+        )
+
+    def test_untrusted_preference_version_cardinality_is_bounded_not_fatal(
+        self,
+    ) -> None:
+        rows = []
+        for index in range(1, 514):
+            row = list(_event(self.catalog_version, suffix=index))
+            row[14] = f"preference-v1:{index:016x}"
+            row[15] = json.dumps([0.0, 0.0, 1.0])
+            rows.append(tuple(row))
+        _write_export(self.export_path, rows)
+
+        artifact = self._build()
+
+        self.assertEqual(artifact["summary"]["event_count"], 513)
+        self.assertEqual(artifact["summary"]["preference_event_count"], 513)
+        self.assertEqual(
+            artifact["summary"]["preference_model_versions"],
+            [
+                {
+                    "version": PREFERENCE_VERSION_OTHER_BUCKET,
+                    "event_count": 513,
+                }
+            ],
+        )
+        self.assertEqual(
+            artifact["preference_model"]["status"],
+            "insufficient_evidence",
+        )
+        self.assertNotIn(
+            "preference-v1:0000000000000001",
+            self.output_path.read_text(encoding="utf-8"),
+        )
+
+    def test_preference_version_bucket_is_deterministic_and_preserves_total(
+        self,
+    ) -> None:
+        counts = {
+            f"preference-v1:{index:016x}": 10 + index
+            for index in range(40)
+        }
+        reversed_counts = dict(reversed(list(counts.items())))
+
+        rows = _published_preference_version_counts(counts)
+
+        self.assertEqual(
+            rows,
+            _published_preference_version_counts(reversed_counts),
+        )
+        self.assertEqual(
+            len(rows),
+            MAX_PUBLISHED_PREFERENCE_MODEL_VERSIONS,
+        )
+        self.assertEqual(
+            sum(row["event_count"] for row in rows),
+            sum(counts.values()),
+        )
+        self.assertEqual(
+            next(
+                row["event_count"]
+                for row in rows
+                if row["version"] == PREFERENCE_VERSION_OTHER_BUCKET
+            ),
+            sum(10 + index for index in range(9)),
         )
 
     def test_database_and_recommendation_catalogs_must_match(self) -> None:
@@ -468,11 +558,262 @@ class TelemetryBuilderTests(unittest.TestCase):
         with self.assertRaisesRegex(InvalidTelemetryError, "catalog mismatch"):
             load_catalog(self.database_path, self.recommendation_path)
 
-    def test_artifact_validation_rejects_non_null_phase_two_model(self) -> None:
+    def test_artifact_validation_rejects_invalid_preference_model(self) -> None:
         artifact = build_artifact([], self.catalog_version)
         artifact["preference_model"] = {"version": "too-early"}
-        with self.assertRaisesRegex(InvalidTelemetryError, "must be null"):
+        with self.assertRaisesRegex(InvalidTelemetryError, "contract"):
             validate_artifact(artifact)
+
+    def test_full_corpus_predictions_use_browser_display_quantization(self) -> None:
+        raw_tie = [0.3337, 0.3325, 0.3338]
+        displayed_tie = _quantize_preference_probabilities(raw_tie)
+        self.assertEqual(displayed_tie, [0.334, 0.332, 0.334])
+        self.assertEqual(
+            min(range(3), key=lambda index: (-displayed_tie[index], index)),
+            0,
+        )
+        self.assertEqual(
+            min(range(3), key=lambda index: (-raw_tie[index], index)),
+            2,
+        )
+
+        raw_margin = [0.4002, 0.30025, 0.29955]
+        displayed_margin = _quantize_preference_probabilities(raw_margin)
+        self.assertEqual(displayed_margin, [0.4, 0.3, 0.3])
+        self.assertLess(raw_margin[0] - raw_margin[1], 0.1)
+        self.assertGreaterEqual(
+            displayed_margin[0] - displayed_margin[1],
+            0.1,
+        )
+
+    def test_quality_gate_uses_precise_stored_values_at_rounding_boundary(
+        self,
+    ) -> None:
+        events = [
+            {
+                "event_id": f"00000000-0000-4000-8000-{index:012d}",
+                "session_id": f"10000000-0000-4000-8000-{index:012d}",
+                "round_number": 1,
+                "round_type": "hero",
+                "model_version": MODEL_VERSION,
+                "pool_before": {"heroes": [], "skills": []},
+                "offered_sets": [["A"], ["B"], ["C"]],
+                "paired_scores": [0.0, 0.0, 0.0],
+                "recommended_index": 1,
+                "chosen_index": 0,
+                "preference_model_version": None,
+                "preference_probabilities": None,
+            }
+            for index in range(1, 241)
+        ]
+        stored_baseline = round(
+            math.log(3),
+            PREFERENCE_QUALITY_DECIMAL_PLACES,
+        )
+
+        def zero_weights(
+            _events: list[dict],
+            selected_features: list[str],
+        ) -> dict[str, float]:
+            return {feature_id: 0.0 for feature_id in selected_features}
+
+        for offset, expected_status in (
+            (0.0, "ready"),
+            (1e-7, "quality_gate_failed"),
+        ):
+            with self.subTest(offset=offset):
+                target_log_loss = (
+                    stored_baseline - 0.01 + offset
+                )
+                chosen_probability = math.exp(-target_log_loss)
+                probabilities = [
+                    chosen_probability,
+                    (1 - chosen_probability) / 2,
+                    (1 - chosen_probability) / 2,
+                ]
+                with patch(
+                    "build_telemetry_data._fit_preference_model",
+                    side_effect=zero_weights,
+                ), patch(
+                    "build_telemetry_data._predict_preference",
+                    return_value=probabilities,
+                ):
+                    artifact = build_artifact(events, self.catalog_version)
+
+                model = artifact["preference_model"]
+                self.assertEqual(model["status"], expected_status)
+                self.assertEqual(
+                    model["held_out"]["log_loss"],
+                    round(
+                        target_log_loss,
+                        PREFERENCE_QUALITY_DECIMAL_PLACES,
+                    ),
+                )
+                validate_artifact(artifact)
+
+    def test_trains_session_held_out_conditional_choice_model_after_evidence_gate(
+        self,
+    ) -> None:
+        rows = [
+            _event(
+                self.catalog_version,
+                suffix=index,
+                round_number=(index % 6) + 1,
+                chosen_index=1 if index % 4 == 0 else 0,
+            )
+            for index in range(1, 241)
+        ]
+        _write_export(self.export_path, rows)
+
+        artifact = self._build()
+        first_bytes = self.output_path.read_bytes()
+        artifact_again = self._build()
+
+        model = artifact["preference_model"]
+        self.assertEqual(artifact, artifact_again)
+        self.assertEqual(first_bytes, self.output_path.read_bytes())
+        self.assertEqual(model["status"], "ready")
+        self.assertRegex(model["version"], r"^preference-v1:[0-9a-f]{16}$")
+        self.assertTrue(model["weights"])
+        self.assertEqual(set(model["weights"]), set(model["support"]))
+        self.assertGreaterEqual(model["held_out"]["event_count"], 36)
+        self.assertLessEqual(
+            model["held_out"]["log_loss"],
+            model["held_out"]["uniform_log_loss"] - 0.01 + 1e-6,
+        )
+        self.assertEqual(
+            artifact["summary"]["recommendation_accepted_count"], 180
+        )
+        self.assertTrue(
+            all(
+                row["preference_top_disagreement_count"] is not None
+                for row in artifact["rounds"]
+            )
+        )
+        self.assertNotIn("pool_before", self.output_path.read_text(encoding="utf-8"))
+
+        invalid_feature = json.loads(json.dumps(artifact))
+        invalid_feature["preference_model"]["weights"] = {"event_id": 1.0}
+        invalid_feature["preference_model"]["support"] = {"event_id": 240}
+        with self.assertRaisesRegex(InvalidTelemetryError, "preference model"):
+            validate_artifact(invalid_feature)
+
+        low_support = json.loads(json.dumps(artifact))
+        low_support["preference_model"]["weights"]['["round_score",8]'] = 0.5
+        low_support["preference_model"]["support"]['["round_score",8]'] = 3
+        with self.assertRaisesRegex(InvalidTelemetryError, "preference model"):
+            validate_artifact(low_support)
+
+        unhashed_version = json.loads(json.dumps(artifact))
+        unhashed_version["preference_model"]["version"] = "preference-v1"
+        with self.assertRaisesRegex(InvalidTelemetryError, "preference model"):
+            validate_artifact(unhashed_version)
+
+        unsupported_hashed_version = json.loads(json.dumps(artifact))
+        unsupported_hashed_version["preference_model"][
+            "version"
+        ] = "preference-v2:0000000000000001"
+        with self.assertRaisesRegex(InvalidTelemetryError, "preference model"):
+            validate_artifact(unsupported_hashed_version)
+
+        zero_train_events = json.loads(json.dumps(artifact))
+        total_events = zero_train_events["summary"]["event_count"]
+        zero_train_events["preference_model"]["evidence"][
+            "holdout_event_count"
+        ] = total_events
+        zero_train_events["preference_model"]["held_out"][
+            "event_count"
+        ] = total_events
+        zero_train_events["preference_model"]["held_out"][
+            "train_event_count"
+        ] = 0
+        with self.assertRaisesRegex(InvalidTelemetryError, "held-out metrics"):
+            validate_artifact(zero_train_events)
+
+        noncanonical_feature = json.loads(json.dumps(artifact))
+        score_weight = noncanonical_feature["preference_model"]["weights"].pop(
+            '["score"]'
+        )
+        score_support = noncanonical_feature["preference_model"]["support"].pop(
+            '["score"]'
+        )
+        noncanonical_feature["preference_model"]["weights"][
+            '[ "score" ]'
+        ] = score_weight
+        noncanonical_feature["preference_model"]["support"][
+            '[ "score" ]'
+        ] = score_support
+        with self.assertRaisesRegex(InvalidTelemetryError, "preference model"):
+            validate_artifact(noncanonical_feature)
+
+        too_many_features = json.loads(json.dumps(artifact))
+        oversized_weights = {
+            json.dumps(
+                ["item", "hero", f"item-{index}"],
+                separators=(",", ":"),
+            ): 0.0
+            for index in range(MAX_PREFERENCE_FEATURES + 1)
+        }
+        too_many_features["preference_model"]["weights"] = oversized_weights
+        too_many_features["preference_model"]["support"] = {
+            feature_id: 10 for feature_id in oversized_weights
+        }
+        with self.assertRaisesRegex(InvalidTelemetryError, "preference model"):
+            validate_artifact(too_many_features)
+
+        failed_quality = json.loads(json.dumps(artifact))
+        failed_quality["preference_model"]["held_out"]["log_loss"] = failed_quality[
+            "preference_model"
+        ]["held_out"]["uniform_log_loss"]
+        with self.assertRaisesRegex(InvalidTelemetryError, "quality gate"):
+            validate_artifact(failed_quality)
+
+    def test_no_signal_model_fails_the_held_out_quality_gate(self) -> None:
+        events = []
+        train_count = 0
+        holdout_count = 0
+        suffix = 1
+        while train_count < 192 or holdout_count < 48:
+            session_id = f"10000000-0000-4000-8000-{suffix:012d}"
+            is_holdout = _session_is_holdout(session_id)
+            if (is_holdout and holdout_count >= 48) or (
+                not is_holdout and train_count >= 192
+            ):
+                suffix += 1
+                continue
+            group_index = holdout_count if is_holdout else train_count
+            chosen_index = group_index % 3
+            if is_holdout:
+                holdout_count += 1
+            else:
+                train_count += 1
+            events.append(
+                {
+                    "event_id": f"00000000-0000-4000-8000-{suffix:012d}",
+                    "session_id": session_id,
+                    "round_number": 1,
+                    "round_type": "hero",
+                    "model_version": MODEL_VERSION,
+                    "pool_before": {"heroes": [], "skills": []},
+                    "offered_sets": [["A"], ["B"], ["C"]],
+                    "paired_scores": [0.0, 0.0, 0.0],
+                    "recommended_index": 0,
+                    "chosen_index": chosen_index,
+                    "preference_model_version": None,
+                    "preference_probabilities": None,
+                }
+            )
+            suffix += 1
+
+        model, predictions = _build_preference_model(events)
+
+        self.assertEqual(model["status"], "quality_gate_failed")
+        self.assertEqual(
+            model["held_out"]["log_loss"],
+            round(math.log(3), PREFERENCE_QUALITY_DECIMAL_PLACES),
+        )
+        self.assertEqual(model["weights"], {})
+        self.assertEqual(predictions, {})
 
 
 if __name__ == "__main__":

--- a/web/README.md
+++ b/web/README.md
@@ -122,12 +122,17 @@ web/
 
 ### Analytics
 - **Analytics**: Player-friendly dashboard driven by the generated paired-model artifact
-- A separate **玩家选择洞察** (player-choice insights) section, driven by
-  `public/game-data/telemetry_data.json`, reports offer/pick counts, AI-recommendation
-  acceptance, per-round historical agreement and position bias, score-margin behaviour,
-  and meaningful paired-vs-preference disagreements. It only describes how players chose
-  (never win rate, never AI scoring); percentages below the support threshold are hidden,
-  and preference-model status/held-out metrics surface only once the gates pass.
+- A separate **玩家最关心的选择排行** section is shown when
+  `public/game-data/telemetry_data.json` contains schema-v3 item analytics. Its compact
+  武将/战法 toggle switches two responsive top-five cards: **系统最常提供** ranks by
+  offer count and shows offer rate, while **玩家最常选择** ranks by pick count and shows
+  the conditional picked-when-offered rate. Ties use a deterministic name ordering,
+  horizontal bars are relative to each card's leader, counts always remain visible, and
+  low-support percentages display `样本不足`.
+- The telemetry artifact still retains diagnostic round, position, score-margin,
+  recommendation-agreement, preference-model status/evidence, and held-out aggregates,
+  but Analytics does not show them in this player-facing ranking section. Schema-v2
+  artifacts have no item analytics, so the section is omitted entirely.
 - Question-led layout with a plain-language guide to the three player-facing measures:
   胜率参考 (smoothed win rate), 组合分 (combo score — the model's extra pairing/hero-skill
   bonus, shown only on the synergy tables), and 参考场次 (reference battles). Individual

--- a/web/README.md
+++ b/web/README.md
@@ -179,10 +179,13 @@ per-game session ID. See the root
 data contract and storage details.
 
 The static `public/game-data/telemetry_data.json` file contains deterministic
-aggregate counts only. It deliberately contains no event IDs, session IDs,
-timestamps, pools, offers, choices, or other row-level data. The Phase 2
-preference model is `null`; the browser continues to use only the paired battle
-model for recommendations.
+aggregate player-choice counts and, after its evidence/quality gates pass, a
+regularized conditional-choice model. It deliberately contains no event IDs,
+session IDs, timestamps, pools, offers, choices, or other row-level data. The
+browser continues to use only the paired battle model for recommendations; the
+preference model supplies a separately labelled player-choice probability and
+is omitted from the option cards unless both its evidence and held-out quality
+gates pass.
 
 ## Cloudflare telemetry setup
 
@@ -218,7 +221,8 @@ manually. Configure it in the repository settings:
    scoped `contents: write` permission can push the changed generated file.
 
 The workflow exports only `round_telemetry` to `$RUNNER_TEMP`, runs the builder,
-and stages only `web/public/game-data/telemetry_data.json`. The builder fails
+then runs the web type-check, unit tests, and production build against the new
+artifact before staging only `web/public/game-data/telemetry_data.json`. The builder fails
 closed for unverifiable schema/catalog/model contracts, while quarantining
 individual malformed or impossible events and publishing only their aggregate
 `invalid_event_count`. It does not upload the SQL export or commit when the

--- a/web/README.md
+++ b/web/README.md
@@ -118,7 +118,10 @@ web/
 - **CurrentTeam**: Show current team (with its roster 评分/score) and manual edit capability
 - **OptionSetInput**: Input 3 option sets (3 items each)
 - **RecommendationPanel**: Highlight the top-ranked option set (ranked by per-round 评分/score)
-- **AnalysisGrid**: Show 3 option sets, each with its marginal 评分/score and key point breakdown
+- **AnalysisGrid**: Show 3 option sets, each with its marginal 评分/score and key point breakdown.
+  When the gated preference model is available it also labels each card with the 玩家选择概率,
+  highlights the highest as 玩家选择最高 (independently from the AI 推荐 card), and — only when the
+  two tops differ by a meaningful margin — shows a short non-causal A/B/C disagreement note
 
 ### Analytics
 - **Analytics**: Player-friendly dashboard driven by the generated paired-model artifact

--- a/web/README.md
+++ b/web/README.md
@@ -122,6 +122,12 @@ web/
 
 ### Analytics
 - **Analytics**: Player-friendly dashboard driven by the generated paired-model artifact
+- A separate **玩家选择洞察** (player-choice insights) section, driven by
+  `public/game-data/telemetry_data.json`, reports offer/pick counts, AI-recommendation
+  acceptance, per-round historical agreement and position bias, score-margin behaviour,
+  and meaningful paired-vs-preference disagreements. It only describes how players chose
+  (never win rate, never AI scoring); percentages below the support threshold are hidden,
+  and preference-model status/held-out metrics surface only once the gates pass.
 - Question-led layout with a plain-language guide to the three player-facing measures:
   胜率参考 (smoothed win rate), 组合分 (combo score — the model's extra pairing/hero-skill
   bonus, shown only on the synergy tables), and 参考场次 (reference battles). Individual

--- a/web/functions/api/telemetry/rounds.js
+++ b/web/functions/api/telemetry/rounds.js
@@ -2,6 +2,7 @@ const MAX_BODY_BYTES = 64 * 1024;
 const MAX_BATCH_SIZE = 8;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const ISO_UTC_MILLIS_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const PREFERENCE_MODEL_VERSION_RE = /^preference-v[1-9]\d*:[0-9a-f]{16}$/;
 const ROUND_TYPES = Object.freeze({
   1: 'hero',
   2: 'skill',
@@ -208,6 +209,7 @@ export function validateRoundEvent(event) {
     event.preference_model_version === null && event.preference_probabilities === null;
   const hasPreference =
     isShortString(event.preference_model_version) &&
+    PREFERENCE_MODEL_VERSION_RE.test(event.preference_model_version) &&
     Array.isArray(event.preference_probabilities) &&
     event.preference_probabilities.length === 3 &&
     event.preference_probabilities.every(

--- a/web/functions/api/telemetry/rounds.test.js
+++ b/web/functions/api/telemetry/rounds.test.js
@@ -134,7 +134,7 @@ describe('round telemetry validation', () => {
     expect(
       validateRoundEvent(
         cloneEvent({
-          preference_model_version: 'preference-v1',
+          preference_model_version: 'preference-v1:0000000000000001',
           preference_probabilities: null,
         })
       )
@@ -145,11 +145,22 @@ describe('round telemetry validation', () => {
     expect(
       validateRoundEvent(
         cloneEvent({
-          preference_model_version: 'preference-v1',
+          preference_model_version: 'preference-v1:0000000000000001',
           preference_probabilities: [0.5, 0.3, 0.2],
         })
       )
     ).toBeNull();
+  });
+
+  test('rejects a preference version without its content hash', () => {
+    expect(
+      validateRoundEvent(
+        cloneEvent({
+          preference_model_version: 'preference-v1',
+          preference_probabilities: [0.5, 0.3, 0.2],
+        })
+      )
+    ).toBe('preference version and probabilities must both be null or valid');
   });
 });
 

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -41,6 +41,24 @@ const AnalysisGrid = ({
   skillMetadata = null,
 }: AnalysisGridProps) => {
   const itemColor = roundType === 'hero' ? 'primary' : 'secondary';
+  const hasRecommendedIndex =
+    typeof recommendedIndex === 'number' &&
+    Number.isInteger(recommendedIndex) &&
+    recommendedIndex >= 0 &&
+    recommendedIndex < 3;
+  const hasMeaningfulDisagreement =
+    preference !== null &&
+    hasRecommendedIndex &&
+    preference.top_index !== recommendedIndex &&
+    preference.probability_margin >= preference.meaningful_margin;
+  const optionLetter = (index: number) =>
+    String.fromCharCode(65 + index);
+  const preferenceExplanation =
+    preference &&
+    hasMeaningfulDisagreement &&
+    typeof recommendedIndex === 'number'
+      ? `AI 按当前阵容强度推荐 ${optionLetter(recommendedIndex)}；玩家选择模型认为 ${optionLetter(preference.top_index)} 更常被选（${(preference.probabilities[preference.top_index] * 100).toFixed(1)}%）。${preference.explanation_driver} 这描述玩家偏好，不会改变 AI 推荐。`
+      : null;
 
   const itemChipLabel = (item: string) => {
     if (roundType === 'hero') {
@@ -76,10 +94,6 @@ const AnalysisGrid = ({
     const isSelected = selectedIndex === index;
     const isRecommended = recommendedIndex === index;
     const isPreferenceTop = preference?.top_index === index;
-    const hasMeaningfulDisagreement =
-      preference !== null &&
-      preference.top_index !== recommendedIndex &&
-      preference.probability_margin >= preference.meaningful_margin;
 
     if (items.length === 0) {
       return null;
@@ -89,7 +103,13 @@ const AnalysisGrid = ({
     const comboSynergies = setAnalysis?.combo_synergies ?? [];
 
     return (
-      <Grid size={{ xs: 12, md: 4 }} key={setName} data-testid="analysis-set-card">
+      <Grid
+        size={{ xs: 12, md: 4 }}
+        key={setName}
+        data-testid="analysis-set-card"
+        data-ai-recommended={isRecommended ? 'true' : undefined}
+        data-player-choice-top={isPreferenceTop ? 'true' : undefined}
+      >
         <Card
           sx={{
             height: '100%',
@@ -97,10 +117,11 @@ const AnalysisGrid = ({
             borderLeft: '5px solid',
             borderColor: isSelected ? 'success.main' : isRecommended ? 'warning.main' : 'divider',
             outline:
-              isPreferenceTop && hasMeaningfulDisagreement
+              isPreferenceTop
                 ? '2px solid'
                 : 'none',
             outlineColor: 'info.main',
+            outlineOffset: '-2px',
             position: 'relative',
             bgcolor: isSelected ? 'rgba(223,232,226,0.72)' : isRecommended ? 'rgba(240,229,207,0.4)' : 'background.paper',
             transition: 'transform 160ms ease, background-color 160ms ease',
@@ -154,7 +175,7 @@ const AnalysisGrid = ({
                       </Typography>
                       {isPreferenceTop && (
                         <Chip
-                          label="玩家偏好最高"
+                          label="玩家选择最高"
                           color="info"
                           size="small"
                           variant="outlined"
@@ -217,18 +238,26 @@ const AnalysisGrid = ({
       <Typography component="h2" variant="h5" gutterBottom>
         选项分析
       </Typography>
-      {preference &&
-        preference.top_index !== recommendedIndex &&
-        preference.probability_margin >= preference.meaningful_margin && (
+      {preferenceExplanation && (
+        <Box
+          sx={{
+            mb: 1.5,
+            px: 1.25,
+            py: 1,
+            bgcolor: 'info.main',
+            color: 'info.contrastText',
+            borderRadius: 1,
+          }}
+          data-testid="preference-disagreement"
+        >
           <Typography
             variant="body2"
-            color="info.main"
-            sx={{ mb: 1.5 }}
-            data-testid="preference-disagreement"
+            color="inherit"
           >
-            AI 评分推荐与玩家偏好模型的首选不同；AI 推荐仍只由阵容评分决定。
+            {preferenceExplanation}
           </Typography>
-        )}
+        </Box>
+      )}
 
       <Grid container spacing={1.5}>
         {renderSetCard('set1', 0)}

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -4,6 +4,7 @@ import StarIcon from '@mui/icons-material/Star';
 import { formatHeroRank, formatSkillTier } from '../../utils/itemMetadata';
 import type { OptionAnalysis, Contribution } from '../../services/recommendationEngine';
 import type { CurrentRoundInputs, SetName, RoundType, HeroMeta, SkillMeta } from '../../types/game';
+import type { PreferencePrediction } from '../../types/telemetryData';
 import ResponsiveDisclosure from '../common/ResponsiveDisclosure';
 
 interface AnalysisGridProps {
@@ -12,6 +13,7 @@ interface AnalysisGridProps {
   analysis?: OptionAnalysis[];
   selectedIndex: number | null;
   recommendedIndex?: number;
+  preference?: PreferencePrediction | null;
   onSelectSet: (index: number) => void;
   roundType: RoundType;
   heroMetadata?: Record<string, HeroMeta> | null;
@@ -32,6 +34,7 @@ const AnalysisGrid = ({
   analysis,
   selectedIndex,
   recommendedIndex,
+  preference = null,
   onSelectSet,
   roundType,
   heroMetadata = null,
@@ -72,6 +75,11 @@ const AnalysisGrid = ({
     const setAnalysis = analysis?.find((a) => a.set_index === index);
     const isSelected = selectedIndex === index;
     const isRecommended = recommendedIndex === index;
+    const isPreferenceTop = preference?.top_index === index;
+    const hasMeaningfulDisagreement =
+      preference !== null &&
+      preference.top_index !== recommendedIndex &&
+      preference.probability_margin >= preference.meaningful_margin;
 
     if (items.length === 0) {
       return null;
@@ -88,6 +96,11 @@ const AnalysisGrid = ({
             border: 1,
             borderLeft: '5px solid',
             borderColor: isSelected ? 'success.main' : isRecommended ? 'warning.main' : 'divider',
+            outline:
+              isPreferenceTop && hasMeaningfulDisagreement
+                ? '2px solid'
+                : 'none',
+            outlineColor: 'info.main',
             position: 'relative',
             bgcolor: isSelected ? 'rgba(223,232,226,0.72)' : isRecommended ? 'rgba(240,229,207,0.4)' : 'background.paper',
             transition: 'transform 160ms ease, background-color 160ms ease',
@@ -121,6 +134,34 @@ const AnalysisGrid = ({
                   >
                     评分：{fmtSigned(gain)}
                   </Typography>
+                  {preference && (
+                    <Box
+                      sx={{
+                        mt: 0.75,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 0.75,
+                        flexWrap: 'wrap',
+                      }}
+                    >
+                      <Typography
+                        variant="body2"
+                        color="info.main"
+                        data-testid={`option-preference-${index}`}
+                        sx={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600 }}
+                      >
+                        玩家选择概率：{(preference.probabilities[index] * 100).toFixed(1)}%
+                      </Typography>
+                      {isPreferenceTop && (
+                        <Chip
+                          label="玩家偏好最高"
+                          color="info"
+                          size="small"
+                          variant="outlined"
+                        />
+                      )}
+                    </Box>
+                  )}
                 </Box>
               )}
             </Box>
@@ -176,6 +217,18 @@ const AnalysisGrid = ({
       <Typography component="h2" variant="h5" gutterBottom>
         选项分析
       </Typography>
+      {preference &&
+        preference.top_index !== recommendedIndex &&
+        preference.probability_margin >= preference.meaningful_margin && (
+          <Typography
+            variant="body2"
+            color="info.main"
+            sx={{ mb: 1.5 }}
+            data-testid="preference-disagreement"
+          >
+            AI 评分推荐与玩家偏好模型的首选不同；AI 推荐仍只由阵容评分决定。
+          </Typography>
+        )}
 
       <Grid container spacing={1.5}>
         {renderSetCard('set1', 0)}

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -14,6 +14,7 @@ import KnownStrongTeams from "./KnownStrongTeams";
 import { copyToClipboard } from "../../utils/clipboard";
 import type { SetName } from "../../types/game";
 import type { OptionAnalysis } from "../../services/recommendationEngine";
+import type { PreferencePrediction } from "../../types/telemetryData";
 import { recordRoundTelemetry } from "../../services/telemetry";
 
 /**
@@ -193,6 +194,10 @@ const GameBoard = () => {
     }
 
     const analysis = currentRecommendation?.analysis as OptionAnalysis[] | undefined;
+    const preference = currentRecommendation?.preference as
+      | PreferencePrediction
+      | null
+      | undefined;
     const recommendedIndex = currentRecommendation?.recommended_set_index;
     const pairedScores = [0, 1, 2].map((index) =>
       analysis?.find((option) => option.set_index === index)?.final_score
@@ -218,6 +223,8 @@ const GameBoard = () => {
         pairedScores,
         recommendedIndex,
         chosenIndex: selectedOptionIndex,
+        preferenceModelVersion: preference?.version ?? null,
+        preferenceProbabilities: preference?.probabilities ?? null,
       });
     }
 
@@ -328,6 +335,12 @@ const GameBoard = () => {
               analysis={currentRecommendation.analysis as OptionAnalysis[] | undefined}
               selectedIndex={selectedOptionIndex}
               recommendedIndex={currentRecommendation.recommended_set_index}
+              preference={
+                currentRecommendation.preference as
+                  | PreferencePrediction
+                  | null
+                  | undefined
+              }
               onSelectSet={handleSelectOption}
               roundType={roundType}
               heroMetadata={heroMetadata}

--- a/web/src/components/game/__tests__/AnalysisGrid.test.tsx
+++ b/web/src/components/game/__tests__/AnalysisGrid.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import AnalysisGrid from '../AnalysisGrid';
+import type { OptionAnalysis } from '../../../services/recommendationEngine';
+
+const option = (setIndex: number, score: number): OptionAnalysis => ({
+  set_index: setIndex,
+  items: [],
+  final_score: score,
+  rank: setIndex + 1,
+  item_scores: [],
+  synergies: [],
+  combo_synergies: [],
+  tradeoffs: [],
+  evidence: { featureCount: 0, totalSupport: 0, minSupport: 0 },
+});
+
+describe('AnalysisGrid player preference display', () => {
+  test('shows normalized probabilities and highlights meaningful model disagreement', () => {
+    render(
+      <AnalysisGrid
+        sets={{
+          set1: ['A', 'B', 'C'],
+          set2: ['D', 'E', 'F'],
+          set3: ['G', 'H', 'I'],
+        }}
+        analysis={[
+          option(0, 8),
+          option(1, 7),
+          option(2, 4),
+        ]}
+        selectedIndex={null}
+        recommendedIndex={0}
+        preference={{
+          version: 'preference-v1:0000000000000001',
+          probabilities: [0.3, 0.55, 0.15],
+          top_index: 1,
+          probability_margin: 0.25,
+          meaningful_margin: 0.1,
+        }}
+        onSelectSet={vi.fn()}
+        roundType="hero"
+      />
+    );
+
+    expect(screen.getByTestId('option-preference-0')).toHaveTextContent('30.0%');
+    expect(screen.getByTestId('option-preference-1')).toHaveTextContent('55.0%');
+    expect(screen.getByTestId('option-preference-2')).toHaveTextContent('15.0%');
+    expect(screen.getByText('玩家偏好最高')).toBeInTheDocument();
+    expect(screen.getByTestId('preference-disagreement')).toHaveTextContent(
+      'AI 评分推荐与玩家偏好模型的首选不同'
+    );
+  });
+});

--- a/web/src/components/game/__tests__/AnalysisGrid.test.tsx
+++ b/web/src/components/game/__tests__/AnalysisGrid.test.tsx
@@ -15,19 +15,22 @@ const option = (setIndex: number, score: number): OptionAnalysis => ({
 });
 
 describe('AnalysisGrid player preference display', () => {
-  test('shows normalized probabilities and highlights meaningful model disagreement', () => {
+  const sets = {
+    set1: ['A', 'B', 'C'],
+    set2: ['D', 'E', 'F'],
+    set3: ['G', 'H', 'I'],
+  };
+  const analysis = [
+    option(0, 8),
+    option(1, 7),
+    option(2, 4),
+  ];
+
+  test('uses player-choice labels and highlights its top separately from AI', () => {
     render(
       <AnalysisGrid
-        sets={{
-          set1: ['A', 'B', 'C'],
-          set2: ['D', 'E', 'F'],
-          set3: ['G', 'H', 'I'],
-        }}
-        analysis={[
-          option(0, 8),
-          option(1, 7),
-          option(2, 4),
-        ]}
+        sets={sets}
+        analysis={analysis}
         selectedIndex={null}
         recommendedIndex={0}
         preference={{
@@ -36,18 +39,81 @@ describe('AnalysisGrid player preference display', () => {
           top_index: 1,
           probability_margin: 0.25,
           meaningful_margin: 0.1,
+          explanation_driver: 'D、E在模型中的选择信号较强。',
         }}
         onSelectSet={vi.fn()}
         roundType="hero"
       />
     );
 
-    expect(screen.getByTestId('option-preference-0')).toHaveTextContent('30.0%');
-    expect(screen.getByTestId('option-preference-1')).toHaveTextContent('55.0%');
-    expect(screen.getByTestId('option-preference-2')).toHaveTextContent('15.0%');
-    expect(screen.getByText('玩家偏好最高')).toBeInTheDocument();
-    expect(screen.getByTestId('preference-disagreement')).toHaveTextContent(
-      'AI 评分推荐与玩家偏好模型的首选不同'
+    expect(screen.getByTestId('option-preference-0')).toHaveTextContent(
+      '玩家选择概率：30.0%'
     );
+    expect(screen.getByTestId('option-preference-1')).toHaveTextContent(
+      '玩家选择概率：55.0%'
+    );
+    expect(screen.getByTestId('option-preference-2')).toHaveTextContent(
+      '玩家选择概率：15.0%'
+    );
+    expect(screen.getByText('玩家选择最高')).toBeInTheDocument();
+    expect(screen.queryByText('玩家偏好最高')).not.toBeInTheDocument();
+    const cards = screen.getAllByTestId('analysis-set-card');
+    expect(cards[0]).toHaveAttribute('data-ai-recommended', 'true');
+    expect(cards[0]).not.toHaveAttribute('data-player-choice-top');
+    expect(cards[1]).toHaveAttribute('data-player-choice-top', 'true');
+    expect(cards[1]).not.toHaveAttribute('data-ai-recommended');
+    expect(screen.getByTestId('preference-disagreement')).toHaveTextContent(
+      'AI 按当前阵容强度推荐 A；玩家选择模型认为 B 更常被选（55.0%）。D、E在模型中的选择信号较强。 这描述玩家偏好，不会改变 AI 推荐。'
+    );
+  });
+
+  test('does not explain a disagreement below the meaningful margin', () => {
+    render(
+      <AnalysisGrid
+        sets={sets}
+        analysis={analysis}
+        selectedIndex={null}
+        recommendedIndex={0}
+        preference={{
+          version: 'preference-v1:0000000000000001',
+          probabilities: [0.42, 0.47, 0.11],
+          top_index: 1,
+          probability_margin: 0.05,
+          meaningful_margin: 0.1,
+          explanation_driver: 'D在模型中的选择信号较强。',
+        }}
+        onSelectSet={vi.fn()}
+        roundType="hero"
+      />
+    );
+
+    expect(screen.getByText('玩家选择最高')).toBeInTheDocument();
+    expect(screen.queryByTestId('preference-disagreement')).not.toBeInTheDocument();
+  });
+
+  test('does not explain a meaningful margin when both models pick the same option', () => {
+    render(
+      <AnalysisGrid
+        sets={sets}
+        analysis={analysis}
+        selectedIndex={null}
+        recommendedIndex={1}
+        preference={{
+          version: 'preference-v1:0000000000000001',
+          probabilities: [0.2, 0.7, 0.1],
+          top_index: 1,
+          probability_margin: 0.5,
+          meaningful_margin: 0.1,
+          explanation_driver: 'D在模型中的选择信号较强。',
+        }}
+        onSelectSet={vi.fn()}
+        roundType="hero"
+      />
+    );
+
+    const cards = screen.getAllByTestId('analysis-set-card');
+    expect(cards[1]).toHaveAttribute('data-ai-recommended', 'true');
+    expect(cards[1]).toHaveAttribute('data-player-choice-top', 'true');
+    expect(screen.queryByTestId('preference-disagreement')).not.toBeInTheDocument();
   });
 });

--- a/web/src/context/GameContext.tsx
+++ b/web/src/context/GameContext.tsx
@@ -8,6 +8,7 @@ import type {
   DatabaseItems,
 } from '../types/game';
 import { initializeTelemetry } from '../services/telemetry';
+import { preloadTelemetryData } from '../services/telemetryData';
 
 const GameContext = createContext<GameContextValue | undefined>(undefined);
 
@@ -214,6 +215,7 @@ export const GameProvider = ({ children, databaseItems }: GameProviderProps) => 
 
   useEffect(() => {
     initializeTelemetry();
+    preloadTelemetryData();
   }, []);
 
   // Load database items from props (passed from index.tsx)

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -21,6 +21,8 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import LinkIcon from '@mui/icons-material/Link';
@@ -102,312 +104,249 @@ const supportedPct = (
   return `${((numerator / denominator) * 100).toFixed(1)}%`;
 };
 
+type TelemetryItemFamily = 'heroes' | 'skills';
+type TelemetryRankingMetric = 'offer_count' | 'picked_count';
+
+const compareTelemetryNames = (
+  left: TelemetryItemAggregate,
+  right: TelemetryItemAggregate
+): number => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0);
+
+const topTelemetryItems = (
+  rows: TelemetryItemAggregate[],
+  metric: TelemetryRankingMetric
+): TelemetryItemAggregate[] =>
+  rows
+    .slice()
+    .sort(
+      (left, right) =>
+        right[metric] - left[metric] || compareTelemetryNames(left, right)
+    )
+    .slice(0, 5);
+
+const TelemetryRankingCard = ({
+  title,
+  rows,
+  metric,
+}: {
+  title: string;
+  rows: TelemetryItemAggregate[];
+  metric: TelemetryRankingMetric;
+}) => {
+  const rankedRows = topTelemetryItems(rows, metric);
+  const isOfferRanking = metric === 'offer_count';
+  const maximumCount = rankedRows[0]?.[metric] ?? 0;
+  const barMaximum = Math.max(maximumCount, 1);
+
+  return (
+    <Card
+      data-testid={
+        isOfferRanking
+          ? 'telemetry-ranking-offers'
+          : 'telemetry-ranking-picks'
+      }
+      sx={{ height: '100%' }}
+    >
+      <CardContent>
+        <Typography component="h3" variant="h6" gutterBottom>
+          {title}
+        </Typography>
+        <Box
+          component="ol"
+          aria-label={`${title}前五名`}
+          sx={{ listStyle: 'none', p: 0, m: 0 }}
+        >
+          {rankedRows.map((row, index) => {
+            const count = row[metric];
+            const rate = isOfferRanking
+              ? supportedPct(
+                  row.offer_count,
+                  row.opportunity_count,
+                  row.rate_suppressed
+                )
+              : supportedPct(
+                  row.picked_count,
+                  row.offer_count,
+                  row.rate_suppressed
+                );
+            const rateLabel = isOfferRanking ? '提供率' : '提供后选择率';
+
+            return (
+              <Box
+                component="li"
+                data-testid="telemetry-ranking-row"
+                key={row.name}
+                sx={{
+                  py: 1.25,
+                  borderTop: index === 0 ? 0 : '1px solid',
+                  borderColor: 'divider',
+                }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'baseline',
+                    gap: 1,
+                    minWidth: 0,
+                  }}
+                >
+                  <Typography
+                    aria-hidden="true"
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ width: 18, flexShrink: 0, fontWeight: 700 }}
+                  >
+                    {index + 1}
+                  </Typography>
+                  <Typography
+                    data-testid="telemetry-ranking-name"
+                    sx={{
+                      flex: 1,
+                      minWidth: 0,
+                      fontWeight: 700,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {row.name}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{ flexShrink: 0, fontWeight: 800 }}
+                  >
+                    {count} 次
+                  </Typography>
+                </Box>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: 'block', ml: '26px', mt: 0.25 }}
+                >
+                  {rateLabel} {rate}
+                </Typography>
+                <Box
+                  role="progressbar"
+                  aria-label={`${row.name}${isOfferRanking ? '提供' : '选择'}次数相对条`}
+                  aria-valuemin={0}
+                  aria-valuemax={barMaximum}
+                  aria-valuenow={count}
+                  sx={{
+                    height: 6,
+                    mt: 0.75,
+                    ml: '26px',
+                    overflow: 'hidden',
+                    bgcolor: 'action.selected',
+                    borderRadius: 999,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: `${(count / barMaximum) * 100}%`,
+                      height: '100%',
+                      bgcolor: isOfferRanking
+                        ? 'primary.main'
+                        : 'secondary.main',
+                      borderRadius: 'inherit',
+                    }}
+                  />
+                </Box>
+              </Box>
+            );
+          })}
+          {rankedRows.length === 0 && (
+            <Typography
+              component="li"
+              variant="body2"
+              color="text.secondary"
+              sx={{ py: 2 }}
+            >
+              暂无选择记录
+            </Typography>
+          )}
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
 const TelemetryAnalyticsSection = ({
   telemetry,
 }: {
   telemetry: TelemetryData;
 }) => {
-  const minimumSupport = telemetry.analytics?.minimum_rate_support ?? 10;
-  const accepted =
-    telemetry.summary.recommendation_accepted_count ??
-    telemetry.rounds.reduce(
-      (sum, round) => sum + round.recommendation_accepted_count,
-      0
-    );
-  const chosenPositions = [0, 1, 2].map((position) =>
-    telemetry.rounds.reduce(
-      (sum, round) => sum + round.chosen_position_counts[position],
-      0
-    )
-  );
-  const model = telemetry.preference_model;
-  const modelStatus =
-    model?.status === 'ready'
-      ? '偏好模型已启用'
-      : model?.status === 'quality_gate_failed'
-        ? '模型质量门未通过'
-        : '正在积累偏好证据';
-  const topItems = (rows: TelemetryItemAggregate[]) =>
-    rows
-      .slice()
-      .sort(
-        (left, right) =>
-          right.offer_count - left.offer_count ||
-          left.name.localeCompare(right.name, 'zh-Hans-CN')
-      )
-      .slice(0, 12);
-  const disagreementRounds = telemetry.rounds
-    .filter(
-      (round) =>
-        round.rate_suppressed !== true &&
-        typeof round.average_meaningful_preference_disagreement_margin ===
-          'number'
-    )
-    .sort(
-      (left, right) =>
-        (right.average_meaningful_preference_disagreement_margin || 0) -
-        (left.average_meaningful_preference_disagreement_margin || 0)
-    );
+  const analytics = telemetry.analytics;
+  const [itemFamily, setItemFamily] =
+    useState<TelemetryItemFamily>('heroes');
 
-  const renderItemTable = (
-    title: string,
-    rows: TelemetryItemAggregate[],
-    color: 'primary' | 'secondary'
-  ) => (
-    <Card>
-      <CardContent>
-        <Typography component="h3" variant="h6" gutterBottom>
-          {title}
-        </Typography>
-        <ScrollableAnalyticsTable label={title}>
-          <Table size="small" stickyHeader>
-            <TableHead>
-              <TableRow>
-                <TableCell>名称</TableCell>
-                <TableCell align="right">出现次数</TableCell>
-                <TableCell align="right">出现率</TableCell>
-                <TableCell align="right">出现后被选</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {topItems(rows).map((row) => (
-                <TableRow key={row.name}>
-                  <TableCell>
-                    <Chip label={row.name} color={color} size="small" />
-                  </TableCell>
-                  <TableCell align="right">{row.offer_count}</TableCell>
-                  <TableCell align="right">
-                    {supportedPct(
-                      row.offer_count,
-                      row.opportunity_count,
-                      row.rate_suppressed
-                    )}
-                  </TableCell>
-                  <TableCell align="right">
-                    {supportedPct(
-                      row.picked_count,
-                      row.offer_count,
-                      row.rate_suppressed
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </ScrollableAnalyticsTable>
-      </CardContent>
-    </Card>
-  );
+  if (!analytics) return null;
+
+  const rows = analytics.items[itemFamily];
 
   return (
     <Box sx={{ mb: 5 }} data-testid="player-choice-analytics">
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
-        <InsightsIcon sx={{ color: 'info.main' }} />
-        <Typography component="h2" variant="h5">
-          玩家选择洞察
-        </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: 1.5,
+          mb: 0.75,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <InsightsIcon sx={{ color: 'info.main' }} />
+          <Typography component="h2" variant="h5">
+            玩家最关心的选择排行
+          </Typography>
+        </Box>
+        <ToggleButtonGroup
+          value={itemFamily}
+          exclusive
+          size="small"
+          aria-label="玩家选择排行类型"
+          onChange={(_, nextFamily: TelemetryItemFamily | null) => {
+            if (nextFamily) setItemFamily(nextFamily);
+          }}
+          sx={{
+            '& .MuiToggleButton-root': {
+              minHeight: 32,
+              px: 1.75,
+              py: 0.25,
+            },
+          }}
+        >
+          <ToggleButton value="heroes" aria-label="武将">
+            武将
+          </ToggleButton>
+          <ToggleButton value="skills" aria-label="战法">
+            战法
+          </ToggleButton>
+        </ToggleButtonGroup>
       </Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        匿名选项记录只描述玩家如何选择；它不是胜率，也不会改变 AI 的阵容评分推荐。
-        百分比少于 {minimumSupport} 次支持时隐藏。
+        匿名选项记录只描述系统提供了什么、玩家看到后选择了什么；它不是胜率，也不会改变
+        AI 的阵容评分推荐。少于 {analytics.minimum_rate_support} 次提供时隐藏百分比，
+        但仍显示次数。
       </Typography>
 
-      <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid size={{ xs: 6, md: 3 }}>
-          <Card>
-            <CardContent data-testid="telemetry-event-count">
-              <Typography variant="overline" color="text.secondary">有效选择</Typography>
-              <Typography variant="h4">{telemetry.summary.event_count}</Typography>
-            </CardContent>
-          </Card>
+      <Grid container spacing={2.5}>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <TelemetryRankingCard
+            title="系统最常提供"
+            rows={rows}
+            metric="offer_count"
+          />
         </Grid>
-        <Grid size={{ xs: 6, md: 3 }}>
-          <Card>
-            <CardContent data-testid="telemetry-session-count">
-              <Typography variant="overline" color="text.secondary">匿名对局</Typography>
-              <Typography variant="h4">{telemetry.summary.session_count}</Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-        <Grid size={{ xs: 6, md: 3 }}>
-          <Card>
-            <CardContent data-testid="telemetry-acceptance-rate">
-              <Typography variant="overline" color="text.secondary">接受 AI 推荐</Typography>
-              <Typography variant="h4">
-                {supportedPct(
-                  accepted,
-                  telemetry.summary.event_count,
-                  telemetry.summary.event_count < minimumSupport
-                )}
-              </Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-        <Grid size={{ xs: 6, md: 3 }}>
-          <Card>
-            <CardContent>
-              <Typography variant="overline" color="text.secondary">偏好模型</Typography>
-              <Typography variant="h6">{modelStatus}</Typography>
-            </CardContent>
-          </Card>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <TelemetryRankingCard
+            title="玩家最常选择"
+            rows={rows}
+            metric="picked_count"
+          />
         </Grid>
       </Grid>
-
-      {model?.status === 'insufficient_evidence' && (
-        <Alert severity="info" sx={{ mb: 3 }}>
-          当前有 {model.evidence.event_count}/{model.evidence.minimum_event_count} 次选择、
-          {model.evidence.session_count}/{model.evidence.minimum_session_count} 个匿名对局、
-          {model.evidence.recommendation_disagreement_count}/
-          {model.evidence.minimum_recommendation_disagreement_count} 次不同于 AI 推荐的选择。
-          达到证据门并通过留出集质量检查后，选项页才会显示玩家选择概率。
-        </Alert>
-      )}
-      {model?.status === 'quality_gate_failed' && (
-        <Alert severity="warning" sx={{ mb: 3 }}>
-          样本量已达到要求，但偏好模型在匿名对局留出集上没有充分优于均匀基线。
-          本次不发布系数，选项页也不会显示玩家选择概率。
-        </Alert>
-      )}
-
-      <Card sx={{ mb: 3 }}>
-        <CardContent>
-          <Typography component="h3" variant="h6" gutterBottom>
-            各轮选择与位置偏好
-          </Typography>
-          <ScrollableAnalyticsTable label="各轮玩家选择">
-            <Table size="small" stickyHeader>
-              <TableHead>
-                <TableRow>
-                  <TableCell>轮次</TableCell>
-                  <TableCell align="right">样本</TableCell>
-                  <TableCell align="right">接受 AI 推荐</TableCell>
-                  <TableCell align="right">偏好模型与历史选择一致</TableCell>
-                  <TableCell align="right">AI–偏好模型冲突</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {telemetry.rounds.map((round) => (
-                  <TableRow key={round.round_number}>
-                    <TableCell>
-                      第 {round.round_number} 轮 ·
-                      {round.round_type === 'hero' ? '武将' : '战法'}
-                    </TableCell>
-                    <TableCell align="right">{round.event_count}</TableCell>
-                    <TableCell align="right">
-                      {supportedPct(
-                        round.recommendation_accepted_count,
-                        round.event_count,
-                        round.rate_suppressed ??
-                          round.event_count < minimumSupport
-                      )}
-                    </TableCell>
-                    <TableCell align="right">
-                      {typeof round.player_preference_agreement_count ===
-                      'number'
-                        ? supportedPct(
-                            round.player_preference_agreement_count,
-                            round.event_count,
-                            round.rate_suppressed ??
-                              round.event_count < minimumSupport
-                          )
-                        : '模型未启用'}
-                    </TableCell>
-                    <TableCell align="right">
-                      {typeof round.meaningful_preference_disagreement_count ===
-                      'number'
-                        ? supportedPct(
-                            round.meaningful_preference_disagreement_count,
-                            round.event_count,
-                            round.rate_suppressed ??
-                              round.event_count < minimumSupport
-                          )
-                        : '模型未启用'}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </ScrollableAnalyticsTable>
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
-            位置选择：A {chosenPositions[0]} 次、B {chosenPositions[1]} 次、C{' '}
-            {chosenPositions[2]} 次。
-          </Typography>
-          {disagreementRounds.length > 0 && (
-            <Typography variant="body2" color="info.main" sx={{ mt: 1 }}>
-              平均概率差最大的有意义 AI–偏好模型分歧出现在第{' '}
-              {disagreementRounds[0].round_number} 轮（
-              {pct(
-                disagreementRounds[0]
-                  .average_meaningful_preference_disagreement_margin
-              )}）。
-            </Typography>
-          )}
-        </CardContent>
-      </Card>
-
-      {telemetry.analytics && (
-        <>
-          <Grid container spacing={3} sx={{ mb: 3 }}>
-            <Grid size={{ xs: 12, md: 6 }}>
-              {renderItemTable(
-                '武将出现与选择',
-                telemetry.analytics.items.heroes,
-                'primary'
-              )}
-            </Grid>
-            <Grid size={{ xs: 12, md: 6 }}>
-              {renderItemTable(
-                '战法出现与选择',
-                telemetry.analytics.items.skills,
-                'secondary'
-              )}
-            </Grid>
-          </Grid>
-
-          <Card sx={{ mb: 3 }}>
-            <CardContent>
-              <Typography component="h3" variant="h6" gutterBottom>
-                AI 评分领先幅度与接受率
-              </Typography>
-              <ScrollableAnalyticsTable label="评分领先幅度">
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>领先幅度</TableCell>
-                      <TableCell align="right">样本</TableCell>
-                      <TableCell align="right">接受 AI 推荐</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {telemetry.analytics.score_margins.map((row) => (
-                      <TableRow key={row.key}>
-                        <TableCell>{row.label}</TableCell>
-                        <TableCell align="right">{row.event_count}</TableCell>
-                        <TableCell align="right">
-                          {supportedPct(
-                            row.recommendation_accepted_count,
-                            row.event_count,
-                            row.rate_suppressed
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </ScrollableAnalyticsTable>
-            </CardContent>
-          </Card>
-
-          {model?.held_out && (
-            <Alert severity={model.status === 'ready' ? 'success' : 'warning'}>
-              偏好模型留出集：{model.held_out.event_count} 次选择，准确率{' '}
-              {pct(model.held_out.accuracy)}，对数损失{' '}
-              {model.held_out.log_loss}，校准误差{' '}
-              {pct(model.held_out.calibration_error)}。
-            </Alert>
-          )}
-        </>
-      )}
     </Box>
   );
 };
@@ -568,7 +507,9 @@ const Analytics = () => {
           <strong>并不保证</strong>在某一场对特定对手时一定获胜。
         </Typography>
 
-        {telemetry && <TelemetryAnalyticsSection telemetry={telemetry} />}
+        {telemetry?.analytics && (
+          <TelemetryAnalyticsSection telemetry={telemetry} />
+        )}
 
         {/* Plain-language guide: how to read the numbers */}
         <Card sx={{ mb: 4, borderTop: '3px solid', borderTopColor: 'primary.main' }}>

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -39,6 +39,8 @@ import TagList from '../components/common/TagList';
 import ResponsiveDisclosure from '../components/common/ResponsiveDisclosure';
 import type { HeroMeta, SkillMeta } from '../types/game';
 import type { AnalyticsResult } from '../services/recommendationEngine';
+import type { TelemetryData, TelemetryItemAggregate } from '../types/telemetryData';
+import { loadTelemetryData } from '../services/telemetryData';
 
 interface ScrollableAnalyticsTableProps {
   children: ReactNode;
@@ -91,8 +93,328 @@ const HelpTip = ({ title, label }: { title: string; label: string }) => (
   </Tooltip>
 );
 
+const supportedPct = (
+  numerator: number,
+  denominator: number,
+  suppressed: boolean
+): string => {
+  if (suppressed || denominator === 0) return '样本不足';
+  return `${((numerator / denominator) * 100).toFixed(1)}%`;
+};
+
+const TelemetryAnalyticsSection = ({
+  telemetry,
+}: {
+  telemetry: TelemetryData;
+}) => {
+  const minimumSupport = telemetry.analytics?.minimum_rate_support ?? 10;
+  const accepted =
+    telemetry.summary.recommendation_accepted_count ??
+    telemetry.rounds.reduce(
+      (sum, round) => sum + round.recommendation_accepted_count,
+      0
+    );
+  const chosenPositions = [0, 1, 2].map((position) =>
+    telemetry.rounds.reduce(
+      (sum, round) => sum + round.chosen_position_counts[position],
+      0
+    )
+  );
+  const model = telemetry.preference_model;
+  const modelStatus =
+    model?.status === 'ready'
+      ? '偏好模型已启用'
+      : model?.status === 'quality_gate_failed'
+        ? '模型质量门未通过'
+        : '正在积累偏好证据';
+  const topItems = (rows: TelemetryItemAggregate[]) =>
+    rows
+      .slice()
+      .sort(
+        (left, right) =>
+          right.offer_count - left.offer_count ||
+          left.name.localeCompare(right.name, 'zh-Hans-CN')
+      )
+      .slice(0, 12);
+  const disagreementRounds = telemetry.rounds
+    .filter(
+      (round) =>
+        round.rate_suppressed !== true &&
+        typeof round.average_meaningful_preference_disagreement_margin ===
+          'number'
+    )
+    .sort(
+      (left, right) =>
+        (right.average_meaningful_preference_disagreement_margin || 0) -
+        (left.average_meaningful_preference_disagreement_margin || 0)
+    );
+
+  const renderItemTable = (
+    title: string,
+    rows: TelemetryItemAggregate[],
+    color: 'primary' | 'secondary'
+  ) => (
+    <Card>
+      <CardContent>
+        <Typography component="h3" variant="h6" gutterBottom>
+          {title}
+        </Typography>
+        <ScrollableAnalyticsTable label={title}>
+          <Table size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>名称</TableCell>
+                <TableCell align="right">出现次数</TableCell>
+                <TableCell align="right">出现率</TableCell>
+                <TableCell align="right">出现后被选</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {topItems(rows).map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell>
+                    <Chip label={row.name} color={color} size="small" />
+                  </TableCell>
+                  <TableCell align="right">{row.offer_count}</TableCell>
+                  <TableCell align="right">
+                    {supportedPct(
+                      row.offer_count,
+                      row.opportunity_count,
+                      row.rate_suppressed
+                    )}
+                  </TableCell>
+                  <TableCell align="right">
+                    {supportedPct(
+                      row.picked_count,
+                      row.offer_count,
+                      row.rate_suppressed
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </ScrollableAnalyticsTable>
+      </CardContent>
+    </Card>
+  );
+
+  return (
+    <Box sx={{ mb: 5 }} data-testid="player-choice-analytics">
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+        <InsightsIcon sx={{ color: 'info.main' }} />
+        <Typography component="h2" variant="h5">
+          玩家选择洞察
+        </Typography>
+      </Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        匿名选项记录只描述玩家如何选择；它不是胜率，也不会改变 AI 的阵容评分推荐。
+        百分比少于 {minimumSupport} 次支持时隐藏。
+      </Typography>
+
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid size={{ xs: 6, md: 3 }}>
+          <Card>
+            <CardContent data-testid="telemetry-event-count">
+              <Typography variant="overline" color="text.secondary">有效选择</Typography>
+              <Typography variant="h4">{telemetry.summary.event_count}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 6, md: 3 }}>
+          <Card>
+            <CardContent data-testid="telemetry-session-count">
+              <Typography variant="overline" color="text.secondary">匿名对局</Typography>
+              <Typography variant="h4">{telemetry.summary.session_count}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 6, md: 3 }}>
+          <Card>
+            <CardContent data-testid="telemetry-acceptance-rate">
+              <Typography variant="overline" color="text.secondary">接受 AI 推荐</Typography>
+              <Typography variant="h4">
+                {supportedPct(
+                  accepted,
+                  telemetry.summary.event_count,
+                  telemetry.summary.event_count < minimumSupport
+                )}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 6, md: 3 }}>
+          <Card>
+            <CardContent>
+              <Typography variant="overline" color="text.secondary">偏好模型</Typography>
+              <Typography variant="h6">{modelStatus}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      {model?.status === 'insufficient_evidence' && (
+        <Alert severity="info" sx={{ mb: 3 }}>
+          当前有 {model.evidence.event_count}/{model.evidence.minimum_event_count} 次选择、
+          {model.evidence.session_count}/{model.evidence.minimum_session_count} 个匿名对局、
+          {model.evidence.recommendation_disagreement_count}/
+          {model.evidence.minimum_recommendation_disagreement_count} 次不同于 AI 推荐的选择。
+          达到证据门并通过留出集质量检查后，选项页才会显示玩家选择概率。
+        </Alert>
+      )}
+      {model?.status === 'quality_gate_failed' && (
+        <Alert severity="warning" sx={{ mb: 3 }}>
+          样本量已达到要求，但偏好模型在匿名对局留出集上没有充分优于均匀基线。
+          本次不发布系数，选项页也不会显示玩家选择概率。
+        </Alert>
+      )}
+
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Typography component="h3" variant="h6" gutterBottom>
+            各轮选择与位置偏好
+          </Typography>
+          <ScrollableAnalyticsTable label="各轮玩家选择">
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell>轮次</TableCell>
+                  <TableCell align="right">样本</TableCell>
+                  <TableCell align="right">接受 AI 推荐</TableCell>
+                  <TableCell align="right">偏好模型与历史选择一致</TableCell>
+                  <TableCell align="right">AI–偏好模型冲突</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {telemetry.rounds.map((round) => (
+                  <TableRow key={round.round_number}>
+                    <TableCell>
+                      第 {round.round_number} 轮 ·
+                      {round.round_type === 'hero' ? '武将' : '战法'}
+                    </TableCell>
+                    <TableCell align="right">{round.event_count}</TableCell>
+                    <TableCell align="right">
+                      {supportedPct(
+                        round.recommendation_accepted_count,
+                        round.event_count,
+                        round.rate_suppressed ??
+                          round.event_count < minimumSupport
+                      )}
+                    </TableCell>
+                    <TableCell align="right">
+                      {typeof round.player_preference_agreement_count ===
+                      'number'
+                        ? supportedPct(
+                            round.player_preference_agreement_count,
+                            round.event_count,
+                            round.rate_suppressed ??
+                              round.event_count < minimumSupport
+                          )
+                        : '模型未启用'}
+                    </TableCell>
+                    <TableCell align="right">
+                      {typeof round.meaningful_preference_disagreement_count ===
+                      'number'
+                        ? supportedPct(
+                            round.meaningful_preference_disagreement_count,
+                            round.event_count,
+                            round.rate_suppressed ??
+                              round.event_count < minimumSupport
+                          )
+                        : '模型未启用'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </ScrollableAnalyticsTable>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+            位置选择：A {chosenPositions[0]} 次、B {chosenPositions[1]} 次、C{' '}
+            {chosenPositions[2]} 次。
+          </Typography>
+          {disagreementRounds.length > 0 && (
+            <Typography variant="body2" color="info.main" sx={{ mt: 1 }}>
+              平均概率差最大的有意义 AI–偏好模型分歧出现在第{' '}
+              {disagreementRounds[0].round_number} 轮（
+              {pct(
+                disagreementRounds[0]
+                  .average_meaningful_preference_disagreement_margin
+              )}）。
+            </Typography>
+          )}
+        </CardContent>
+      </Card>
+
+      {telemetry.analytics && (
+        <>
+          <Grid container spacing={3} sx={{ mb: 3 }}>
+            <Grid size={{ xs: 12, md: 6 }}>
+              {renderItemTable(
+                '武将出现与选择',
+                telemetry.analytics.items.heroes,
+                'primary'
+              )}
+            </Grid>
+            <Grid size={{ xs: 12, md: 6 }}>
+              {renderItemTable(
+                '战法出现与选择',
+                telemetry.analytics.items.skills,
+                'secondary'
+              )}
+            </Grid>
+          </Grid>
+
+          <Card sx={{ mb: 3 }}>
+            <CardContent>
+              <Typography component="h3" variant="h6" gutterBottom>
+                AI 评分领先幅度与接受率
+              </Typography>
+              <ScrollableAnalyticsTable label="评分领先幅度">
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>领先幅度</TableCell>
+                      <TableCell align="right">样本</TableCell>
+                      <TableCell align="right">接受 AI 推荐</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {telemetry.analytics.score_margins.map((row) => (
+                      <TableRow key={row.key}>
+                        <TableCell>{row.label}</TableCell>
+                        <TableCell align="right">{row.event_count}</TableCell>
+                        <TableCell align="right">
+                          {supportedPct(
+                            row.recommendation_accepted_count,
+                            row.event_count,
+                            row.rate_suppressed
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </ScrollableAnalyticsTable>
+            </CardContent>
+          </Card>
+
+          {model?.held_out && (
+            <Alert severity={model.status === 'ready' ? 'success' : 'warning'}>
+              偏好模型留出集：{model.held_out.event_count} 次选择，准确率{' '}
+              {pct(model.held_out.accuracy)}，对数损失{' '}
+              {model.held_out.log_loss}，校准误差{' '}
+              {pct(model.held_out.calibration_error)}。
+            </Alert>
+          )}
+        </>
+      )}
+    </Box>
+  );
+};
+
 const Analytics = () => {
   const [data, setData] = useState<AnalyticsResult | null>(null);
+  const [telemetry, setTelemetry] = useState<TelemetryData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedHeroes, setSelectedHeroes] = useState<string[]>([]);
@@ -144,6 +466,11 @@ const Analytics = () => {
         setLoading(false);
       }
     })();
+    void loadTelemetryData()
+      .then(setTelemetry)
+      .catch((telemetryError) => {
+        console.warn('Player-choice telemetry is unavailable', telemetryError);
+      });
   }, []);
 
   const allHeroNames = useMemo(() => {
@@ -240,6 +567,8 @@ const Analytics = () => {
           所有结论都来自已记录的 {data.summary.total_battles} 场对局，是历史经验的参考，
           <strong>并不保证</strong>在某一场对特定对手时一定获胜。
         </Typography>
+
+        {telemetry && <TelemetryAnalyticsSection telemetry={telemetry} />}
 
         {/* Plain-language guide: how to read the numbers */}
         <Card sx={{ mb: 4, borderTop: '3px solid', borderTopColor: 'primary.main' }}>

--- a/web/src/services/__tests__/api.test.ts
+++ b/web/src/services/__tests__/api.test.ts
@@ -1,0 +1,47 @@
+import { database } from '../../data';
+import { api } from '../api';
+import { clearTelemetryDataCacheForTests } from '../telemetryData';
+
+describe('recommendation telemetry isolation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearTelemetryDataCacheForTests();
+  });
+
+  test('a stalled telemetry artifact request never blocks the paired recommendation', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => undefined))
+    );
+    clearTelemetryDataCacheForTests();
+    const heroes = Object.keys(database.heroes);
+    const currentHeroes = heroes.slice(0, 4);
+    const candidates = heroes.slice(4, 13);
+
+    const completed = await Promise.race([
+      api
+        .getRecommendation(
+          'hero',
+          [
+            candidates.slice(0, 3),
+            candidates.slice(3, 6),
+            candidates.slice(6, 9),
+          ],
+          {
+            current_heroes: currentHeroes,
+            current_skills: [],
+            support_hero: null,
+            support_skills: [],
+            round_number: 1,
+            round_history: [],
+          }
+        )
+        .then(() => true),
+      new Promise<boolean>((resolve) => {
+        setTimeout(() => resolve(false), 100);
+      }),
+    ]);
+
+    expect(completed).toBe(true);
+  });
+});

--- a/web/src/services/__tests__/preferenceModel.test.ts
+++ b/web/src/services/__tests__/preferenceModel.test.ts
@@ -1,0 +1,119 @@
+import {
+  preferenceFeatures,
+  normalizePreferenceForDisplay,
+  predictPlayerPreference,
+  type PreferenceContext,
+} from '../preferenceModel';
+import type { TelemetryData } from '../../types/telemetryData';
+
+const CONTEXT: PreferenceContext = {
+  roundNumber: 4,
+  roundType: 'hero',
+  poolBefore: {
+    heroes: ['刘备'],
+    skills: ['避其锐气'],
+    heroSupport: '关羽',
+  },
+  offeredSets: [
+    ['曹操', '夏侯惇', '夏侯渊'],
+    ['孙权', '周瑜', '鲁肃'],
+    ['袁绍', '颜良', '文丑'],
+  ],
+  pairedScores: [10, 0, -10],
+};
+
+const artifact = {
+  schema: { version: 3, source_event_schema_version: 1 },
+  catalog_version: 'test',
+  summary: {
+    event_count: 240,
+    invalid_event_count: 0,
+    session_count: 40,
+    recommendation_accepted_count: 180,
+    preference_event_count: 0,
+    model_versions: [],
+    preference_model_versions: [],
+  },
+  rounds: [],
+  preference_model: {
+    model_type: 'conditional-choice-logit',
+    feature_schema_version: 1,
+    meaningful_probability_margin: 0.1,
+    l2: 0.05,
+    evidence: {
+      event_count: 240,
+      session_count: 40,
+      recommendation_disagreement_count: 60,
+      minimum_event_count: 240,
+      minimum_session_count: 40,
+      minimum_recommendation_disagreement_count: 30,
+      holdout_event_count: 48,
+      minimum_holdout_event_count: 36,
+    },
+    status: 'ready',
+    version: 'preference-v1:0000000000000001',
+    held_out: null,
+    weights: {
+      '[\"score\"]': 1,
+      '[\"position\",2]': 0.5,
+    },
+    support: {
+      '[\"score\"]': 720,
+      '[\"position\",2]': 240,
+    },
+  },
+} as unknown as TelemetryData;
+
+describe('Phase 3 preference model', () => {
+  test('builds the same JSON-array feature ids as the Python builder', () => {
+    const features = preferenceFeatures(CONTEXT, 0);
+
+    expect(features['["score"]']).toBe(1);
+    expect(features['["round_score",4]']).toBe(1);
+    expect(features['["position",0]']).toBe(1);
+    expect(features['["item","hero","曹操"]']).toBe(1);
+    expect(
+      features['["pool_item","hero","刘备","hero","曹操"]']
+    ).toBe(1);
+    expect(
+      features['["pool_item","skill","避其锐气","hero","曹操"]']
+    ).toBe(1);
+  });
+
+  test('normalizes three probabilities without changing the AI recommendation', () => {
+    const prediction = predictPlayerPreference(artifact, CONTEXT);
+
+    expect(prediction).not.toBeNull();
+    expect(
+      prediction!.probabilities.reduce((sum, probability) => sum + probability, 0)
+    ).toBeCloseTo(1, 12);
+    expect(prediction!.top_index).toBe(0);
+    expect(prediction!.version).toBe('preference-v1:0000000000000001');
+    expect(
+      prediction!.probabilities
+        .map((probability) => (probability * 100).toFixed(1))
+        .reduce((sum, percentage) => sum + Number(percentage), 0)
+    ).toBe(100);
+  });
+
+  test('rounds displayed thirds to an exact 100.0 percent total', () => {
+    expect(
+      normalizePreferenceForDisplay([1 / 3, 1 / 3, 1 / 3])
+    ).toEqual([0.334, 0.333, 0.333]);
+  });
+
+  test('does not emit probabilities before the evidence and quality gates pass', () => {
+    const unavailable = {
+      ...artifact,
+      preference_model: {
+        ...artifact.preference_model!,
+        status: 'insufficient_evidence' as const,
+        version: null,
+        weights: {},
+        support: {},
+      },
+    };
+
+    expect(predictPlayerPreference(unavailable, CONTEXT)).toBeNull();
+  });
+});

--- a/web/src/services/__tests__/preferenceModel.test.ts
+++ b/web/src/services/__tests__/preferenceModel.test.ts
@@ -89,6 +89,16 @@ describe('Phase 3 preference model', () => {
     ).toBeCloseTo(1, 12);
     expect(prediction!.top_index).toBe(0);
     expect(prediction!.version).toBe('preference-v1:0000000000000001');
+    expect(prediction!.explanation_driver).toBe(
+      '这是相似阵容与选项中的总体选择倾向。'
+    );
+    expect(
+      prediction!.probabilities.every(
+        (probability) =>
+          Math.abs(probability * 1000 - Math.round(probability * 1000)) <
+          Number.EPSILON
+      )
+    ).toBe(true);
     expect(
       prediction!.probabilities
         .map((probability) => (probability * 100).toFixed(1))
@@ -100,6 +110,58 @@ describe('Phase 3 preference model', () => {
     expect(
       normalizePreferenceForDisplay([1 / 3, 1 / 3, 1 / 3])
     ).toEqual([0.334, 0.333, 0.333]);
+  });
+
+  test('grounds its driver in the strongest positive top-side item signals', () => {
+    const grounded = {
+      ...artifact,
+      preference_model: {
+        ...artifact.preference_model!,
+        weights: {
+          '["position",1]': 3,
+          '["pool_item","hero","刘备","hero","孙权"]': 1.4,
+          '["pool_item","hero","刘备","hero","周瑜"]': 1.2,
+          '["pool_item","hero","刘备","hero","鲁肃"]': 1,
+          // An AI-option penalty helps the comparison mathematically, but is
+          // not presented as a positive signal belonging to the preference top.
+          '["item","hero","曹操"]': -2,
+        },
+        support: {
+          '["position",1]': 240,
+          '["pool_item","hero","刘备","hero","孙权"]': 80,
+          '["pool_item","hero","刘备","hero","周瑜"]': 70,
+          '["pool_item","hero","刘备","hero","鲁肃"]': 60,
+          '["item","hero","曹操"]': 100,
+        },
+      },
+    };
+
+    const prediction = predictPlayerPreference(grounded, CONTEXT);
+
+    expect(prediction?.top_index).toBe(1);
+    expect(prediction?.explanation_driver).toBe(
+      '当前已有刘备时，孙权、周瑜在模型中的选择信号较强。'
+    );
+    expect(prediction?.explanation_driver).not.toContain('鲁肃');
+    expect(prediction?.explanation_driver).not.toContain('曹操');
+  });
+
+  test('uses the generic driver when only non-readable model features differ', () => {
+    const positionOnly = {
+      ...artifact,
+      preference_model: {
+        ...artifact.preference_model!,
+        weights: { '["position",1]': 3 },
+        support: { '["position",1]': 240 },
+      },
+    };
+
+    const prediction = predictPlayerPreference(positionOnly, CONTEXT);
+
+    expect(prediction?.top_index).toBe(1);
+    expect(prediction?.explanation_driver).toBe(
+      '这是相似阵容与选项中的总体选择倾向。'
+    );
   });
 
   test('does not emit probabilities before the evidence and quality gates pass', () => {

--- a/web/src/services/__tests__/telemetry.test.ts
+++ b/web/src/services/__tests__/telemetry.test.ts
@@ -79,6 +79,33 @@ describe('round telemetry construction', () => {
     expect(createRoundTelemetryEvent({ ...INPUT, pairedScores: [1, 2] })).toBeNull();
   });
 
+  test('records the exact displayed preference model and normalized probabilities', () => {
+    const event = createRoundTelemetryEvent({
+      ...INPUT,
+      preferenceModelVersion: 'preference-v1:0000000000000001',
+      preferenceProbabilities: [0.6, 0.3, 0.1],
+    });
+
+    expect(event).toMatchObject({
+      preference_model_version: 'preference-v1:0000000000000001',
+      preference_probabilities: [0.6, 0.3, 0.1],
+    });
+    expect(
+      createRoundTelemetryEvent({
+        ...INPUT,
+        preferenceModelVersion: 'preference-v1:0000000000000001',
+        preferenceProbabilities: [0.6, 0.3, 0.2],
+      })
+    ).toBeNull();
+    expect(
+      createRoundTelemetryEvent({
+        ...INPUT,
+        preferenceModelVersion: 'preference-v1',
+        preferenceProbabilities: [0.6, 0.3, 0.1],
+      })
+    ).toBeNull();
+  });
+
   test('refuses an offered item already present in the relevant pool', () => {
     expect(
       createRoundTelemetryEvent({

--- a/web/src/services/__tests__/telemetryData.test.ts
+++ b/web/src/services/__tests__/telemetryData.test.ts
@@ -1,0 +1,422 @@
+import telemetryRaw from '../../../public/game-data/telemetry_data.json';
+import {
+  clearTelemetryDataCacheForTests,
+  getCachedTelemetryData,
+  loadTelemetryData,
+  parseTelemetryData,
+} from '../telemetryData';
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const ROUND_TYPES = [
+  'hero',
+  'skill',
+  'skill',
+  'hero',
+  'skill',
+  'skill',
+  'hero',
+  'skill',
+] as const;
+
+const schemaV2Artifact = (): Record<string, any> => ({
+  catalog_version: telemetryRaw.catalog_version,
+  preference_model: null,
+  rounds: ROUND_TYPES.map((roundType, index) => ({
+    round_number: index + 1,
+    round_type: roundType,
+    event_count: 0,
+    recommendation_accepted_count: 0,
+    chosen_position_counts: [0, 0, 0],
+    recommended_position_counts: [0, 0, 0],
+  })),
+  schema: { version: 2, source_event_schema_version: 1 },
+  summary: {
+    event_count: 0,
+    invalid_event_count: 0,
+    session_count: 0,
+    preference_event_count: 0,
+    model_versions: [],
+    preference_model_versions: [],
+  },
+});
+
+const readyArtifact = (): Record<string, any> => ({
+  catalog_version: telemetryRaw.catalog_version,
+  schema: { version: 3, source_event_schema_version: 1 },
+  summary: {
+    event_count: 240,
+    invalid_event_count: 0,
+    session_count: 40,
+    recommendation_accepted_count: 160,
+    preference_event_count: 0,
+    model_versions: [
+      { version: '2:0000000000000000', event_count: 240 },
+    ],
+    preference_model_versions: [],
+  },
+  rounds: ROUND_TYPES.map((roundType, index) => ({
+    round_number: index + 1,
+    round_type: roundType,
+    event_count: 30,
+    recommendation_accepted_count: 20,
+    chosen_position_counts: [10, 10, 10],
+    recommended_position_counts: [12, 10, 8],
+    rate_suppressed: false,
+    preference_top_disagreement_count: 8,
+    meaningful_preference_disagreement_count: 5,
+    player_preference_agreement_count: 15,
+    average_meaningful_preference_disagreement_margin: null,
+  })),
+  analytics: {
+    minimum_rate_support: 10,
+    items: { heroes: [], skills: [] },
+    score_margins: [
+      {
+        key: 'tie',
+        label: '并列',
+        event_count: 240,
+        recommendation_accepted_count: 160,
+        rate_suppressed: false,
+      },
+      ...['0_to_1', '1_to_3', 'over_3'].map((key) => ({
+        key,
+        label: key,
+        event_count: 0,
+        recommendation_accepted_count: 0,
+        rate_suppressed: true,
+      })),
+    ],
+  },
+  preference_model: {
+    model_type: 'conditional-choice-logit',
+    feature_schema_version: 1,
+    meaningful_probability_margin: 0.1,
+    l2: 0.05,
+    evidence: {
+      event_count: 240,
+      session_count: 40,
+      recommendation_disagreement_count: 80,
+      minimum_event_count: 240,
+      minimum_session_count: 40,
+      minimum_recommendation_disagreement_count: 30,
+      holdout_event_count: 48,
+      minimum_holdout_event_count: 36,
+    },
+    status: 'ready',
+    version: 'preference-v1:0000000000000001',
+    held_out: {
+      event_count: 48,
+      accuracy: 0.7,
+      log_loss: 0.8,
+      brier: 0.15,
+      calibration_error: 0.05,
+      train_event_count: 192,
+      paired_accuracy: 0.65,
+      uniform_log_loss: 1.098612288668,
+    },
+    weights: { '["score"]': 0.5 },
+    support: { '["score"]': 720 },
+  },
+});
+
+const responseFor = (body: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(body),
+  }) as unknown as Response;
+
+afterEach(() => {
+  clearTelemetryDataCacheForTests();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('static telemetry artifact boundary', () => {
+  test('accepts the generated hand-off with version-appropriate invariants', () => {
+    const telemetry = parseTelemetryData(telemetryRaw);
+
+    expect(telemetry.summary.event_count).toBe(
+      telemetry.rounds.reduce((sum, round) => sum + round.event_count, 0)
+    );
+    expect(telemetry.rounds).toHaveLength(8);
+    if (telemetry.schema.version === 2) {
+      expect(telemetry.preference_model).toBeNull();
+      expect(telemetry.analytics).toBeUndefined();
+    } else {
+      expect(telemetry.schema.version).toBe(3);
+      expect(telemetry.analytics?.minimum_rate_support).toBe(10);
+      expect(telemetry.preference_model?.status).toMatch(
+        /^(insufficient_evidence|quality_gate_failed|ready)$/
+      );
+    }
+  });
+
+  test('continues to accept the frozen schema-v2 contract', () => {
+    const telemetry = parseTelemetryData(schemaV2Artifact());
+
+    expect(telemetry.schema.version).toBe(2);
+    expect(telemetry.preference_model).toBeNull();
+    expect(telemetry.analytics).toBeUndefined();
+  });
+
+  test('keeps schema-v2 isolated from phase-three fields', () => {
+    const schemaV2 = schemaV2Artifact();
+    expect(() =>
+      parseTelemetryData({
+        ...schemaV2,
+        preference_model: readyArtifact().preference_model,
+      })
+    ).toThrow('Schema-v2');
+    expect(() =>
+      parseTelemetryData({
+        ...schemaV2,
+        analytics: readyArtifact().analytics,
+      })
+    ).toThrow('contract');
+  });
+
+  test('rejects inconsistent public aggregate totals', () => {
+    const schemaV2 = schemaV2Artifact();
+    expect(() =>
+      parseTelemetryData({
+        ...schemaV2,
+        summary: { ...schemaV2.summary, event_count: 999 },
+      })
+    ).toThrow('totals');
+  });
+
+  test('validates a mutually consistent ready schema-v3 model', () => {
+    expect(parseTelemetryData(readyArtifact()).preference_model?.status).toBe(
+      'ready'
+    );
+  });
+
+  test('allows only the exact privacy bucket among unhashed preference versions', () => {
+    const bucketed = readyArtifact();
+    bucketed.summary.preference_event_count = 30;
+    bucketed.summary.preference_model_versions = [
+      { version: 'other', event_count: 20 },
+      {
+        version: 'preference-v2:0000000000000002',
+        event_count: 10,
+      },
+    ];
+    expect(
+      parseTelemetryData(bucketed).summary.preference_model_versions
+    ).toEqual(bucketed.summary.preference_model_versions);
+
+    const arbitraryLabel = clone(bucketed);
+    arbitraryLabel.summary.preference_model_versions[0].version = 'redacted';
+    expect(() => parseTelemetryData(arbitraryLabel)).toThrow('version totals');
+
+    const bareModelFamily = clone(bucketed);
+    bareModelFamily.summary.preference_model_versions[1].version =
+      'preference-v1';
+    expect(() => parseTelemetryData(bareModelFamily)).toThrow('version totals');
+  });
+
+  test('cross-checks round types, summary totals, suppression, and evidence', () => {
+    const mutations = [
+      (artifact: Record<string, any>) => {
+        artifact.rounds[0].round_type = 'skill';
+      },
+      (artifact: Record<string, any>) => {
+        artifact.summary.recommendation_accepted_count = 159;
+      },
+      (artifact: Record<string, any>) => {
+        artifact.rounds[0].rate_suppressed = true;
+      },
+      (artifact: Record<string, any>) => {
+        artifact.preference_model.evidence.event_count = 239;
+      },
+      (artifact: Record<string, any>) => {
+        artifact.preference_model.evidence.recommendation_disagreement_count =
+          30;
+      },
+      (artifact: Record<string, any>) => {
+        artifact.preference_model.held_out.train_event_count = 191;
+      },
+      (artifact: Record<string, any>) => {
+        artifact.preference_model.evidence.holdout_event_count = 240;
+        artifact.preference_model.held_out.event_count = 240;
+        artifact.preference_model.held_out.train_event_count = 0;
+      },
+      (artifact: Record<string, any>) => {
+        artifact.preference_model.held_out.log_loss = 1.098612288668;
+      },
+    ];
+
+    for (const mutate of mutations) {
+      const artifact = readyArtifact();
+      mutate(artifact);
+      expect(() => parseTelemetryData(artifact)).toThrow();
+    }
+  });
+
+  test('requires canonical, supported, bounded preference features', () => {
+    const malformed = readyArtifact();
+    malformed.preference_model.weights = { '[ "score" ]': 0.5 };
+    malformed.preference_model.support = { '[ "score" ]': 720 };
+    expect(() => parseTelemetryData(malformed)).toThrow('ready model');
+
+    const lowSupport = readyArtifact();
+    lowSupport.preference_model.weights = { '["round_score",1]': 0.5 };
+    lowSupport.preference_model.support = { '["round_score",1]': 29 };
+    expect(() => parseTelemetryData(lowSupport)).toThrow('ready model');
+
+    const tooMany = readyArtifact();
+    tooMany.preference_model.weights = Object.fromEntries(
+      Array.from({ length: 5_001 }, (_, index) => [
+        JSON.stringify(['item', 'hero', `H${index}`]),
+        0.1,
+      ])
+    );
+    tooMany.preference_model.support = Object.fromEntries(
+      Object.keys(tooMany.preference_model.weights).map((featureId) => [
+        featureId,
+        10,
+      ])
+    );
+    expect(() => parseTelemetryData(tooMany)).toThrow('ready model');
+  });
+
+  test('cross-checks item opportunities, item suppression, and margin totals', () => {
+    const withItem = readyArtifact();
+    withItem.analytics.items.heroes = [
+      {
+        name: '甲',
+        offer_count: 5,
+        opportunity_count: 90,
+        picked_count: 2,
+        rate_suppressed: true,
+      },
+    ];
+    expect(parseTelemetryData(withItem).analytics?.items.heroes).toHaveLength(1);
+
+    const wrongOpportunity = clone(withItem);
+    wrongOpportunity.analytics.items.heroes[0].opportunity_count = 89;
+    expect(() => parseTelemetryData(wrongOpportunity)).toThrow('analytics');
+
+    const impossibleOfferCount = clone(withItem);
+    impossibleOfferCount.analytics.items.heroes[0].offer_count = 91;
+    impossibleOfferCount.analytics.items.heroes[0].rate_suppressed = false;
+    expect(() => parseTelemetryData(impossibleOfferCount)).toThrow('analytics');
+
+    const wrongItemSuppression = clone(withItem);
+    wrongItemSuppression.analytics.items.heroes[0].rate_suppressed = false;
+    expect(() => parseTelemetryData(wrongItemSuppression)).toThrow('analytics');
+
+    const wrongMarginTotal = readyArtifact();
+    wrongMarginTotal.analytics.score_margins[0].event_count = 239;
+    expect(() => parseTelemetryData(wrongMarginTotal)).toThrow('totals');
+
+    const wrongMarginSuppression = readyArtifact();
+    wrongMarginSuppression.analytics.score_margins[1].rate_suppressed = false;
+    expect(() => parseTelemetryData(wrongMarginSuppression)).toThrow(
+      'score-margin'
+    );
+  });
+
+  test('publishes disagreement averages only for ready, supported rounds', () => {
+    const supported = readyArtifact();
+    supported.rounds[0].preference_top_disagreement_count = 10;
+    supported.rounds[0].meaningful_preference_disagreement_count = 10;
+    supported.rounds[0].average_meaningful_preference_disagreement_margin = 0.2;
+    expect(
+      parseTelemetryData(supported).rounds[0]
+        .average_meaningful_preference_disagreement_margin
+    ).toBe(0.2);
+
+    const lowSupport = readyArtifact();
+    lowSupport.rounds[0].average_meaningful_preference_disagreement_margin = 0.2;
+    expect(() => parseTelemetryData(lowSupport)).toThrow('round 1');
+
+    const unavailable = readyArtifact();
+    unavailable.preference_model.status = 'quality_gate_failed';
+    unavailable.preference_model.version = null;
+    unavailable.preference_model.held_out.log_loss = 1.098612288668;
+    unavailable.preference_model.weights = {};
+    unavailable.preference_model.support = {};
+    unavailable.rounds.forEach((round: Record<string, any>) => {
+      round.preference_top_disagreement_count = null;
+      round.meaningful_preference_disagreement_count = null;
+      round.player_preference_agreement_count = null;
+      round.average_meaningful_preference_disagreement_margin = null;
+    });
+    expect(
+      parseTelemetryData(unavailable).preference_model?.status
+    ).toBe('quality_gate_failed');
+    unavailable.rounds[0].average_meaningful_preference_disagreement_margin =
+      0.2;
+    expect(() => parseTelemetryData(unavailable)).toThrow('round 1');
+  });
+});
+
+describe('static telemetry cache recovery', () => {
+  test('times out, aborts, clears the failed cache, and retries successfully', async () => {
+    vi.useFakeTimers();
+    let firstSignal: AbortSignal | null | undefined;
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        (
+          _input: Parameters<typeof fetch>[0],
+          init?: Parameters<typeof fetch>[1]
+        ) => {
+          firstSignal = init?.signal;
+          return new Promise<Response>(() => undefined);
+        }
+      )
+      .mockResolvedValueOnce(responseFor(schemaV2Artifact()));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const firstLoad = loadTelemetryData();
+    const rejection = expect(firstLoad).rejects.toThrow('timed out');
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejection;
+
+    expect(firstSignal?.aborted).toBe(true);
+    const recovered = await loadTelemetryData();
+    expect(recovered.schema.version).toBe(2);
+    expect(getCachedTelemetryData()).toBe(recovered);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('clearing an in-flight request prevents its late result from replacing a new cache', async () => {
+    vi.useFakeTimers();
+    let settleFirst!: (response: Response) => void;
+    let firstSignal: AbortSignal | null | undefined;
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        (
+          _input: Parameters<typeof fetch>[0],
+          init?: Parameters<typeof fetch>[1]
+        ) => {
+          firstSignal = init?.signal;
+          return new Promise<Response>((resolve) => {
+            settleFirst = resolve;
+          });
+        }
+      )
+      .mockResolvedValueOnce(responseFor(schemaV2Artifact()));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const staleLoad = loadTelemetryData();
+    clearTelemetryDataCacheForTests();
+    expect(firstSignal?.aborted).toBe(true);
+
+    const active = await loadTelemetryData();
+    const staleArtifact = schemaV2Artifact();
+    staleArtifact.summary.invalid_event_count = 99;
+    settleFirst(responseFor(staleArtifact));
+    await staleLoad;
+
+    expect(getCachedTelemetryData()).toBe(active);
+    expect(getCachedTelemetryData()?.summary.invalid_event_count).toBe(
+      schemaV2Artifact().summary.invalid_event_count
+    );
+  });
+});

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -7,6 +7,9 @@ import {
 import { database, recommendationData } from '../data';
 import { tierRank } from '../utils/tiers';
 import type { DatabaseItems, RoundType, GameState } from '../types/game';
+import type { PreferencePrediction } from '../types/telemetryData';
+import { getCachedTelemetryData, preloadTelemetryData } from './telemetryData';
+import { predictPlayerPreference } from './preferenceModel';
 
 /**
  * In-memory recommendation shim (nothing in this module is HTTP). All scoring
@@ -103,6 +106,7 @@ export const api = {
       recommended_set_index: number;
       recommended_set: string[];
       analysis: OptionAnalysis[];
+      preference: PreferencePrediction | null;
     };
     round_info: {
       round_number: number;
@@ -124,6 +128,31 @@ export const api = {
       roundType === 'hero'
         ? recommendHeroSet(availableSets, currentHeroes, recommendationData, currentSkills)
         : recommendSkillSet(availableSets, currentHeroes, currentSkills, recommendationData);
+    const pairedScores = [0, 1, 2].map(
+      (index) =>
+        rec.analysis.find((option) => option.set_index === index)?.final_score ??
+        0
+    );
+    const telemetryData = getCachedTelemetryData();
+    if (!telemetryData) preloadTelemetryData();
+    const preference = telemetryData
+      ? predictPlayerPreference(telemetryData, {
+          roundNumber: gameState.round_number || 1,
+          roundType,
+          poolBefore: {
+            heroes: [...(gameState.current_heroes || [])],
+            skills: [...(gameState.current_skills || [])],
+            ...(gameState.support_hero
+              ? { heroSupport: gameState.support_hero }
+              : {}),
+            ...(gameState.support_skills?.length
+              ? { skillsSupport: [...gameState.support_skills] }
+              : {}),
+          },
+          offeredSets: availableSets,
+          pairedScores,
+        })
+      : null;
 
     return {
       success: true,
@@ -131,6 +160,7 @@ export const api = {
         recommended_set_index: rec.recommended_set,
         recommended_set: availableSets[rec.recommended_set] || [],
         analysis: rec.analysis,
+        preference,
       },
       round_info: {
         round_number: gameState.round_number || 1,

--- a/web/src/services/preferenceModel.ts
+++ b/web/src/services/preferenceModel.ts
@@ -1,0 +1,139 @@
+import type {
+  PreferencePrediction,
+  TelemetryData,
+} from '../types/telemetryData';
+import type { RoundType } from '../types/game';
+
+export interface PreferenceContext {
+  roundNumber: number;
+  roundType: RoundType;
+  poolBefore: {
+    heroes: string[];
+    skills: string[];
+    heroSupport?: string;
+    skillsSupport?: string[];
+  };
+  offeredSets: string[][];
+  pairedScores: number[];
+}
+
+const featureId = (...parts: unknown[]): string => JSON.stringify(parts);
+
+export const preferenceFeatures = (
+  context: PreferenceContext,
+  optionIndex: number
+): Record<string, number> => {
+  const scoreMean =
+    context.pairedScores.reduce((sum, score) => sum + score, 0) / 3;
+  const centeredScore =
+    (context.pairedScores[optionIndex] - scoreMean) / 10;
+  const features: Record<string, number> = {
+    [featureId('score')]: centeredScore,
+    [featureId('round_score', context.roundNumber)]: centeredScore,
+    [featureId('position', optionIndex)]: 1,
+  };
+  const poolItems: [RoundType, string][] = [
+    ...context.poolBefore.heroes.map(
+      (item): [RoundType, string] => ['hero', item]
+    ),
+    ...context.poolBefore.skills.map(
+      (item): [RoundType, string] => ['skill', item]
+    ),
+    ...(context.poolBefore.heroSupport
+      ? ([['hero', context.poolBefore.heroSupport]] as [RoundType, string][])
+      : []),
+    ...(context.poolBefore.skillsSupport || []).map(
+      (item): [RoundType, string] => ['skill', item]
+    ),
+  ];
+
+  for (const item of context.offeredSets[optionIndex]) {
+    features[featureId('item', context.roundType, item)] = 1;
+    for (const [poolType, poolItem] of poolItems) {
+      features[
+        featureId(
+          'pool_item',
+          poolType,
+          poolItem,
+          context.roundType,
+          item
+        )
+      ] = 1;
+    }
+  }
+  return features;
+};
+
+const softmax = (values: number[]): [number, number, number] => {
+  const maximum = Math.max(...values);
+  const exponentials = values.map((value) =>
+    Math.exp(Math.max(-700, Math.min(700, value - maximum)))
+  );
+  const total = exponentials.reduce((sum, value) => sum + value, 0);
+  return exponentials.map((value) => value / total) as [
+    number,
+    number,
+    number,
+  ];
+};
+
+/**
+ * Match the one-decimal percentages shown in the UI while preserving an exact
+ * 100.0% total. The same quantized probabilities are stored in telemetry.
+ */
+export const normalizePreferenceForDisplay = (
+  probabilities: [number, number, number]
+): [number, number, number] => {
+  const scaled = probabilities.map((probability) => probability * 1000);
+  const units = scaled.map(Math.floor);
+  let remainder = 1000 - units.reduce((sum, value) => sum + value, 0);
+  const order = [0, 1, 2].sort(
+    (left, right) =>
+      scaled[right] - units[right] - (scaled[left] - units[left]) ||
+      left - right
+  );
+  for (let index = 0; index < remainder; index += 1) {
+    units[order[index % order.length]] += 1;
+  }
+  remainder = 1000 - units.reduce((sum, value) => sum + value, 0);
+  if (remainder !== 0) units[0] += remainder;
+  return units.map((value) => value / 1000) as [number, number, number];
+};
+
+export const predictPlayerPreference = (
+  artifact: TelemetryData,
+  context: PreferenceContext
+): PreferencePrediction | null => {
+  const model = artifact.preference_model;
+  if (
+    !model ||
+    model.status !== 'ready' ||
+    !model.version ||
+    context.offeredSets.length !== 3 ||
+    context.offeredSets.some((set) => set.length === 0) ||
+    context.pairedScores.length !== 3 ||
+    context.pairedScores.some((score) => !Number.isFinite(score))
+  ) {
+    return null;
+  }
+
+  const utilities = [0, 1, 2].map((optionIndex) =>
+    Object.entries(preferenceFeatures(context, optionIndex)).reduce(
+      (sum, [key, value]) => sum + (model.weights[key] || 0) * value,
+      0
+    )
+  );
+  const probabilities = normalizePreferenceForDisplay(softmax(utilities));
+  const ranked = [0, 1, 2].sort(
+    (left, right) =>
+      probabilities[right] - probabilities[left] || left - right
+  );
+  return {
+    version: model.version,
+    probabilities,
+    top_index: ranked[0],
+    probability_margin:
+      probabilities[ranked[0]] - probabilities[ranked[1]],
+    meaningful_margin: model.meaningful_probability_margin,
+  };
+};

--- a/web/src/services/preferenceModel.ts
+++ b/web/src/services/preferenceModel.ts
@@ -18,6 +18,17 @@ export interface PreferenceContext {
 }
 
 const featureId = (...parts: unknown[]): string => JSON.stringify(parts);
+const GENERIC_EXPLANATION_DRIVER =
+  '这是相似阵容与选项中的总体选择倾向。';
+
+interface ReadablePreferenceDriver {
+  featureId: string;
+  kind: 'item' | 'pool_item';
+  item: string;
+  poolItem?: string;
+  contribution: number;
+  support: number;
+}
 
 export const preferenceFeatures = (
   context: PreferenceContext,
@@ -77,6 +88,109 @@ const softmax = (values: number[]): [number, number, number] => {
   ];
 };
 
+const parseReadableDriver = (
+  id: string,
+  contribution: number,
+  support: number
+): ReadablePreferenceDriver | null => {
+  let parts: unknown;
+  try {
+    parts = JSON.parse(id);
+  } catch {
+    return null;
+  }
+  if (
+    !Array.isArray(parts) ||
+    parts.some((part) => typeof part !== 'string')
+  ) {
+    return null;
+  }
+  if (
+    parts.length === 3 &&
+    parts[0] === 'item'
+  ) {
+    return {
+      featureId: id,
+      kind: 'item',
+      item: parts[2],
+      contribution,
+      support,
+    };
+  }
+  if (
+    parts.length === 5 &&
+    parts[0] === 'pool_item'
+  ) {
+    return {
+      featureId: id,
+      kind: 'pool_item',
+      poolItem: parts[2],
+      item: parts[4],
+      contribution,
+      support,
+    };
+  }
+  return null;
+};
+
+const readableExplanationDriver = (
+  weights: Record<string, number>,
+  support: Record<string, number>,
+  preferenceTopFeatures: Record<string, number>,
+  pairedTopFeatures: Record<string, number>
+): string => {
+  const candidates = Object.entries(weights)
+    .map(([id, weight]) => {
+      const preferenceValue = preferenceTopFeatures[id] || 0;
+      const pairedValue = pairedTopFeatures[id] || 0;
+      if (preferenceValue <= pairedValue) return null;
+      const contribution = weight * (preferenceValue - pairedValue);
+      if (!(contribution > 0)) return null;
+      return parseReadableDriver(id, contribution, support[id] || 0);
+    })
+    .filter(
+      (candidate): candidate is ReadablePreferenceDriver =>
+        candidate !== null
+    )
+    .sort(
+      (left, right) =>
+        right.contribution - left.contribution ||
+        right.support - left.support ||
+        (left.featureId < right.featureId
+          ? -1
+          : left.featureId > right.featureId
+            ? 1
+            : 0)
+    );
+
+  const strongest = candidates[0];
+  if (!strongest) return GENERIC_EXPLANATION_DRIVER;
+
+  if (strongest.kind === 'pool_item') {
+    const items = [
+      ...new Set(
+        candidates
+          .filter(
+            (candidate) =>
+              candidate.kind === 'pool_item' &&
+              candidate.poolItem === strongest.poolItem
+          )
+          .map((candidate) => candidate.item)
+      ),
+    ].slice(0, 2);
+    return `当前已有${strongest.poolItem}时，${items.join('、')}在模型中的选择信号较强。`;
+  }
+
+  const items = [
+    ...new Set(
+      candidates
+        .filter((candidate) => candidate.kind === 'item')
+        .map((candidate) => candidate.item)
+    ),
+  ].slice(0, 2);
+  return `${items.join('、')}在模型中的选择信号较强。`;
+};
+
 /**
  * Match the one-decimal percentages shown in the UI while preserving an exact
  * 100.0% total. The same quantized probabilities are stored in telemetry.
@@ -117,8 +231,11 @@ export const predictPlayerPreference = (
     return null;
   }
 
-  const utilities = [0, 1, 2].map((optionIndex) =>
-    Object.entries(preferenceFeatures(context, optionIndex)).reduce(
+  const optionFeatures = [0, 1, 2].map((optionIndex) =>
+    preferenceFeatures(context, optionIndex)
+  );
+  const utilities = optionFeatures.map((features) =>
+    Object.entries(features).reduce(
       (sum, [key, value]) => sum + (model.weights[key] || 0) * value,
       0
     )
@@ -128,6 +245,19 @@ export const predictPlayerPreference = (
     (left, right) =>
       probabilities[right] - probabilities[left] || left - right
   );
+  const maximumPairedScore = Math.max(...context.pairedScores);
+  const pairedTopIndices = [0, 1, 2].filter(
+    (index) => context.pairedScores[index] === maximumPairedScore
+  );
+  const explanationDriver =
+    pairedTopIndices.length === 1
+      ? readableExplanationDriver(
+          model.weights,
+          model.support,
+          optionFeatures[ranked[0]],
+          optionFeatures[pairedTopIndices[0]]
+        )
+      : GENERIC_EXPLANATION_DRIVER;
   return {
     version: model.version,
     probabilities,
@@ -135,5 +265,6 @@ export const predictPlayerPreference = (
     probability_margin:
       probabilities[ranked[0]] - probabilities[ranked[1]],
     meaningful_margin: model.meaningful_probability_margin,
+    explanation_driver: explanationDriver,
   };
 };

--- a/web/src/services/telemetry.ts
+++ b/web/src/services/telemetry.ts
@@ -27,7 +27,29 @@ const isValidInput = (input: RoundTelemetryInput): boolean => {
       : [
           ...input.poolBefore.skills,
           ...(input.poolBefore.skillsSupport || []),
-        ];
+      ];
+  const preferenceAbsent =
+    input.preferenceModelVersion == null &&
+    input.preferenceProbabilities == null;
+  const preferencePresent =
+    typeof input.preferenceModelVersion === 'string' &&
+    /^preference-v[1-9]\d*:[0-9a-f]{16}$/.test(
+      input.preferenceModelVersion
+    ) &&
+    Array.isArray(input.preferenceProbabilities) &&
+    input.preferenceProbabilities.length === 3 &&
+    input.preferenceProbabilities.every(
+      (probability) =>
+        Number.isFinite(probability) &&
+        probability >= 0 &&
+        probability <= 1
+    ) &&
+    Math.abs(
+      input.preferenceProbabilities.reduce(
+        (sum, probability) => sum + probability,
+        0
+      ) - 1
+    ) <= 1e-6;
 
   return (
     Number.isInteger(input.roundNumber) &&
@@ -43,7 +65,8 @@ const isValidInput = (input: RoundTelemetryInput): boolean => {
     input.recommendedIndex <= 2 &&
     Number.isInteger(input.chosenIndex) &&
     input.chosenIndex >= 0 &&
-    input.chosenIndex <= 2
+    input.chosenIndex <= 2 &&
+    (preferenceAbsent || preferencePresent)
   );
 };
 
@@ -75,8 +98,10 @@ export const createRoundTelemetryEvent = (
     paired_scores: [...input.pairedScores],
     recommended_index: input.recommendedIndex,
     chosen_index: input.chosenIndex,
-    preference_model_version: null,
-    preference_probabilities: null,
+    preference_model_version: input.preferenceModelVersion ?? null,
+    preference_probabilities: input.preferenceProbabilities
+      ? [...input.preferenceProbabilities]
+      : null,
   };
 };
 

--- a/web/src/services/telemetryData.ts
+++ b/web/src/services/telemetryData.ts
@@ -1,0 +1,780 @@
+import { recommendationData } from '../data';
+import type { TelemetryData } from '../types/telemetryData';
+
+const ENDPOINT = '/game-data/telemetry_data.json';
+const STATIC_FETCH_TIMEOUT_MS = 5_000;
+
+const MIN_RATE_SUPPORT = 10;
+const MIN_MODEL_EVENTS = 240;
+const MIN_MODEL_SESSIONS = 40;
+const MIN_MODEL_DISAGREEMENTS = 30;
+const MIN_HOLDOUT_EVENTS = 36;
+const MIN_FEATURE_SUPPORT = 10;
+const MAX_MODEL_VERSIONS = 32;
+const MAX_PUBLISHED_PREFERENCE_MODEL_VERSIONS = 32;
+const MAX_PREFERENCE_FEATURES = 5_000;
+const MEANINGFUL_PREFERENCE_MARGIN = 0.1;
+const PREFERENCE_L2 = 0.05;
+const MIN_HELD_OUT_LOG_LOSS_IMPROVEMENT = 0.01;
+const UNIFORM_LOG_LOSS = 1.098612288668;
+const PREFERENCE_VERSION_OTHER_BUCKET = 'other';
+
+const ROUND_TYPES = [
+  'hero',
+  'skill',
+  'skill',
+  'hero',
+  'skill',
+  'skill',
+  'hero',
+  'skill',
+] as const;
+const SCORE_MARGIN_KEYS = ['tie', '0_to_1', '1_to_3', 'over_3'] as const;
+const MODEL_VERSION_RE = /^[1-9]\d*:[0-9a-f]{16}$/;
+const PREFERENCE_MODEL_VERSION_RE =
+  /^preference-v[1-9]\d*:[0-9a-f]{16}$/;
+const READY_PREFERENCE_MODEL_VERSION_RE =
+  /^preference-v1:[0-9a-f]{16}$/;
+
+const V2_TOP_LEVEL_KEYS = [
+  'schema',
+  'catalog_version',
+  'summary',
+  'rounds',
+  'preference_model',
+] as const;
+const V3_TOP_LEVEL_KEYS = [...V2_TOP_LEVEL_KEYS, 'analytics'] as const;
+const SCHEMA_KEYS = ['version', 'source_event_schema_version'] as const;
+const V2_SUMMARY_KEYS = [
+  'event_count',
+  'invalid_event_count',
+  'session_count',
+  'preference_event_count',
+  'model_versions',
+  'preference_model_versions',
+] as const;
+const V3_SUMMARY_KEYS = [
+  'event_count',
+  'invalid_event_count',
+  'session_count',
+  'recommendation_accepted_count',
+  'preference_event_count',
+  'model_versions',
+  'preference_model_versions',
+] as const;
+const V2_ROUND_KEYS = [
+  'round_number',
+  'round_type',
+  'event_count',
+  'recommendation_accepted_count',
+  'chosen_position_counts',
+  'recommended_position_counts',
+] as const;
+const V3_ROUND_KEYS = [
+  ...V2_ROUND_KEYS,
+  'rate_suppressed',
+  'preference_top_disagreement_count',
+  'meaningful_preference_disagreement_count',
+  'player_preference_agreement_count',
+  'average_meaningful_preference_disagreement_margin',
+] as const;
+const VERSION_COUNT_KEYS = ['version', 'event_count'] as const;
+const PREFERENCE_MODEL_KEYS = [
+  'model_type',
+  'feature_schema_version',
+  'meaningful_probability_margin',
+  'l2',
+  'evidence',
+  'status',
+  'version',
+  'held_out',
+  'weights',
+  'support',
+] as const;
+const EVIDENCE_KEYS = [
+  'event_count',
+  'session_count',
+  'recommendation_disagreement_count',
+  'minimum_event_count',
+  'minimum_session_count',
+  'minimum_recommendation_disagreement_count',
+  'holdout_event_count',
+  'minimum_holdout_event_count',
+] as const;
+const HELD_OUT_KEYS = [
+  'event_count',
+  'accuracy',
+  'log_loss',
+  'brier',
+  'calibration_error',
+  'train_event_count',
+  'paired_accuracy',
+  'uniform_log_loss',
+] as const;
+const ANALYTICS_KEYS = [
+  'minimum_rate_support',
+  'items',
+  'score_margins',
+] as const;
+const ITEM_FAMILY_KEYS = ['heroes', 'skills'] as const;
+const ITEM_KEYS = [
+  'name',
+  'offer_count',
+  'opportunity_count',
+  'picked_count',
+  'rate_suppressed',
+] as const;
+const SCORE_MARGIN_KEYS_REQUIRED = [
+  'key',
+  'label',
+  'event_count',
+  'recommendation_accepted_count',
+  'rate_suppressed',
+] as const;
+
+let cached: Promise<TelemetryData> | null = null;
+let resolved: TelemetryData | null = null;
+let cachedController: AbortController | null = null;
+let cacheGeneration = 0;
+
+const isCount = (value: unknown): value is number =>
+  Number.isInteger(value) && (value as number) >= 0;
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+const isShortString = (
+  value: unknown,
+  maximum = 128
+): value is string =>
+  typeof value === 'string' && value.length > 0 && value.length <= maximum;
+const hasExactKeys = (
+  value: unknown,
+  expected: readonly string[]
+): value is Record<string, unknown> =>
+  isRecord(value) &&
+  Object.keys(value).length === expected.length &&
+  expected.every((key) => Object.hasOwn(value, key));
+
+const validPositionCounts = (value: unknown, expectedTotal: number): boolean =>
+  Array.isArray(value) &&
+  value.length === 3 &&
+  value.every(isCount) &&
+  value.reduce((sum, count) => sum + count, 0) === expectedTotal;
+
+const validVersionCounts = (
+  value: unknown,
+  expectedTotal: number,
+  maximumEntries: number,
+  validEntry: (version: string, eventCount: number) => boolean
+): boolean => {
+  if (!Array.isArray(value) || value.length > maximumEntries) return false;
+  let total = 0;
+  let previousVersion: string | null = null;
+  for (const entry of value) {
+    if (
+      !hasExactKeys(entry, VERSION_COUNT_KEYS) ||
+      !isShortString(entry.version) ||
+      !isCount(entry.event_count) ||
+      entry.event_count === 0 ||
+      !validEntry(entry.version, entry.event_count) ||
+      (previousVersion !== null && previousVersion >= entry.version)
+    ) {
+      return false;
+    }
+    previousVersion = entry.version;
+    total += entry.event_count;
+  }
+  return total === expectedTotal;
+};
+
+const preferenceFeatureParts = (featureId: string): unknown[] | null => {
+  if (!isShortString(featureId, 512)) return null;
+  let parts: unknown;
+  try {
+    parts = JSON.parse(featureId);
+  } catch {
+    return null;
+  }
+  if (
+    !Array.isArray(parts) ||
+    parts.length === 0 ||
+    JSON.stringify(parts) !== featureId
+  ) {
+    return null;
+  }
+  const item = (value: unknown) => isShortString(value, 64);
+  if (parts.length === 1 && parts[0] === 'score') return parts;
+  if (
+    parts.length === 2 &&
+    parts[0] === 'round_score' &&
+    Number.isInteger(parts[1]) &&
+    (parts[1] as number) >= 1 &&
+    (parts[1] as number) <= 8
+  ) {
+    return parts;
+  }
+  if (
+    parts.length === 2 &&
+    parts[0] === 'position' &&
+    Number.isInteger(parts[1]) &&
+    (parts[1] as number) >= 0 &&
+    (parts[1] as number) <= 2
+  ) {
+    return parts;
+  }
+  if (
+    parts.length === 3 &&
+    parts[0] === 'item' &&
+    (parts[1] === 'hero' || parts[1] === 'skill') &&
+    item(parts[2])
+  ) {
+    return parts;
+  }
+  if (
+    parts.length === 5 &&
+    parts[0] === 'pool_item' &&
+    (parts[1] === 'hero' || parts[1] === 'skill') &&
+    item(parts[2]) &&
+    (parts[3] === 'hero' || parts[3] === 'skill') &&
+    item(parts[4])
+  ) {
+    return parts;
+  }
+  return null;
+};
+
+const validateRounds = (
+  rounds: unknown,
+  schemaVersion: 2 | 3
+): { totalEvents: number; totalAccepted: number } => {
+  if (!Array.isArray(rounds) || rounds.length !== 8) {
+    throw new Error('Telemetry artifact contract is invalid');
+  }
+
+  let totalEvents = 0;
+  let totalAccepted = 0;
+  rounds.forEach((round, index) => {
+    const expectedKeys = schemaVersion === 2 ? V2_ROUND_KEYS : V3_ROUND_KEYS;
+    if (
+      !hasExactKeys(round, expectedKeys) ||
+      round.round_number !== index + 1 ||
+      round.round_type !== ROUND_TYPES[index] ||
+      !isCount(round.event_count) ||
+      !isCount(round.recommendation_accepted_count) ||
+      round.recommendation_accepted_count > round.event_count ||
+      !validPositionCounts(round.chosen_position_counts, round.event_count) ||
+      !validPositionCounts(round.recommended_position_counts, round.event_count) ||
+      (schemaVersion === 3 &&
+        round.rate_suppressed !== (round.event_count < MIN_RATE_SUPPORT))
+    ) {
+      throw new Error(`Telemetry round ${index + 1} is invalid`);
+    }
+    totalEvents += round.event_count;
+    totalAccepted += round.recommendation_accepted_count;
+  });
+  return { totalEvents, totalAccepted };
+};
+
+const validateSummary = (
+  summary: unknown,
+  schemaVersion: 2 | 3,
+  totalEvents: number,
+  totalAccepted: number
+): Record<string, unknown> => {
+  const expectedKeys = schemaVersion === 2 ? V2_SUMMARY_KEYS : V3_SUMMARY_KEYS;
+  if (
+    !hasExactKeys(summary, expectedKeys) ||
+    !isCount(summary.event_count) ||
+    !isCount(summary.invalid_event_count) ||
+    !isCount(summary.session_count) ||
+    summary.session_count > totalEvents ||
+    !isCount(summary.preference_event_count) ||
+    summary.preference_event_count > totalEvents
+  ) {
+    throw new Error('Telemetry artifact contract is invalid');
+  }
+  if (summary.event_count !== totalEvents) {
+    throw new Error('Telemetry event totals are inconsistent');
+  }
+  if (
+    schemaVersion === 3 &&
+    (!isCount(summary.recommendation_accepted_count) ||
+      summary.recommendation_accepted_count !== totalAccepted)
+  ) {
+    throw new Error('Phase 3 telemetry summary totals are inconsistent');
+  }
+  if (
+    !validVersionCounts(
+      summary.model_versions,
+      totalEvents,
+      MAX_MODEL_VERSIONS,
+      (version) => MODEL_VERSION_RE.test(version)
+    ) ||
+    !validVersionCounts(
+      summary.preference_model_versions,
+      summary.preference_event_count,
+      MAX_PUBLISHED_PREFERENCE_MODEL_VERSIONS,
+      (version, eventCount) =>
+        version === PREFERENCE_VERSION_OTHER_BUCKET ||
+        (PREFERENCE_MODEL_VERSION_RE.test(version) &&
+          eventCount >= MIN_RATE_SUPPORT)
+    )
+  ) {
+    throw new Error('Telemetry artifact version totals are inconsistent');
+  }
+  return summary;
+};
+
+const validHeldOutMetrics = (
+  heldOut: unknown,
+  totalEvents: number,
+  holdoutEventCount: number
+): heldOut is Record<string, unknown> => {
+  if (
+    !hasExactKeys(heldOut, HELD_OUT_KEYS) ||
+    !isCount(heldOut.event_count) ||
+    heldOut.event_count !== holdoutEventCount ||
+    !isCount(heldOut.train_event_count) ||
+    heldOut.train_event_count === 0 ||
+    heldOut.train_event_count + heldOut.event_count !== totalEvents
+  ) {
+    return false;
+  }
+  const finiteFields = [
+    'accuracy',
+    'log_loss',
+    'brier',
+    'calibration_error',
+    'paired_accuracy',
+    'uniform_log_loss',
+  ] as const;
+  if (!finiteFields.every((field) => isFiniteNumber(heldOut[field]))) {
+    return false;
+  }
+  const unitIntervalFields = [
+    'accuracy',
+    'brier',
+    'calibration_error',
+    'paired_accuracy',
+  ] as const;
+  return (
+    unitIntervalFields.every(
+      (field) =>
+        (heldOut[field] as number) >= 0 &&
+        (heldOut[field] as number) <= 1
+    ) &&
+    (heldOut.log_loss as number) >= 0 &&
+    heldOut.uniform_log_loss === UNIFORM_LOG_LOSS
+  );
+};
+
+const validReadyCoefficients = (
+  weights: Record<string, unknown>,
+  support: Record<string, unknown>
+): boolean => {
+  const featureIds = Object.keys(weights);
+  const supportIds = Object.keys(support);
+  if (
+    featureIds.length === 0 ||
+    featureIds.length > MAX_PREFERENCE_FEATURES ||
+    featureIds.length !== supportIds.length ||
+    featureIds.some((featureId) => !Object.hasOwn(support, featureId))
+  ) {
+    return false;
+  }
+  return featureIds.every((featureId) => {
+    const parts = preferenceFeatureParts(featureId);
+    const minimumSupport =
+      parts?.[0] === 'round_score'
+        ? MIN_RATE_SUPPORT * 3
+        : MIN_FEATURE_SUPPORT;
+    return (
+      parts !== null &&
+      isFiniteNumber(weights[featureId]) &&
+      isCount(support[featureId]) &&
+      (support[featureId] as number) >= minimumSupport
+    );
+  });
+};
+
+const validatePreferenceModel = (
+  value: unknown,
+  summary: Record<string, unknown>,
+  totalEvents: number
+): 'insufficient_evidence' | 'quality_gate_failed' | 'ready' => {
+  if (
+    !hasExactKeys(value, PREFERENCE_MODEL_KEYS) ||
+    value.model_type !== 'conditional-choice-logit' ||
+    value.feature_schema_version !== 1 ||
+    value.meaningful_probability_margin !== MEANINGFUL_PREFERENCE_MARGIN ||
+    value.l2 !== PREFERENCE_L2 ||
+    (value.status !== 'insufficient_evidence' &&
+      value.status !== 'quality_gate_failed' &&
+      value.status !== 'ready') ||
+    !hasExactKeys(value.evidence, EVIDENCE_KEYS) ||
+    !isRecord(value.weights) ||
+    !isRecord(value.support)
+  ) {
+    throw new Error('Phase 3 telemetry preference model is invalid');
+  }
+
+  const evidence = value.evidence;
+  const weights = value.weights;
+  const support = value.support;
+  if (
+    !EVIDENCE_KEYS.every((field) => isCount(evidence[field])) ||
+    evidence.event_count !== totalEvents ||
+    evidence.session_count !== summary.session_count ||
+    !isCount(summary.recommendation_accepted_count) ||
+    evidence.recommendation_disagreement_count !==
+      totalEvents - summary.recommendation_accepted_count ||
+    evidence.minimum_event_count !== MIN_MODEL_EVENTS ||
+    evidence.minimum_session_count !== MIN_MODEL_SESSIONS ||
+    evidence.minimum_recommendation_disagreement_count !==
+      MIN_MODEL_DISAGREEMENTS ||
+    evidence.minimum_holdout_event_count !== MIN_HOLDOUT_EVENTS ||
+    (evidence.holdout_event_count as number) > totalEvents
+  ) {
+    throw new Error('Phase 3 telemetry preference evidence is inconsistent');
+  }
+
+  const evidenceSufficient =
+    (evidence.event_count as number) >=
+      (evidence.minimum_event_count as number) &&
+    (evidence.session_count as number) >=
+      (evidence.minimum_session_count as number) &&
+    (evidence.recommendation_disagreement_count as number) >=
+      (evidence.minimum_recommendation_disagreement_count as number) &&
+    (evidence.holdout_event_count as number) >=
+      (evidence.minimum_holdout_event_count as number);
+  const status = value.status;
+
+  if (status === 'insufficient_evidence') {
+    if (
+      value.version !== null ||
+      value.held_out !== null ||
+      Object.keys(weights).length !== 0 ||
+      Object.keys(support).length !== 0 ||
+      (evidenceSufficient && evidence.holdout_event_count !== totalEvents)
+    ) {
+      throw new Error('Phase 3 telemetry model status is inconsistent');
+    }
+    return status;
+  }
+
+  if (
+    !evidenceSufficient ||
+    !validHeldOutMetrics(
+      value.held_out,
+      totalEvents,
+      evidence.holdout_event_count as number
+    )
+  ) {
+    throw new Error('Phase 3 telemetry held-out metrics are inconsistent');
+  }
+  const qualityPassed =
+    (value.held_out.uniform_log_loss as number) -
+      (value.held_out.log_loss as number) >=
+    MIN_HELD_OUT_LOG_LOSS_IMPROVEMENT;
+
+  if (status === 'quality_gate_failed') {
+    if (
+      qualityPassed ||
+      value.version !== null ||
+      Object.keys(weights).length !== 0 ||
+      Object.keys(support).length !== 0
+    ) {
+      throw new Error('Phase 3 telemetry model status is inconsistent');
+    }
+    return status;
+  }
+
+  if (
+    !qualityPassed ||
+    !isShortString(value.version) ||
+    !READY_PREFERENCE_MODEL_VERSION_RE.test(value.version) ||
+    !validReadyCoefficients(weights, support)
+  ) {
+    throw new Error('Phase 3 telemetry ready model is invalid');
+  }
+  return status;
+};
+
+const validatePreferenceRoundFields = (
+  rounds: unknown,
+  status: 'insufficient_evidence' | 'quality_gate_failed' | 'ready'
+): void => {
+  if (!Array.isArray(rounds)) {
+    throw new Error('Phase 3 telemetry rounds are invalid');
+  }
+  for (const round of rounds) {
+    if (!isRecord(round) || !isCount(round.event_count)) {
+      throw new Error('Phase 3 telemetry rounds are invalid');
+    }
+    const preferenceCounts = [
+      round.preference_top_disagreement_count,
+      round.meaningful_preference_disagreement_count,
+      round.player_preference_agreement_count,
+    ];
+    const eventCount = round.event_count;
+    if (status !== 'ready') {
+      if (
+        preferenceCounts.some((count) => count !== null) ||
+        round.average_meaningful_preference_disagreement_margin !== null
+      ) {
+        throw new Error(
+          `Phase 3 telemetry round ${String(round.round_number)} is invalid`
+        );
+      }
+      continue;
+    }
+    if (
+      preferenceCounts.some(
+        (count) => !isCount(count) || count > eventCount
+      ) ||
+      !isCount(round.preference_top_disagreement_count) ||
+      !isCount(round.meaningful_preference_disagreement_count) ||
+      round.meaningful_preference_disagreement_count >
+        round.preference_top_disagreement_count
+    ) {
+      throw new Error(
+        `Phase 3 telemetry round ${String(round.round_number)} is invalid`
+      );
+    }
+    const meaningfulCount = round.meaningful_preference_disagreement_count;
+    const averageMargin =
+      round.average_meaningful_preference_disagreement_margin;
+    if (
+      (meaningfulCount >= MIN_RATE_SUPPORT &&
+        (!isFiniteNumber(averageMargin) ||
+          averageMargin < MEANINGFUL_PREFERENCE_MARGIN ||
+          averageMargin > 1)) ||
+      (meaningfulCount < MIN_RATE_SUPPORT && averageMargin !== null)
+    ) {
+      throw new Error(
+        `Phase 3 telemetry round ${String(round.round_number)} is invalid`
+      );
+    }
+  }
+};
+
+const validateItemRows = (
+  value: unknown,
+  expectedOpportunityCount: number
+): boolean => {
+  if (!Array.isArray(value)) return false;
+  let previousName: string | null = null;
+  for (const row of value) {
+    if (
+      !hasExactKeys(row, ITEM_KEYS) ||
+      !isShortString(row.name, 64) ||
+      (previousName !== null && previousName >= row.name) ||
+      !isCount(row.offer_count) ||
+      row.offer_count === 0 ||
+      !isCount(row.opportunity_count) ||
+      row.opportunity_count !== expectedOpportunityCount ||
+      row.offer_count > row.opportunity_count ||
+      !isCount(row.picked_count) ||
+      row.picked_count > row.offer_count ||
+      row.rate_suppressed !== (row.offer_count < MIN_RATE_SUPPORT)
+    ) {
+      return false;
+    }
+    previousName = row.name;
+  }
+  return true;
+};
+
+const validateAnalytics = (
+  value: unknown,
+  rounds: unknown,
+  totalEvents: number,
+  totalAccepted: number
+): void => {
+  if (
+    !hasExactKeys(value, ANALYTICS_KEYS) ||
+    value.minimum_rate_support !== MIN_RATE_SUPPORT ||
+    !hasExactKeys(value.items, ITEM_FAMILY_KEYS) ||
+    !Array.isArray(rounds)
+  ) {
+    throw new Error('Phase 3 telemetry analytics are invalid');
+  }
+  const heroEvents = rounds.reduce(
+    (total, round) =>
+      total +
+      (isRecord(round) && round.round_type === 'hero' && isCount(round.event_count)
+        ? round.event_count
+        : 0),
+    0
+  );
+  const skillEvents = totalEvents - heroEvents;
+  if (
+    !validateItemRows(value.items.heroes, heroEvents) ||
+    !validateItemRows(value.items.skills, skillEvents) ||
+    !Array.isArray(value.score_margins) ||
+    value.score_margins.length !== SCORE_MARGIN_KEYS.length
+  ) {
+    throw new Error('Phase 3 telemetry analytics are invalid');
+  }
+
+  let marginEvents = 0;
+  let marginAccepted = 0;
+  value.score_margins.forEach((row, index) => {
+    if (
+      !hasExactKeys(row, SCORE_MARGIN_KEYS_REQUIRED) ||
+      row.key !== SCORE_MARGIN_KEYS[index] ||
+      !isShortString(row.label) ||
+      !isCount(row.event_count) ||
+      !isCount(row.recommendation_accepted_count) ||
+      row.recommendation_accepted_count > row.event_count ||
+      row.rate_suppressed !== (row.event_count < MIN_RATE_SUPPORT)
+    ) {
+      throw new Error('Phase 3 telemetry score-margin analytics are invalid');
+    }
+    marginEvents += row.event_count;
+    marginAccepted += row.recommendation_accepted_count;
+  });
+  if (marginEvents !== totalEvents || marginAccepted !== totalAccepted) {
+    throw new Error('Phase 3 telemetry score-margin totals are inconsistent');
+  }
+};
+
+export const parseTelemetryData = (value: unknown): TelemetryData => {
+  if (!isRecord(value)) {
+    throw new Error('Telemetry artifact must be an object');
+  }
+  if (
+    !hasExactKeys(value.schema, SCHEMA_KEYS) ||
+    (value.schema.version !== 2 && value.schema.version !== 3) ||
+    value.schema.source_event_schema_version !== 1
+  ) {
+    throw new Error('Telemetry artifact contract is invalid');
+  }
+  const schemaVersion = value.schema.version;
+  if (
+    !hasExactKeys(
+      value,
+      schemaVersion === 2 ? V2_TOP_LEVEL_KEYS : V3_TOP_LEVEL_KEYS
+    ) ||
+    value.catalog_version !== recommendationData.catalog.catalog_version ||
+    !isRecord(value.summary)
+  ) {
+    throw new Error('Telemetry artifact contract is invalid');
+  }
+
+  const { totalEvents, totalAccepted } = validateRounds(
+    value.rounds,
+    schemaVersion
+  );
+  if (
+    isCount(value.summary.event_count) &&
+    value.summary.event_count !== totalEvents
+  ) {
+    throw new Error('Telemetry event totals are inconsistent');
+  }
+  const summary = validateSummary(
+    value.summary,
+    schemaVersion,
+    totalEvents,
+    totalAccepted
+  );
+
+  if (schemaVersion === 2) {
+    if (value.preference_model !== null) {
+      throw new Error('Schema-v2 telemetry contract is invalid');
+    }
+    return value as unknown as TelemetryData;
+  }
+
+  const modelStatus = validatePreferenceModel(
+    value.preference_model,
+    summary,
+    totalEvents
+  );
+  validatePreferenceRoundFields(value.rounds, modelStatus);
+  validateAnalytics(value.analytics, value.rounds, totalEvents, totalAccepted);
+  return value as unknown as TelemetryData;
+};
+
+const fetchTelemetryData = async (
+  fetcher: typeof fetch,
+  signal?: AbortSignal
+): Promise<TelemetryData> => {
+  const response = await fetcher(ENDPOINT, {
+    headers: { Accept: 'application/json' },
+    ...(signal ? { signal } : {}),
+  });
+  if (!response.ok) {
+    throw new Error(`Telemetry artifact request failed (${response.status})`);
+  }
+  return parseTelemetryData(await response.json());
+};
+
+const fetchDefaultTelemetryData = async (
+  fetcher: typeof fetch,
+  controller: AbortController
+): Promise<TelemetryData> => {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const timedOut = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      reject(new Error('Telemetry artifact request timed out'));
+    }, STATIC_FETCH_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([
+      fetchTelemetryData(fetcher, controller.signal),
+      timedOut,
+    ]);
+  } finally {
+    if (timeout !== null) clearTimeout(timeout);
+  }
+};
+
+export const loadTelemetryData = (
+  fetcher?: typeof fetch
+): Promise<TelemetryData> => {
+  if (fetcher) return fetchTelemetryData(fetcher);
+  if (!cached) {
+    const generation = cacheGeneration;
+    const controller = new AbortController();
+    let attempt: Promise<TelemetryData>;
+    attempt = fetchDefaultTelemetryData(fetch, controller)
+      .then((artifact) => {
+        if (cacheGeneration === generation && cached === attempt) {
+          resolved = artifact;
+          cachedController = null;
+        }
+        return artifact;
+      })
+      .catch((error: unknown) => {
+        if (cacheGeneration === generation && cached === attempt) {
+          cached = null;
+          cachedController = null;
+        }
+        throw error;
+      });
+    cachedController = controller;
+    cached = attempt;
+  }
+  return cached;
+};
+
+/** Return only already-loaded data so local recommendation can never await I/O. */
+export const getCachedTelemetryData = (): TelemetryData | null => resolved;
+
+export const preloadTelemetryData = (): void => {
+  void loadTelemetryData().catch(() => {
+    // A missing or stalled static artifact must not affect local gameplay.
+  });
+};
+
+export const clearTelemetryDataCacheForTests = (): void => {
+  cacheGeneration += 1;
+  const controller = cachedController;
+  cached = null;
+  resolved = null;
+  cachedController = null;
+  controller?.abort();
+};

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './domain';
 export * from './recommendation';
 export * from './game';
 export * from './telemetry';
+export * from './telemetryData';

--- a/web/src/types/telemetry.ts
+++ b/web/src/types/telemetry.ts
@@ -36,4 +36,6 @@ export interface RoundTelemetryInput {
   pairedScores: number[];
   recommendedIndex: number;
   chosenIndex: number;
+  preferenceModelVersion?: string | null;
+  preferenceProbabilities?: number[] | null;
 }

--- a/web/src/types/telemetryData.ts
+++ b/web/src/types/telemetryData.ts
@@ -1,0 +1,113 @@
+import type { RoundType } from './game';
+
+export type PreferenceModelStatus =
+  | 'insufficient_evidence'
+  | 'quality_gate_failed'
+  | 'ready';
+
+export interface PreferenceEvidence {
+  event_count: number;
+  session_count: number;
+  recommendation_disagreement_count: number;
+  minimum_event_count: number;
+  minimum_session_count: number;
+  minimum_recommendation_disagreement_count: number;
+  holdout_event_count: number;
+  minimum_holdout_event_count: number;
+}
+
+export interface PreferenceMetrics {
+  event_count: number;
+  accuracy: number | null;
+  log_loss: number | null;
+  brier: number | null;
+  calibration_error: number | null;
+}
+
+export interface PreferenceHeldOutMetrics extends PreferenceMetrics {
+  train_event_count: number;
+  paired_accuracy: number;
+  uniform_log_loss: number;
+}
+
+export interface PreferenceModelArtifact {
+  model_type: 'conditional-choice-logit';
+  feature_schema_version: 1;
+  meaningful_probability_margin: number;
+  l2: number;
+  evidence: PreferenceEvidence;
+  status: PreferenceModelStatus;
+  version: string | null;
+  held_out: PreferenceHeldOutMetrics | null;
+  weights: Record<string, number>;
+  support: Record<string, number>;
+}
+
+export interface TelemetryRoundAggregate {
+  round_number: number;
+  round_type: RoundType;
+  event_count: number;
+  recommendation_accepted_count: number;
+  chosen_position_counts: [number, number, number];
+  recommended_position_counts: [number, number, number];
+  rate_suppressed?: boolean;
+  preference_top_disagreement_count?: number | null;
+  meaningful_preference_disagreement_count?: number | null;
+  player_preference_agreement_count?: number | null;
+  average_meaningful_preference_disagreement_margin?: number | null;
+}
+
+export interface TelemetryItemAggregate {
+  name: string;
+  offer_count: number;
+  opportunity_count: number;
+  picked_count: number;
+  rate_suppressed: boolean;
+}
+
+export interface ScoreMarginAggregate {
+  key: 'tie' | '0_to_1' | '1_to_3' | 'over_3';
+  label: string;
+  event_count: number;
+  recommendation_accepted_count: number;
+  rate_suppressed: boolean;
+}
+
+export interface TelemetryAnalytics {
+  minimum_rate_support: number;
+  items: {
+    heroes: TelemetryItemAggregate[];
+    skills: TelemetryItemAggregate[];
+  };
+  score_margins: ScoreMarginAggregate[];
+}
+
+export interface TelemetryData {
+  schema: {
+    version: number;
+    source_event_schema_version: number;
+  };
+  catalog_version: string;
+  summary: {
+    event_count: number;
+    invalid_event_count: number;
+    session_count: number;
+    recommendation_accepted_count?: number;
+    preference_event_count: number;
+    model_versions: { version: string; event_count: number }[];
+    preference_model_versions: { version: string; event_count: number }[];
+  };
+  rounds: TelemetryRoundAggregate[];
+  /** Schema v2 uses null; schema v3 always emits a status-bearing object. */
+  preference_model: PreferenceModelArtifact | null;
+  /** Added in schema v3; absent from the checked-in schema-v2 hand-off. */
+  analytics?: TelemetryAnalytics;
+}
+
+export interface PreferencePrediction {
+  version: string;
+  probabilities: [number, number, number];
+  top_index: number;
+  probability_margin: number;
+  meaningful_margin: number;
+}

--- a/web/src/types/telemetryData.ts
+++ b/web/src/types/telemetryData.ts
@@ -110,4 +110,9 @@ export interface PreferencePrediction {
   top_index: number;
   probability_margin: number;
   meaningful_margin: number;
+  /**
+   * Complete, non-causal sentence describing up to two readable model signals
+   * for the preference-top option versus the paired-model top option.
+   */
+  explanation_driver: string;
 }

--- a/web/tests/playerChoiceAnalytics.spec.js
+++ b/web/tests/playerChoiceAnalytics.spec.js
@@ -1,6 +1,21 @@
 const { test, expect } = require('@playwright/test');
 const telemetry = require('../public/game-data/telemetry_data.json');
-const database = require('../public/game-data/database.json');
+
+const byName = (left, right) =>
+  left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+
+const item = (
+  name,
+  offerCount,
+  pickedCount,
+  opportunityCount
+) => ({
+  name,
+  offer_count: offerCount,
+  opportunity_count: opportunityCount,
+  picked_count: pickedCount,
+  rate_suppressed: offerCount < 10,
+});
 
 const phaseThreeArtifact = () => {
   const eventCount = telemetry.summary.event_count;
@@ -31,23 +46,23 @@ const phaseThreeArtifact = () => {
       minimum_rate_support: 10,
       items: {
         heroes: [
-          {
-            name: Object.keys(database.heroes)[0],
-            offer_count: 10,
-            opportunity_count: opportunityCount('hero'),
-            picked_count: 5,
-            rate_suppressed: false,
-          },
-        ],
+          item('曹操', 30, 12, opportunityCount('hero')),
+          item('刘备', 25, 18, opportunityCount('hero')),
+          item('关羽', 20, 18, opportunityCount('hero')),
+          item('张飞', 20, 8, opportunityCount('hero')),
+          item('赵云', 15, 14, opportunityCount('hero')),
+          item('周瑜', 10, 0, opportunityCount('hero')),
+          item('孙权', 9, 9, opportunityCount('hero')),
+        ].sort(byName),
         skills: [
-          {
-            name: Object.keys(database.skills)[0],
-            offer_count: 10,
-            opportunity_count: opportunityCount('skill'),
-            picked_count: 4,
-            rate_suppressed: false,
-          },
-        ],
+          item('万人之敌', 60, 20, opportunityCount('skill')),
+          item('一计决胜', 50, 30, opportunityCount('skill')),
+          item('七进七出', 50, 25, opportunityCount('skill')),
+          item('上兵伐谋', 40, 30, opportunityCount('skill')),
+          item('临机制胜', 35, 8, opportunityCount('skill')),
+          item('不屈意志', 20, 10, opportunityCount('skill')),
+          item('临阵突袭', 9, 9, opportunityCount('skill')),
+        ].sort(byName),
       },
       score_margins: [
         {
@@ -94,44 +109,28 @@ const phaseThreeArtifact = () => {
   };
 };
 
-test('Analytics exposes the aggregate-only player choice telemetry hand-off', async ({
+test('Analytics omits player-choice rankings for a schema-v2 artifact', async ({
   page,
 }) => {
+  const telemetryResponse = page.waitForResponse((response) =>
+    response.url().includes('/game-data/telemetry_data.json')
+  );
   await page.goto('/analytics');
-
-  const section = page.getByTestId('player-choice-analytics');
-  const accepted = telemetry.rounds.reduce(
-    (sum, round) => sum + round.recommendation_accepted_count,
-    0
-  );
-  const acceptance =
-    telemetry.summary.event_count < 10
-      ? '样本不足'
-      : `${((accepted / telemetry.summary.event_count) * 100).toFixed(1)}%`;
-  const modelStatus =
-    telemetry.preference_model?.status === 'ready'
-      ? '偏好模型已启用'
-      : telemetry.preference_model?.status === 'quality_gate_failed'
-        ? '模型质量门未通过'
-        : '正在积累偏好证据';
-  await expect(section).toBeVisible({ timeout: 15000 });
-  await expect(section.getByText('玩家选择洞察')).toBeVisible();
-  await expect(page.getByTestId('telemetry-event-count')).toContainText(
-    String(telemetry.summary.event_count)
-  );
-  await expect(page.getByTestId('telemetry-session-count')).toContainText(
-    String(telemetry.summary.session_count)
-  );
-  await expect(page.getByTestId('telemetry-acceptance-rate')).toContainText(
-    acceptance
-  );
-  await expect(section.getByText(modelStatus)).toBeVisible();
+  await telemetryResponse;
   await expect(
-    section.getByRole('region', { name: '各轮玩家选择表格，可滚动' })
-  ).toBeVisible();
+    page.getByRole('heading', { name: '数据洞察' })
+  ).toBeVisible({ timeout: 15000 });
+  await page.evaluate(
+    () =>
+      new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+      )
+  );
+
+  await expect(page.getByTestId('player-choice-analytics')).toHaveCount(0);
 });
 
-test('Analytics renders schema-v3 offer, agreement, and score-margin aggregates', async ({
+test('Analytics renders schema-v3 top-five offer and pick rankings', async ({
   page,
 }) => {
   const artifact = phaseThreeArtifact();
@@ -146,13 +145,79 @@ test('Analytics renders schema-v3 offer, agreement, and score-margin aggregates'
 
   const section = page.getByTestId('player-choice-analytics');
   await expect(section).toBeVisible({ timeout: 15000 });
-  await expect(
-    section.getByRole('columnheader', {
-      name: '偏好模型与历史选择一致',
-    })
-  ).toBeVisible();
-  await expect(section.getByText('武将出现与选择')).toBeVisible();
-  await expect(section.getByText('战法出现与选择')).toBeVisible();
-  await expect(section.getByText('AI 评分领先幅度与接受率')).toBeVisible();
-  await expect(section.getByText('模型未启用').first()).toBeVisible();
+  await expect(section.getByText('玩家最关心的选择排行')).toBeVisible();
+
+  const heroToggle = section.getByRole('button', { name: '武将' });
+  const skillToggle = section.getByRole('button', { name: '战法' });
+  await expect(heroToggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(skillToggle).toHaveAttribute('aria-pressed', 'false');
+
+  const offered = section.getByTestId('telemetry-ranking-offers');
+  const picked = section.getByTestId('telemetry-ranking-picks');
+  await expect(offered.getByRole('heading', { name: '系统最常提供' })).toBeVisible();
+  await expect(picked.getByRole('heading', { name: '玩家最常选择' })).toBeVisible();
+  await expect(offered.getByTestId('telemetry-ranking-row')).toHaveCount(5);
+  await expect(picked.getByTestId('telemetry-ranking-row')).toHaveCount(5);
+  await expect(offered.getByTestId('telemetry-ranking-name')).toHaveText([
+    '曹操',
+    '刘备',
+    '关羽',
+    '张飞',
+    '赵云',
+  ]);
+  await expect(picked.getByTestId('telemetry-ranking-name')).toHaveText([
+    '关羽',
+    '刘备',
+    '赵云',
+    '曹操',
+    '孙权',
+  ]);
+
+  const topOffer = offered.getByTestId('telemetry-ranking-row').first();
+  await expect(topOffer).toContainText('30 次');
+  await expect(topOffer).toContainText('提供率 78.9%');
+  await expect(topOffer.getByRole('progressbar')).toHaveAttribute(
+    'aria-valuemax',
+    '30'
+  );
+  await expect(topOffer.getByRole('progressbar')).toHaveAttribute(
+    'aria-valuenow',
+    '30'
+  );
+
+  const lowSupportPick = picked
+    .getByTestId('telemetry-ranking-row')
+    .filter({ hasText: '孙权' });
+  await expect(lowSupportPick).toContainText('9 次');
+  await expect(lowSupportPick).toContainText('提供后选择率 样本不足');
+
+  for (const hiddenText of [
+    '有效选择',
+    '匿名对局',
+    '接受 AI 推荐',
+    '偏好模型',
+    '各轮选择与位置偏好',
+    '位置选择',
+    'AI 评分领先幅度与接受率',
+    '留出集',
+  ]) {
+    await expect(section.getByText(hiddenText, { exact: false })).toHaveCount(0);
+  }
+
+  await skillToggle.click();
+  await expect(skillToggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(offered.getByTestId('telemetry-ranking-name')).toHaveText([
+    '万人之敌',
+    '一计决胜',
+    '七进七出',
+    '上兵伐谋',
+    '临机制胜',
+  ]);
+  await expect(picked.getByTestId('telemetry-ranking-name')).toHaveText([
+    '一计决胜',
+    '上兵伐谋',
+    '七进七出',
+    '万人之敌',
+    '不屈意志',
+  ]);
 });

--- a/web/tests/playerChoiceAnalytics.spec.js
+++ b/web/tests/playerChoiceAnalytics.spec.js
@@ -1,0 +1,158 @@
+const { test, expect } = require('@playwright/test');
+const telemetry = require('../public/game-data/telemetry_data.json');
+const database = require('../public/game-data/database.json');
+
+const phaseThreeArtifact = () => {
+  const eventCount = telemetry.summary.event_count;
+  const accepted = telemetry.rounds.reduce(
+    (sum, round) => sum + round.recommendation_accepted_count,
+    0
+  );
+  const opportunityCount = (roundType) =>
+    telemetry.rounds
+      .filter((round) => round.round_type === roundType)
+      .reduce((sum, round) => sum + round.event_count, 0);
+  return {
+    ...telemetry,
+    schema: { version: 3, source_event_schema_version: 1 },
+    summary: {
+      ...telemetry.summary,
+      recommendation_accepted_count: accepted,
+    },
+    rounds: telemetry.rounds.map((round) => ({
+      ...round,
+      rate_suppressed: round.event_count < 10,
+      preference_top_disagreement_count: null,
+      meaningful_preference_disagreement_count: null,
+      player_preference_agreement_count: null,
+      average_meaningful_preference_disagreement_margin: null,
+    })),
+    analytics: {
+      minimum_rate_support: 10,
+      items: {
+        heroes: [
+          {
+            name: Object.keys(database.heroes)[0],
+            offer_count: 10,
+            opportunity_count: opportunityCount('hero'),
+            picked_count: 5,
+            rate_suppressed: false,
+          },
+        ],
+        skills: [
+          {
+            name: Object.keys(database.skills)[0],
+            offer_count: 10,
+            opportunity_count: opportunityCount('skill'),
+            picked_count: 4,
+            rate_suppressed: false,
+          },
+        ],
+      },
+      score_margins: [
+        {
+          key: 'tie',
+          label: '并列',
+          event_count: eventCount,
+          recommendation_accepted_count: accepted,
+          rate_suppressed: false,
+        },
+        ...[
+          ['0_to_1', '0–1 分'],
+          ['1_to_3', '1–3 分'],
+          ['over_3', '超过 3 分'],
+        ].map(([key, label]) => ({
+          key,
+          label,
+          event_count: 0,
+          recommendation_accepted_count: 0,
+          rate_suppressed: true,
+        })),
+      ],
+    },
+    preference_model: {
+      model_type: 'conditional-choice-logit',
+      feature_schema_version: 1,
+      meaningful_probability_margin: 0.1,
+      l2: 0.05,
+      evidence: {
+        event_count: eventCount,
+        session_count: telemetry.summary.session_count,
+        recommendation_disagreement_count: eventCount - accepted,
+        minimum_event_count: 240,
+        minimum_session_count: 40,
+        minimum_recommendation_disagreement_count: 30,
+        holdout_event_count: 20,
+        minimum_holdout_event_count: 36,
+      },
+      status: 'insufficient_evidence',
+      version: null,
+      held_out: null,
+      weights: {},
+      support: {},
+    },
+  };
+};
+
+test('Analytics exposes the aggregate-only player choice telemetry hand-off', async ({
+  page,
+}) => {
+  await page.goto('/analytics');
+
+  const section = page.getByTestId('player-choice-analytics');
+  const accepted = telemetry.rounds.reduce(
+    (sum, round) => sum + round.recommendation_accepted_count,
+    0
+  );
+  const acceptance =
+    telemetry.summary.event_count < 10
+      ? '样本不足'
+      : `${((accepted / telemetry.summary.event_count) * 100).toFixed(1)}%`;
+  const modelStatus =
+    telemetry.preference_model?.status === 'ready'
+      ? '偏好模型已启用'
+      : telemetry.preference_model?.status === 'quality_gate_failed'
+        ? '模型质量门未通过'
+        : '正在积累偏好证据';
+  await expect(section).toBeVisible({ timeout: 15000 });
+  await expect(section.getByText('玩家选择洞察')).toBeVisible();
+  await expect(page.getByTestId('telemetry-event-count')).toContainText(
+    String(telemetry.summary.event_count)
+  );
+  await expect(page.getByTestId('telemetry-session-count')).toContainText(
+    String(telemetry.summary.session_count)
+  );
+  await expect(page.getByTestId('telemetry-acceptance-rate')).toContainText(
+    acceptance
+  );
+  await expect(section.getByText(modelStatus)).toBeVisible();
+  await expect(
+    section.getByRole('region', { name: '各轮玩家选择表格，可滚动' })
+  ).toBeVisible();
+});
+
+test('Analytics renders schema-v3 offer, agreement, and score-margin aggregates', async ({
+  page,
+}) => {
+  const artifact = phaseThreeArtifact();
+  await page.route('**/game-data/telemetry_data.json', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(artifact),
+    })
+  );
+  await page.goto('/analytics');
+
+  const section = page.getByTestId('player-choice-analytics');
+  await expect(section).toBeVisible({ timeout: 15000 });
+  await expect(
+    section.getByRole('columnheader', {
+      name: '偏好模型与历史选择一致',
+    })
+  ).toBeVisible();
+  await expect(section.getByText('武将出现与选择')).toBeVisible();
+  await expect(section.getByText('战法出现与选择')).toBeVisible();
+  await expect(section.getByText('AI 评分领先幅度与接受率')).toBeVisible();
+  await expect(section.getByText('模型未启用').first()).toBeVisible();
+});

--- a/web/tests/playerPreferenceFlow.spec.js
+++ b/web/tests/playerPreferenceFlow.spec.js
@@ -131,12 +131,40 @@ test('ready preference probabilities flow from static model to UI and telemetry'
   for (const index of [0, 1, 2]) {
     const label = page.getByTestId(`option-preference-${index}`);
     await expect(label).toBeVisible();
+    await expect(label).toContainText('玩家选择概率：');
     displayed.push(
       Number((await label.innerText()).match(/(\d+\.\d)%/)[1]) / 100
     );
   }
   expect(displayed.reduce((sum, probability) => sum + probability, 0)).toBe(1);
+  expect(
+    displayed.every(
+      (probability) =>
+        Math.abs(probability * 1000 - Math.round(probability * 1000)) < 1e-9
+    )
+  ).toBe(true);
   expect(displayed[1]).toBeGreaterThan(displayed[0]);
+  await expect(
+    page.getByText('玩家选择最高', { exact: true })
+  ).toBeVisible();
+
+  const cards = page.getByTestId('analysis-set-card');
+  const aiIndex = await cards.evaluateAll((nodes) =>
+    nodes.findIndex((node) => node.dataset.aiRecommended === 'true')
+  );
+  const playerChoiceIndex = await cards.evaluateAll((nodes) =>
+    nodes.findIndex((node) => node.dataset.playerChoiceTop === 'true')
+  );
+  expect(aiIndex).toBeGreaterThanOrEqual(0);
+  expect(playerChoiceIndex).toBe(1);
+  if (aiIndex !== playerChoiceIndex) {
+    const optionLetter = (index) => String.fromCharCode(65 + index);
+    await expect(page.getByTestId('preference-disagreement')).toHaveText(
+      `AI 按当前阵容强度推荐 ${optionLetter(aiIndex)}；玩家选择模型认为 ${optionLetter(playerChoiceIndex)} 更常被选（${(displayed[playerChoiceIndex] * 100).toFixed(1)}%）。这是相似阵容与选项中的总体选择倾向。 这描述玩家偏好，不会改变 AI 推荐。`
+    );
+  } else {
+    await expect(page.getByTestId('preference-disagreement')).toHaveCount(0);
+  }
 
   await page.getByRole('button', { name: '选择本组' }).first().click();
   await page

--- a/web/tests/playerPreferenceFlow.spec.js
+++ b/web/tests/playerPreferenceFlow.spec.js
@@ -1,0 +1,150 @@
+const { test, expect } = require('@playwright/test');
+const telemetry = require('../public/game-data/telemetry_data.json');
+const {
+  seedGame,
+  makeGameState,
+  heroesWithMeta,
+  anySkills,
+} = require('./helpers');
+
+const readyArtifact = () => ({
+  ...telemetry,
+  schema: { version: 3, source_event_schema_version: 1 },
+  summary: {
+    ...telemetry.summary,
+    event_count: 240,
+    session_count: 40,
+    recommendation_accepted_count: 160,
+    model_versions: [
+      {
+        version: telemetry.summary.model_versions[0].version,
+        event_count: 240,
+      },
+    ],
+  },
+  rounds: telemetry.rounds.map((round) => ({
+    ...round,
+    event_count: 30,
+    recommendation_accepted_count: 20,
+    chosen_position_counts: [10, 10, 10],
+    recommended_position_counts: [12, 10, 8],
+    rate_suppressed: false,
+    preference_top_disagreement_count: 8,
+    meaningful_preference_disagreement_count: 5,
+    player_preference_agreement_count: 15,
+    average_meaningful_preference_disagreement_margin: null,
+  })),
+  analytics: {
+    minimum_rate_support: 10,
+    items: { heroes: [], skills: [] },
+    score_margins: [
+      {
+        key: 'tie',
+        label: '并列',
+        event_count: 240,
+        recommendation_accepted_count: 160,
+        rate_suppressed: false,
+      },
+      ...['0_to_1', '1_to_3', 'over_3'].map((key) => ({
+        key,
+        label: key,
+        event_count: 0,
+        recommendation_accepted_count: 0,
+        rate_suppressed: true,
+      })),
+    ],
+  },
+  preference_model: {
+    model_type: 'conditional-choice-logit',
+    feature_schema_version: 1,
+    meaningful_probability_margin: 0.1,
+    l2: 0.05,
+    evidence: {
+      event_count: 240,
+      session_count: 40,
+      recommendation_disagreement_count: 80,
+      minimum_event_count: 240,
+      minimum_session_count: 40,
+      minimum_recommendation_disagreement_count: 30,
+      holdout_event_count: 48,
+      minimum_holdout_event_count: 36,
+    },
+    status: 'ready',
+    version: 'preference-v1:0000000000000001',
+    held_out: {
+      event_count: 48,
+      accuracy: 0.7,
+      log_loss: 0.8,
+      brier: 0.15,
+      calibration_error: 0.05,
+      train_event_count: 192,
+      paired_accuracy: 0.65,
+      uniform_log_loss: 1.098612288668,
+    },
+    weights: { '["position",1]': 2 },
+    support: { '["position",1]': 240 },
+  },
+});
+
+test('ready preference probabilities flow from static model to UI and telemetry', async ({
+  page,
+}) => {
+  let artifactLoaded = false;
+  const loggedRounds = [];
+  await page.route('**/game-data/telemetry_data.json', async (route) => {
+    artifactLoaded = true;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(readyArtifact()),
+    });
+  });
+  await page.route('**/api/telemetry/rounds', async (route) => {
+    const body = route.request().postDataJSON();
+    loggedRounds.push(...body.events);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        accepted: body.events.length,
+        duplicates: 0,
+      }),
+    });
+  });
+
+  const team = heroesWithMeta.slice(0, 4);
+  const candidates = heroesWithMeta.slice(4, 13);
+  await seedGame(
+    page,
+    makeGameState({ roundNumber: 1, heroes: team, skills: anySkills(8) }),
+    {
+      set1: candidates.slice(0, 3),
+      set2: candidates.slice(3, 6),
+      set3: candidates.slice(6, 9),
+    }
+  );
+  await expect.poll(() => artifactLoaded).toBe(true);
+
+  await page.getByRole('button', { name: '获取 AI 推荐' }).click();
+  const displayed = [];
+  for (const index of [0, 1, 2]) {
+    const label = page.getByTestId(`option-preference-${index}`);
+    await expect(label).toBeVisible();
+    displayed.push(
+      Number((await label.innerText()).match(/(\d+\.\d)%/)[1]) / 100
+    );
+  }
+  expect(displayed.reduce((sum, probability) => sum + probability, 0)).toBe(1);
+  expect(displayed[1]).toBeGreaterThan(displayed[0]);
+
+  await page.getByRole('button', { name: '选择本组' }).first().click();
+  await page
+    .getByRole('button', { name: '确认选择并进入下一轮' })
+    .click();
+  await expect.poll(() => loggedRounds.length).toBe(1);
+  expect(loggedRounds[0].preference_model_version).toBe(
+    'preference-v1:0000000000000001'
+  );
+  expect(loggedRounds[0].preference_probabilities).toEqual(displayed);
+});


### PR DESCRIPTION
## Intent

Start telemetry Phase 3 so the entire retained telemetry corpus trains a versioned, session-held-out player-preference model and publishes aggregate support and quality metrics without changing the paired model as the sole AI recommendation. In the approved player-facing follow-up, label all displayed probabilities 玩家选择概率, highlight the preference top as 玩家选择最高 independently from AI 推荐, and only when the two tops differ by a meaningful probability margin show a short grounded, non-causal A/B/C explanation that uses the exact displayed probability and at most two readable item or pool signals with a generic fallback. Redesign /analytics to omit summary and diagnostic telemetry cards and instead show a compact 武将/战法 toggle with top-five 系统最常提供 and 玩家最常选择 rankings, counts, correct offer or picked-when-offered rates, relative bars, deterministic name tie breaks, and 样本不足 for low support while keeping counts visible. Keep diagnostic aggregates in the artifact; do not add a new telemetry JSON shape beyond the existing Phase 3 schema, and omit this section for schema v2.

## What Changed

- Extended the offline telemetry builder (`data/build_telemetry_data.py`) and its TS consumers (`preferenceModel.ts`, `telemetryData.ts`) to train a versioned, session-held-out conditional player-preference model over the retained corpus, publishing aggregate support/quality metrics into the existing Phase 3 schema without altering the paired model as the sole AI recommender; the model stays gated behind evidence and held-out quality checks.
- Surfaced player-choice signals in the app: recommendation options now show `玩家选择概率`, highlight the `玩家选择最高` pick independently from the AI `推荐`, and render a short grounded, non-causal A/B/C explanation only when the two tops differ by a meaningful margin (`AnalysisGrid.tsx`, `GameBoard.tsx`, `GameContext.tsx`).
- Redesigned `/analytics` (`Analytics.tsx`) into a compact 武将/战法 toggle showing top-five `系统最常提供` / `玩家最常选择` rankings with counts, offer/picked-when-offered rates, relative bars, deterministic name tie-breaks, and `样本不足` for low support; diagnostic aggregates remain in the artifact but are omitted from the cards and the section is hidden for schema v2. The weekly telemetry workflow now runs typecheck/test/build as a consumer gate before committing the artifact.

## Risk Assessment

✅ Low: The change is large but tightly bounded and unusually well-validated — the Python builder and TS consumer enforce byte-identical, mutually-consistent contracts, the preference model is display-only and does not alter the AI recommendation, and every required intent behavior is present with no forbidden behavior.

## Testing

Ran the workspace-scoped web unit tests (Vitest, 33 passed) and typecheck (clean), the two new Playwright e2e specs plus the schema-v2 omission case (3 passed), and the telemetry-builder Python suite (25 passed) — then exercised the builder end-to-end with the empty-migration smoke input to confirm it emits the schema-v3, aggregate-only artifact with the gated preference model and retained diagnostic aggregates. For the player-facing UI I captured full-page screenshots against the same schema-v3 fixtures showing 玩家选择概率 labels, the independent 玩家选择最高 highlight vs the ★AI 推荐 badge, the grounded non-causal A/B/C disagreement explanation quoting the exact 78.7% probability, and the redesigned /analytics 武将/战法 top-five rankings with counts, offer/picked rates, relative bars, and 样本不足 for the low-support pick. Transient artifacts (regenerated telemetry_data.json, temp evidence spec, test-results) were removed and the working tree is clean. Overall: all targeted tests pass and the intent is demonstrated on the real end-user surfaces.

- Evidence: /analytics — 武将 (heroes) player-choice rankings: 系统最常提供 / 玩家最常选择 top-five with counts, offer rates, relative bars, and 样本不足 for low-support 孙权 (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY7CVA0G7TV2FJ3QGYC3XB01/analytics-heroes.png</code>)
- Evidence: /analytics — 战法 (skills) toggle showing parallel skill offer/pick top-five rankings (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY7CVA0G7TV2FJ3QGYC3XB01/analytics-skills.png</code>)
- Evidence: Recommendation view — 玩家选择概率 per option, 玩家选择最高 highlight on Option A independent of ★AI 推荐 on Option B, and the grounded non-causal disagreement explanation citing 78.7% (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY7CVA0G7TV2FJ3QGYC3XB01/preference-recommendation.png</code>)
<details>
<summary>Evidence: Disagreement explanation text rendered in the UI</summary>

```text
AI 按当前阵容强度推荐 B；玩家选择模型认为 A 更常被选（78.7%）。这是相似阵容与选项中的总体选择倾向。 这描述玩家偏好，不会改变 AI 推荐。
```
</details>
<details>
<summary>Evidence: Generated schema-v3 telemetry artifact shape (from build-telemetry smoke run)</summary>

```text
schema: {"source_event_schema_version":1,"version":3}
top-level keys: analytics, catalog_version, preference_model, rounds, schema, summary
preference_model status: insufficient_evidence version: null
analytics.items: heroes, skills
rounds keys include: preference_top_disagreement_count, meaningful_preference_disagreement_count, player_preference_agreement_count, chosen/recommended_position_counts
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `.github/workflows/update-telemetry-data.yml:72` - The weekly telemetry refresh now runs `npm ci &amp;&amp; npm run typecheck &amp;&amp; npm test &amp;&amp; npm run build` as a gate before committing the rebuilt artifact. This is a deliberate consumer-validation step, but it couples the data refresh to overall web-test health: a transient/unrelated web unit-test or build failure will abort the job and skip that week&#39;s telemetry commit (concurrency won&#39;t retry until the next schedule). Consider whether the validation should be non-blocking for the commit, or scoped to just the telemetry-consumer tests, so an unrelated flaky test can&#39;t stall the data pipeline. No code defect.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; npx vitest run` on the 5 changed suites (preferenceModel, telemetryData, api, telemetry, AnalysisGrid) — 33 passed</code>
- <code>`cd web &amp;&amp; npm run typecheck` (Go-native tsc) — clean</code>
- <code>`cd web &amp;&amp; npx playwright test playerChoiceAnalytics.spec.js playerPreferenceFlow.spec.js` — 3 passed (schema-v2 omission, schema-v3 rankings, ready preference-probability flow)</code>
- `Captured reviewer-visible screenshots via a temporary Playwright evidence spec (since removed) reusing the same routed schema-v3 artifacts: /analytics heroes view, /analytics skills view, and the recommendation view with player-choice probabilities + forced disagreement explanation`
- <code>`make test-telemetry` (uv run pytest data/test_build_telemetry_data.py) — 25 passed, 17 subtests</code>
- <code>`make build-telemetry EXPORT=web/migrations/0001_round_telemetry.sql` — built schema-v3 artifact end-to-end; inspected shape (preference_model gated to insufficient_evidence, analytics.items heroes/skills, score_margins, per-round diagnostic aggregates); regenerated file reverted afterward</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
