### PR TITLE
feat(analytics): separate anonymous option stats from battle reports

### DIFF
--- a/TELEMETRY_IMPLEMENTATION_PLAN.md
+++ b/TELEMETRY_IMPLEMENTATION_PLAN.md
@@ -148,17 +148,19 @@ Status: in progress.
   units.
 - Publish offer/pick, recommendation-acceptance, round, position, score-margin,
   and model-disagreement aggregates in the artifact. Player-facing Analytics
-  emphasizes two 武将/战法 rankings: `系统最常提供` by offer count and
+  emphasizes two 武将/战法 rankings: `游戏最常提供` by offer count and
   `玩家最常选择` by pick count, with offer and picked-when-offered rates.
   Round, position, and score-margin aggregates remain available for diagnostics
   rather than occupying the main player view.
-- Suppress low-support percentages and publish held-out quality/calibration
-  metrics in the generated artifact.
+- Retain low-support markers in the artifact for diagnostics, while the
+  player-facing all-item rankings show their exact count-derived percentages
+  alongside the underlying counts. Publish held-out quality/calibration metrics
+  in the generated artifact.
 
 Implementation thresholds are explicit and deterministic: at least 240 valid
 choices, 40 anonymous game sessions, 30 choices that differ from the paired
-recommendation, and 36 events in the session-grouped holdout. Public
-percentages require at least 10 supporting observations. Until every evidence
+recommendation, and 36 events in the session-grouped holdout. Artifact
+item-rate diagnostic markers use a 10-offer threshold. Until every evidence
 gate and the held-out quality gate passes, the artifact reports
 `insufficient_evidence` or `quality_gate_failed`, publishes no coefficients,
 and the option cards show only the paired-model score.

--- a/TELEMETRY_IMPLEMENTATION_PLAN.md
+++ b/TELEMETRY_IMPLEMENTATION_PLAN.md
@@ -95,7 +95,6 @@ Status: implemented.
 - Record an event immediately before the confirmed choice updates game state.
 - Retry queued events on later choices, page initialization, and browser
   `online` events.
-- Add a short anonymous-collection disclosure to the game setup screen.
 - Document the required `TELEMETRY_DB` dashboard binding and migration command.
 
 ## Phase 2 — weekly GitHub builder

--- a/data/build_telemetry_data.py
+++ b/data/build_telemetry_data.py
@@ -1286,6 +1286,8 @@ def build_artifact(
 
         round_type = str(event["round_type"])
         opportunity_counts[round_type] += 1
+        # Only the three sets offered in this round count as offers. Existing
+        # pool/support items inform the preference model but are not offers.
         for offered_set in event["offered_sets"]:
             for item in offered_set:
                 item_counts[(round_type, str(item))][0] += 1

--- a/data/test_build_telemetry_data.py
+++ b/data/test_build_telemetry_data.py
@@ -241,6 +241,36 @@ class TelemetryBuilderTests(unittest.TestCase):
         self.assertNotIn("session_id", serialized)
         self.assertNotIn("client_ts", serialized)
 
+    def test_item_analytics_count_only_offered_sets_and_chosen_option(self) -> None:
+        rows = [
+            _event(self.catalog_version, suffix=1, round_number=1, chosen_index=2),
+            _event(self.catalog_version, suffix=2, round_number=2, chosen_index=1),
+        ]
+        _write_export(self.export_path, rows)
+
+        artifact = self._build()
+        hero_rows = {
+            row["name"]: row for row in artifact["analytics"]["items"]["heroes"]
+        }
+        skill_rows = {
+            row["name"]: row for row in artifact["analytics"]["items"]["skills"]
+        }
+
+        self.assertNotIn("J", hero_rows)
+        self.assertNotIn("j", skill_rows)
+        self.assertEqual(sum(row["offer_count"] for row in hero_rows.values()), 9)
+        self.assertEqual(sum(row["picked_count"] for row in hero_rows.values()), 3)
+        self.assertEqual(sum(row["offer_count"] for row in skill_rows.values()), 9)
+        self.assertEqual(sum(row["picked_count"] for row in skill_rows.values()), 3)
+        self.assertEqual(
+            [hero_rows[name]["picked_count"] for name in ("G", "H", "I")],
+            [1, 1, 1],
+        )
+        self.assertEqual(
+            [skill_rows[name]["picked_count"] for name in ("d", "e", "f")],
+            [1, 1, 1],
+        )
+
     def test_accepts_empty_export_and_emits_all_rounds(self) -> None:
         _write_export(self.export_path, [])
         artifact = self._build()

--- a/web/.tool-versions
+++ b/web/.tool-versions
@@ -1,0 +1,13 @@
+# Cloudflare Pages builds this app with root directory `web` and the command
+# `npm run build` (Vite). This is a Node-only static build; it does not need
+# Python. Declaring only Node here scopes the build image's toolchain to Node
+# so the build does not spend minutes compiling a Python interpreter from
+# source on every (cache-less) build — the slow, network-dependent step that
+# has stalled the Pages build past its time limit.
+#
+# This file is read only by asdf-based build images (Cloudflare Pages). Local
+# development and GitHub Actions are unaffected: they resolve Node via
+# `.node-version` (fnm) and Python via `.python-version` (uv / setup-python),
+# neither of which reads `.tool-versions`. The repo-root `.python-version`
+# (3.12, required by the Python workspaces) is intentionally left untouched.
+nodejs 22.22.0

--- a/web/README.md
+++ b/web/README.md
@@ -126,13 +126,16 @@ web/
 ### Analytics
 - **Analytics**: Player-friendly dashboard driven by the generated paired-model artifact
 - A separate **匿名选项统计** section is shown when
-  `public/game-data/telemetry_data.json` contains schema-v3 item analytics. Its compact
-  武将/战法 toggle switches two responsive top-five cards: **系统最常提供** ranks by
-  offer count and shows offer rate, while **玩家最常选择** ranks by pick count and shows
-  the conditional picked-when-offered rate. Offer counts include only the three option
-  sets shown for that round, never items already in the pool or support slots. Ties use a
-  deterministic name ordering, horizontal bars are relative to each card's leader, counts
-  always remain visible, and low-support percentages display `样本不足`.
+  `public/game-data/telemetry_data.json` contains schema-v3 item analytics. Its 武将/战法
+  toggle switches two responsive, height-capped tables showing every aggregated item:
+  **系统最常提供** ranks by offer count and shows offer rate, while **玩家最常选择**
+  ranks by pick count and shows the conditional picked-when-offered rate. Offer counts
+  include only the three option sets shown for that round, never items already in the pool
+  or support slots. Ties use a deterministic name ordering, counts always remain visible,
+  and low-support percentages display `样本不足`.
+- The telemetry rankings and paired-model **历史战报分析** are separate, named page
+  sections. Battle-count provenance, the historical-experience caveat, filters, and the
+  win-rate/synergy tables live only inside the battle-report section.
 - The telemetry artifact still retains diagnostic round, position, score-margin,
   recommendation-agreement, preference-model status/evidence, and held-out aggregates,
   but Analytics does not show them in this player-facing ranking section. Schema-v2

--- a/web/README.md
+++ b/web/README.md
@@ -125,13 +125,14 @@ web/
 
 ### Analytics
 - **Analytics**: Player-friendly dashboard driven by the generated paired-model artifact
-- A separate **玩家最关心的选择排行** section is shown when
+- A separate **匿名选项统计** section is shown when
   `public/game-data/telemetry_data.json` contains schema-v3 item analytics. Its compact
   武将/战法 toggle switches two responsive top-five cards: **系统最常提供** ranks by
   offer count and shows offer rate, while **玩家最常选择** ranks by pick count and shows
-  the conditional picked-when-offered rate. Ties use a deterministic name ordering,
-  horizontal bars are relative to each card's leader, counts always remain visible, and
-  low-support percentages display `样本不足`.
+  the conditional picked-when-offered rate. Offer counts include only the three option
+  sets shown for that round, never items already in the pool or support slots. Ties use a
+  deterministic name ordering, horizontal bars are relative to each card's leader, counts
+  always remain visible, and low-support percentages display `样本不足`.
 - The telemetry artifact still retains diagnostic round, position, score-margin,
   recommendation-agreement, preference-model status/evidence, and held-out aggregates,
   but Analytics does not show them in this player-facing ranking section. Schema-v2

--- a/web/README.md
+++ b/web/README.md
@@ -128,11 +128,11 @@ web/
 - A separate **匿名选项统计** section is shown when
   `public/game-data/telemetry_data.json` contains schema-v3 item analytics. Its 武将/战法
   toggle switches two responsive, height-capped tables showing every aggregated item:
-  **系统最常提供** ranks by offer count and shows offer rate, while **玩家最常选择**
+  **游戏最常提供** ranks by offer count and shows offer rate, while **玩家最常选择**
   ranks by pick count and shows the conditional picked-when-offered rate. Offer counts
   include only the three option sets shown for that round, never items already in the pool
   or support slots. Ties use a deterministic name ordering, counts always remain visible,
-  and low-support percentages display `样本不足`.
+  and the exact count-derived percentages remain visible for every row.
 - The telemetry rankings and paired-model **历史战报分析** are separate, named page
   sections. Battle-count provenance, the historical-experience caveat, filters, and the
   win-rate/synergy tables live only inside the battle-report section.

--- a/web/src/components/setup/SetupForm.tsx
+++ b/web/src/components/setup/SetupForm.tsx
@@ -157,10 +157,6 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
             请选择恰好 4 个武将和 8 个战法以开始
           </Typography>
         )}
-
-        <Typography variant="caption" color="text.secondary" sx={{ mt: 1.5, display: 'block', textAlign: 'center' }}>
-          本站会匿名记录每轮选项、模型评分和最终选择，用于生成玩家选择倾向与统计；不记录账号或个人资料。
-        </Typography>
       </CardContent>
     </Card>
   );

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -298,7 +298,7 @@ const TelemetryAnalyticsSection = ({
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <InsightsIcon sx={{ color: 'info.main' }} />
           <Typography component="h2" variant="h5">
-            玩家最关心的选择排行
+            匿名选项统计
           </Typography>
         </Box>
         <ToggleButtonGroup
@@ -326,9 +326,9 @@ const TelemetryAnalyticsSection = ({
         </ToggleButtonGroup>
       </Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        匿名选项记录只描述系统提供了什么、玩家看到后选择了什么；它不是胜率，也不会改变
-        AI 的阵容评分推荐。少于 {analytics.minimum_rate_support} 次提供时隐藏百分比，
-        但仍显示次数。
+        匿名选项统计只计算每轮三组选项中的武将、战法，不重复计算已有阵容；它描述系统提供了什么、
+        玩家看到后选择了什么，不是胜率，也不会改变 AI 的阵容评分推荐。少于{' '}
+        {analytics.minimum_rate_support} 次提供时隐藏百分比，但仍显示次数。
       </Typography>
 
       <Grid container spacing={2.5}>

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -101,12 +101,11 @@ const HelpTip = ({ title, label }: { title: string; label: string }) => (
   </Tooltip>
 );
 
-const supportedPct = (
+const telemetryPct = (
   numerator: number,
-  denominator: number,
-  suppressed: boolean
+  denominator: number
 ): string => {
-  if (suppressed || denominator === 0) return '样本不足';
+  if (denominator === 0) return '-';
   return `${((numerator / denominator) * 100).toFixed(1)}%`;
 };
 
@@ -183,15 +182,13 @@ const TelemetryRankingTable = ({
                 {rankedRows.map((row, index) => {
                   const count = row[metric];
                   const rate = isOfferRanking
-                    ? supportedPct(
+                    ? telemetryPct(
                         row.offer_count,
-                        row.opportunity_count,
-                        row.rate_suppressed
+                        row.opportunity_count
                       )
-                    : supportedPct(
+                    : telemetryPct(
                         row.picked_count,
-                        row.offer_count,
-                        row.rate_suppressed
+                        row.offer_count
                       );
 
                   return (
@@ -298,15 +295,15 @@ const TelemetryAnalyticsSection = ({
         </ToggleButtonGroup>
       </Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        匿名选项统计只计算每轮三组选项中的武将、战法，不重复计算已有阵容；它描述系统提供了什么、
-        玩家看到后选择了什么，不是胜率，也不会改变 AI 的阵容评分推荐。少于{' '}
-        {analytics.minimum_rate_support} 次提供时隐藏百分比，但仍显示次数。
+        匿名选项统计汇总玩家使用本工具时的匿名选择：它只记录游戏每轮三组选项中提供了哪些武将、
+        战法，以及玩家最终选择了什么，不重复计算已有阵容。这里展示的是选择次数和倾向，不是胜率，
+        也不会改变 AI 的阵容评分推荐。
       </Typography>
 
       <Grid container spacing={2.5}>
         <Grid size={{ xs: 12, md: 6 }}>
           <TelemetryRankingTable
-            title="系统最常提供"
+            title="游戏最常提供"
             rows={rows}
             metric="offer_count"
             itemFamily={itemFamily}

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -21,6 +21,7 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Button,
   ToggleButton,
   ToggleButtonGroup,
 } from '@mui/material';
@@ -47,9 +48,14 @@ import { loadTelemetryData } from '../services/telemetryData';
 interface ScrollableAnalyticsTableProps {
   children: ReactNode;
   label: string;
+  maxHeight?: number;
 }
 
-const ScrollableAnalyticsTable = ({ children, label }: ScrollableAnalyticsTableProps) => (
+const ScrollableAnalyticsTable = ({
+  children,
+  label,
+  maxHeight = 800,
+}: ScrollableAnalyticsTableProps) => (
   <>
     <Typography
       variant="caption"
@@ -62,7 +68,7 @@ const ScrollableAnalyticsTable = ({ children, label }: ScrollableAnalyticsTableP
       role="region"
       aria-label={`${label}表格，可滚动`}
       tabIndex={0}
-      sx={{ maxHeight: 800 }}
+      sx={{ maxHeight }}
     >
       {children}
     </TableContainer>
@@ -112,7 +118,7 @@ const compareTelemetryNames = (
   right: TelemetryItemAggregate
 ): number => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0);
 
-const topTelemetryItems = (
+const rankTelemetryItems = (
   rows: TelemetryItemAggregate[],
   metric: TelemetryRankingMetric
 ): TelemetryItemAggregate[] =>
@@ -121,22 +127,25 @@ const topTelemetryItems = (
     .sort(
       (left, right) =>
         right[metric] - left[metric] || compareTelemetryNames(left, right)
-    )
-    .slice(0, 5);
+    );
 
-const TelemetryRankingCard = ({
+const TelemetryRankingTable = ({
   title,
   rows,
   metric,
+  itemFamily,
 }: {
   title: string;
   rows: TelemetryItemAggregate[];
   metric: TelemetryRankingMetric;
+  itemFamily: TelemetryItemFamily;
 }) => {
-  const rankedRows = topTelemetryItems(rows, metric);
+  const rankedRows = rankTelemetryItems(rows, metric);
   const isOfferRanking = metric === 'offer_count';
-  const maximumCount = rankedRows[0]?.[metric] ?? 0;
-  const barMaximum = Math.max(maximumCount, 1);
+  const itemLabel = itemFamily === 'heroes' ? '武将' : '战法';
+  const countLabel = isOfferRanking ? '提供次数' : '选择次数';
+  const rateLabel = isOfferRanking ? '提供率' : '提供后选择率';
+  const chipColor = itemFamily === 'heroes' ? 'primary' : 'secondary';
 
   return (
     <Card
@@ -151,120 +160,70 @@ const TelemetryRankingCard = ({
         <Typography component="h3" variant="h6" gutterBottom>
           {title}
         </Typography>
-        <Box
-          component="ol"
-          aria-label={`${title}前五名`}
-          sx={{ listStyle: 'none', p: 0, m: 0 }}
-        >
-          {rankedRows.map((row, index) => {
-            const count = row[metric];
-            const rate = isOfferRanking
-              ? supportedPct(
-                  row.offer_count,
-                  row.opportunity_count,
-                  row.rate_suppressed
-                )
-              : supportedPct(
-                  row.picked_count,
-                  row.offer_count,
-                  row.rate_suppressed
-                );
-            const rateLabel = isOfferRanking ? '提供率' : '提供后选择率';
-
-            return (
-              <Box
-                component="li"
-                data-testid="telemetry-ranking-row"
-                key={row.name}
-                sx={{
-                  py: 1.25,
-                  borderTop: index === 0 ? 0 : '1px solid',
-                  borderColor: 'divider',
-                }}
-              >
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'baseline',
-                    gap: 1,
-                    minWidth: 0,
-                  }}
-                >
-                  <Typography
-                    aria-hidden="true"
-                    variant="caption"
-                    color="text.secondary"
-                    sx={{ width: 18, flexShrink: 0, fontWeight: 700 }}
-                  >
-                    {index + 1}
-                  </Typography>
-                  <Typography
-                    data-testid="telemetry-ranking-name"
-                    sx={{
-                      flex: 1,
-                      minWidth: 0,
-                      fontWeight: 700,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {row.name}
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    sx={{ flexShrink: 0, fontWeight: 800 }}
-                  >
-                    {count} 次
-                  </Typography>
-                </Box>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ display: 'block', ml: '26px', mt: 0.25 }}
-                >
-                  {rateLabel} {rate}
-                </Typography>
-                <Box
-                  role="progressbar"
-                  aria-label={`${row.name}${isOfferRanking ? '提供' : '选择'}次数相对条`}
-                  aria-valuemin={0}
-                  aria-valuemax={barMaximum}
-                  aria-valuenow={count}
-                  sx={{
-                    height: 6,
-                    mt: 0.75,
-                    ml: '26px',
-                    overflow: 'hidden',
-                    bgcolor: 'action.selected',
-                    borderRadius: 999,
-                  }}
-                >
-                  <Box
-                    sx={{
-                      width: `${(count / barMaximum) * 100}%`,
-                      height: '100%',
-                      bgcolor: isOfferRanking
-                        ? 'primary.main'
-                        : 'secondary.main',
-                      borderRadius: 'inherit',
-                    }}
-                  />
-                </Box>
-              </Box>
-            );
-          })}
-          {rankedRows.length === 0 && (
-            <Typography
-              component="li"
-              variant="body2"
-              color="text.secondary"
-              sx={{ py: 2 }}
+        <ResponsiveDisclosure label={`${title}${itemLabel}排行`}>
+          <ScrollableAnalyticsTable
+            label={`${title}${itemLabel}排行`}
+            maxHeight={520}
+          >
+            <Table
+              size="small"
+              stickyHeader
+              aria-label={`${title}全部${itemLabel}排行`}
+              sx={{ minWidth: 480 }}
             >
-              暂无选择记录
-            </Typography>
-          )}
-        </Box>
+              <TableHead>
+                <TableRow>
+                  <TableCell>排名</TableCell>
+                  <TableCell>{itemLabel}</TableCell>
+                  <TableCell align="right">{countLabel}</TableCell>
+                  <TableCell align="right">{rateLabel}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rankedRows.map((row, index) => {
+                  const count = row[metric];
+                  const rate = isOfferRanking
+                    ? supportedPct(
+                        row.offer_count,
+                        row.opportunity_count,
+                        row.rate_suppressed
+                      )
+                    : supportedPct(
+                        row.picked_count,
+                        row.offer_count,
+                        row.rate_suppressed
+                      );
+
+                  return (
+                    <TableRow
+                      data-testid="telemetry-ranking-row"
+                      key={row.name}
+                    >
+                      <TableCell>{index + 1}</TableCell>
+                      <TableCell>
+                        <Chip
+                          data-testid="telemetry-ranking-name"
+                          label={row.name}
+                          color={chipColor}
+                          size="small"
+                        />
+                      </TableCell>
+                      <TableCell align="right">{count} 次</TableCell>
+                      <TableCell align="right">{rate}</TableCell>
+                    </TableRow>
+                  );
+                })}
+                {rankedRows.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} align="center">
+                      暂无选择记录
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </ScrollableAnalyticsTable>
+        </ResponsiveDisclosure>
       </CardContent>
     </Card>
   );
@@ -284,7 +243,16 @@ const TelemetryAnalyticsSection = ({
   const rows = analytics.items[itemFamily];
 
   return (
-    <Box sx={{ mb: 5 }} data-testid="player-choice-analytics">
+    <Box
+      component="section"
+      id="anonymous-choice-analytics"
+      aria-labelledby="anonymous-choice-analytics-title"
+      sx={{ mb: 4, scrollMarginTop: 24 }}
+      data-testid="player-choice-analytics"
+    >
+      <Typography variant="overline" color="info.main">
+        ANONYMOUS CHOICES
+      </Typography>
       <Box
         sx={{
           display: 'flex',
@@ -297,7 +265,11 @@ const TelemetryAnalyticsSection = ({
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <InsightsIcon sx={{ color: 'info.main' }} />
-          <Typography component="h2" variant="h5">
+          <Typography
+            id="anonymous-choice-analytics-title"
+            component="h2"
+            variant="h5"
+          >
             匿名选项统计
           </Typography>
         </Box>
@@ -311,7 +283,7 @@ const TelemetryAnalyticsSection = ({
           }}
           sx={{
             '& .MuiToggleButton-root': {
-              minHeight: 32,
+              minHeight: 40,
               px: 1.75,
               py: 0.25,
             },
@@ -333,17 +305,19 @@ const TelemetryAnalyticsSection = ({
 
       <Grid container spacing={2.5}>
         <Grid size={{ xs: 12, md: 6 }}>
-          <TelemetryRankingCard
+          <TelemetryRankingTable
             title="系统最常提供"
             rows={rows}
             metric="offer_count"
+            itemFamily={itemFamily}
           />
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
-          <TelemetryRankingCard
+          <TelemetryRankingTable
             title="玩家最常选择"
             rows={rows}
             metric="picked_count"
+            itemFamily={itemFamily}
           />
         </Grid>
       </Grid>
@@ -499,22 +473,74 @@ const Analytics = () => {
   return (
     <Container maxWidth="xl" disableGutters>
       <Box>
-        <Typography variant="overline" color="error.main">BATTLE ARCHIVE</Typography>
-        <Typography component="h1" variant="h3" gutterBottom>数据洞察</Typography>
-        <Typography variant="body1" color="text.secondary" paragraph>
-          这里帮你回答两个问题：<strong>哪些武将、战法更值得选</strong>，以及<strong>哪些搭配放在一起更好用</strong>。
-          所有结论都来自已记录的 {data.summary.total_battles} 场对局，是历史经验的参考，
-          <strong>并不保证</strong>在某一场对特定对手时一定获胜。
+        <Typography variant="overline" color="text.secondary">
+          ANALYTICS
         </Typography>
+        <Typography component="h1" variant="h3" gutterBottom>
+          数据洞察
+        </Typography>
+        <Box
+          component="nav"
+          aria-label="数据洞察分区"
+          sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 4 }}
+        >
+          {telemetry?.analytics && (
+            <Button
+              component="a"
+              href="#anonymous-choice-analytics"
+              variant="contained"
+              size="small"
+            >
+              匿名选项统计
+            </Button>
+          )}
+          <Button
+            component="a"
+            href="#battle-report-analytics"
+            variant={telemetry?.analytics ? 'outlined' : 'contained'}
+            size="small"
+          >
+            历史战报分析
+          </Button>
+        </Box>
 
         {telemetry?.analytics && (
           <TelemetryAnalyticsSection telemetry={telemetry} />
         )}
 
-        {/* Plain-language guide: how to read the numbers */}
-        <Card sx={{ mb: 4, borderTop: '3px solid', borderTopColor: 'primary.main' }}>
+        <Box
+          component="section"
+          id="battle-report-analytics"
+          aria-labelledby="battle-report-analytics-title"
+          data-testid="battle-report-analytics"
+          sx={{
+            pt: telemetry?.analytics ? 4 : 0,
+            borderTop: telemetry?.analytics ? '3px solid' : 0,
+            borderColor: 'divider',
+            scrollMarginTop: 24,
+          }}
+        >
+          <Typography variant="overline" color="error.main">
+            BATTLE ARCHIVE
+          </Typography>
+          <Typography
+            id="battle-report-analytics-title"
+            component="h2"
+            variant="h5"
+            gutterBottom
+          >
+            历史战报分析
+          </Typography>
+          <Typography variant="body1" color="text.secondary" paragraph>
+            这里帮你回答两个问题：<strong>哪些武将、战法更值得选</strong>，以及<strong>哪些搭配放在一起更好用</strong>。
+            所有结论都来自已记录的 {data.summary.total_battles} 场对局，是历史经验的参考，
+            <strong>并不保证</strong>在某一场对特定对手时一定获胜。
+          </Typography>
+
+          {/* Plain-language guide: how to read the numbers */}
+          <Card sx={{ mb: 4, borderTop: '3px solid', borderTopColor: 'primary.main' }}>
           <CardContent>
-            <Typography component="h2" variant="h6" gutterBottom>三步看懂这些数字</Typography>
+            <Typography component="h3" variant="h6" gutterBottom>三步看懂这些数字</Typography>
             <Grid container spacing={2}>
               <Grid size={{ xs: 12, md: 4 }}>
                 <Typography variant="subtitle2" gutterBottom>1. 胜率参考</Typography>
@@ -541,7 +567,7 @@ const Analytics = () => {
         {/* Filters */}
         <Paper sx={{ p: { xs: 2, sm: 2.5 }, mb: 4, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
           <Box sx={{ display: 'flex', alignItems: 'center', mb: 0.5, gap: 1 }}>
-            <Typography component="h2" variant="h6">只看我关心的武将和战法</Typography>
+            <Typography component="h3" variant="h6">只看我关心的武将和战法</Typography>
             {(hasHeroFilter || hasSkillFilter) && (
               <IconButton
                 size="small"
@@ -593,7 +619,7 @@ const Analytics = () => {
         {/* Section 1: who is worth picking */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
           <TrendingUpIcon sx={{ color: 'warning.main' }} />
-          <Typography component="h2" variant="h5">先看谁更值得选</Typography>
+          <Typography component="h3" variant="h5">先看谁更值得选</Typography>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           单个武将、战法按胜率参考排名。想快速挑人挑战法，从这里开始。
@@ -604,7 +630,7 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography component="h3" variant="h6">全部武将（按胜率参考排序）</Typography>
+                  <Typography component="h4" variant="h6">全部武将（按胜率参考排序）</Typography>
                 </Box>
                 <ResponsiveDisclosure label="全部武将排名">
                 <ScrollableAnalyticsTable label="全部武将排名">
@@ -639,7 +665,7 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography component="h3" variant="h6">全部战法（按胜率参考排序）</Typography>
+                  <Typography component="h4" variant="h6">全部战法（按胜率参考排序）</Typography>
                 </Box>
                 <ResponsiveDisclosure label="全部战法排名">
                 <ScrollableAnalyticsTable label="全部战法排名">
@@ -679,7 +705,7 @@ const Analytics = () => {
         {/* Section 2: which combinations work well */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
           <GroupsIcon sx={{ color: 'info.main' }} />
-          <Typography component="h2" variant="h5">再看哪些搭配效果好</Typography>
+          <Typography component="h3" variant="h5">再看哪些搭配效果好</Typography>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           放在一起会互相加分的组合。组合分越高，同队时对整体阵容的帮助越大。
@@ -688,7 +714,7 @@ const Analytics = () => {
           <CardContent>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
               <LinkIcon sx={{ mr: 1, color: 'info.main' }} />
-              <Typography component="h3" variant="h6">最搭的武将组合</Typography>
+              <Typography component="h4" variant="h6">最搭的武将组合</Typography>
             </Box>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
               这些武将同队时，模型给出的额外组合分最高。
@@ -721,7 +747,7 @@ const Analytics = () => {
           <CardContent>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
               <LinkIcon sx={{ mr: 1, color: 'secondary.main' }} />
-              <Typography component="h3" variant="h6">最搭的武将与战法</Typography>
+              <Typography component="h4" variant="h6">最搭的武将与战法</Typography>
             </Box>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
               某个武将带上某个战法时，模型给出的额外组合分最高。
@@ -753,7 +779,7 @@ const Analytics = () => {
         {/* Section 3: what everyone uses */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
           <BarChartIcon sx={{ color: 'text.secondary' }} />
-          <Typography component="h2" variant="h5">看看大家常用什么</Typography>
+          <Typography component="h3" variant="h5">看看大家常用什么</Typography>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           出场次数最多的武将和战法。常用不一定最强，但能反映当前流行的选择。
@@ -762,7 +788,7 @@ const Analytics = () => {
           <Grid size={{ xs: 12, md: 6 }}>
             <Card>
               <CardContent>
-                <Typography component="h3" variant="h6" gutterBottom>武将使用排行</Typography>
+                <Typography component="h4" variant="h6" gutterBottom>武将使用排行</Typography>
                 <ResponsiveDisclosure label="武将使用排行">
                 <ScrollableAnalyticsTable label="武将使用排行">
                   <Table size="small" stickyHeader>
@@ -785,7 +811,7 @@ const Analytics = () => {
           <Grid size={{ xs: 12, md: 6 }}>
             <Card>
               <CardContent>
-                <Typography component="h3" variant="h6" gutterBottom>战法使用排行</Typography>
+                <Typography component="h4" variant="h6" gutterBottom>战法使用排行</Typography>
                 <ResponsiveDisclosure label="战法使用排行">
                 <ScrollableAnalyticsTable label="战法使用排行">
                   <Table size="small" stickyHeader>
@@ -817,7 +843,7 @@ const Analytics = () => {
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <InsightsIcon sx={{ color: 'info.main' }} />
               <Box>
-                <Typography component="h2" variant="h6">数据与算法说明</Typography>
+                <Typography component="h3" variant="h6">数据与算法说明</Typography>
                 <Typography variant="body2" color="text.secondary">
                   选看内容：了解这些推荐有多可靠，不影响日常挑人挑战法。
                 </Typography>
@@ -865,7 +891,8 @@ const Analytics = () => {
               </Grid>
             </Grid>
           </AccordionDetails>
-        </Accordion>
+          </Accordion>
+        </Box>
       </Box>
     </Container>
   );

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -78,13 +78,13 @@ test.describe('Accessibility and responsive layout', () => {
     await page.goto('/analytics');
 
     const telemetryDisclosure = page.getByRole('button', {
-      name: '展开系统最常提供武将排行',
+      name: '展开游戏最常提供武将排行',
     });
     await expect(telemetryDisclosure).toBeVisible({ timeout: 15000 });
     await telemetryDisclosure.click();
 
     const telemetryTableRegion = page.getByRole('region', {
-      name: '系统最常提供武将排行表格，可滚动',
+      name: '游戏最常提供武将排行表格，可滚动',
     });
     await expect(telemetryTableRegion).toBeVisible();
     await expect(telemetryTableRegion).toHaveAttribute('tabindex', '0');

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -77,6 +77,27 @@ test.describe('Accessibility and responsive layout', () => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/analytics');
 
+    const telemetryDisclosure = page.getByRole('button', {
+      name: '展开系统最常提供武将排行',
+    });
+    await expect(telemetryDisclosure).toBeVisible({ timeout: 15000 });
+    await telemetryDisclosure.click();
+
+    const telemetryTableRegion = page.getByRole('region', {
+      name: '系统最常提供武将排行表格，可滚动',
+    });
+    await expect(telemetryTableRegion).toBeVisible();
+    await expect(telemetryTableRegion).toHaveAttribute('tabindex', '0');
+    expect(
+      await telemetryTableRegion.evaluate((element) => {
+        const styles = window.getComputedStyle(element);
+        return {
+          maxHeight: styles.maxHeight,
+          overflowY: styles.overflowY,
+        };
+      })
+    ).toEqual({ maxHeight: '520px', overflowY: 'auto' });
+
     const disclosure = page.getByRole('button', { name: '展开全部武将排名' });
     await expect(disclosure).toBeVisible({ timeout: 15000 });
     await disclosure.click();
@@ -86,25 +107,60 @@ test.describe('Accessibility and responsive layout', () => {
     await expect(tableRegion).toHaveAttribute('tabindex', '0');
   });
 
-  test('analytics leads with a player-friendly intro and how-to-read guide', async ({ page }) => {
+  test('analytics separates telemetry from the battle-report guide', async ({ page }) => {
     await page.goto('/analytics');
 
     // The single level-one heading is preserved.
     await expect(page.getByRole('heading', { level: 1, name: '数据洞察' })).toBeVisible({ timeout: 15000 });
 
-    // Plain-language guide explaining the three key numbers in player terms.
-    await expect(page.getByRole('heading', { name: '三步看懂这些数字' })).toBeVisible();
-    await expect(page.getByText('胜率参考')).not.toHaveCount(0);
-    await expect(page.getByText('组合分')).not.toHaveCount(0);
-    await expect(page.getByText('参考场次')).not.toHaveCount(0);
-    await expect(page.getByText('强度加成')).toHaveCount(0);
+    const telemetrySection = page.getByTestId('player-choice-analytics');
+    const battleSection = page.getByTestId('battle-report-analytics');
+    await expect(
+      telemetrySection.getByRole('heading', {
+        level: 2,
+        name: '匿名选项统计',
+      })
+    ).toBeVisible();
+    await expect(
+      battleSection.getByRole('heading', {
+        level: 2,
+        name: '历史战报分析',
+      })
+    ).toBeVisible();
+    await expect(telemetrySection).not.toContainText('所有结论都来自已记录的');
+    await expect(battleSection).toContainText('所有结论都来自已记录的');
+    expect(
+      await page.evaluate(() => {
+        const telemetryElement = document.querySelector(
+          '[data-testid="player-choice-analytics"]'
+        );
+        const battleElement = document.querySelector(
+          '[data-testid="battle-report-analytics"]'
+        );
+        return Boolean(
+          telemetryElement &&
+            battleElement &&
+            telemetryElement.compareDocumentPosition(battleElement) &
+              Node.DOCUMENT_POSITION_FOLLOWING
+        );
+      })
+    ).toBe(true);
+
+    // The battle-report section owns the guide to its three measures.
+    await expect(
+      battleSection.getByRole('heading', { name: '三步看懂这些数字' })
+    ).toBeVisible();
+    await expect(battleSection.getByText('胜率参考')).not.toHaveCount(0);
+    await expect(battleSection.getByText('组合分')).not.toHaveCount(0);
+    await expect(battleSection.getByText('参考场次')).not.toHaveCount(0);
+    await expect(battleSection.getByText('强度加成')).toHaveCount(0);
 
     // Actionable sections come before the optional diagnostics section.
-    await expect(page.getByRole('heading', { name: '先看谁更值得选' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: '再看哪些搭配效果好' })).toBeVisible();
+    await expect(battleSection.getByRole('heading', { name: '先看谁更值得选' })).toBeVisible();
+    await expect(battleSection.getByRole('heading', { name: '再看哪些搭配效果好' })).toBeVisible();
 
     // The action-oriented filter section replaces the old "筛选名册" wording.
-    await expect(page.getByRole('heading', { name: '只看我关心的武将和战法' })).toBeVisible();
+    await expect(battleSection.getByRole('heading', { name: '只看我关心的武将和战法' })).toBeVisible();
   });
 
   test('data-and-algorithm details start collapsed and expand by keyboard', async ({ page }) => {

--- a/web/tests/playerChoiceAnalytics.spec.js
+++ b/web/tests/playerChoiceAnalytics.spec.js
@@ -147,9 +147,15 @@ test('Analytics omits player-choice rankings for a schema-v2 artifact', async ({
   ).toBeVisible({ timeout: 15000 });
 
   await expect(page.getByTestId('player-choice-analytics')).toHaveCount(0);
+  const battleSection = page.getByTestId('battle-report-analytics');
+  await expect(battleSection).toBeVisible();
+  await expect(
+    battleSection.getByRole('heading', { name: '历史战报分析' })
+  ).toBeVisible();
+  await expect(battleSection).toContainText('所有结论都来自已记录的');
 });
 
-test('Analytics renders schema-v3 top-five offer and pick rankings', async ({
+test('Analytics separates battle reports and renders full scrollable telemetry rankings', async ({
   page,
 }) => {
   const artifact = phaseThreeArtifact();
@@ -170,6 +176,13 @@ test('Analytics renders schema-v3 top-five offer and pick rankings', async ({
   await expect(
     section.getByRole('heading', { name: '匿名选项统计' })
   ).toBeVisible();
+  const battleSection = page.getByTestId('battle-report-analytics');
+  await expect(battleSection).toBeVisible();
+  await expect(
+    battleSection.getByRole('heading', { name: '历史战报分析' })
+  ).toBeVisible();
+  await expect(battleSection).toContainText('所有结论都来自已记录的');
+  await expect(section).not.toContainText('所有结论都来自已记录的');
 
   const heroToggle = section.getByRole('button', { name: '武将' });
   const skillToggle = section.getByRole('button', { name: '战法' });
@@ -180,14 +193,30 @@ test('Analytics renders schema-v3 top-five offer and pick rankings', async ({
   const picked = section.getByTestId('telemetry-ranking-picks');
   await expect(offered.getByRole('heading', { name: '系统最常提供' })).toBeVisible();
   await expect(picked.getByRole('heading', { name: '玩家最常选择' })).toBeVisible();
-  await expect(offered.getByTestId('telemetry-ranking-row')).toHaveCount(5);
-  await expect(picked.getByTestId('telemetry-ranking-row')).toHaveCount(5);
+  await expect(
+    offered.getByRole('region', {
+      name: '系统最常提供武将排行表格，可滚动',
+    })
+  ).toHaveAttribute('tabindex', '0');
+  await expect(
+    picked.getByRole('region', {
+      name: '玩家最常选择武将排行表格，可滚动',
+    })
+  ).toHaveAttribute('tabindex', '0');
+  await expect(offered.getByTestId('telemetry-ranking-row')).toHaveCount(
+    artifact.analytics.items.heroes.length
+  );
+  await expect(picked.getByTestId('telemetry-ranking-row')).toHaveCount(
+    artifact.analytics.items.heroes.length
+  );
   await expect(offered.getByTestId('telemetry-ranking-name')).toHaveText([
     '曹操',
     '刘备',
     '关羽',
     '张飞',
     '赵云',
+    '周瑜',
+    '孙权',
   ]);
   await expect(picked.getByTestId('telemetry-ranking-name')).toHaveText([
     '关羽',
@@ -195,27 +224,25 @@ test('Analytics renders schema-v3 top-five offer and pick rankings', async ({
     '赵云',
     '曹操',
     '孙权',
+    '张飞',
+    '周瑜',
   ]);
 
   const topOffer = offered.getByTestId('telemetry-ranking-row').first();
   await expect(topOffer).toContainText('30 次');
   await expect(topOffer).toContainText(
-    `提供率 ${((30 / heroOpportunityCount) * 100).toFixed(1)}%`
-  );
-  await expect(topOffer.getByRole('progressbar')).toHaveAttribute(
-    'aria-valuemax',
-    '30'
-  );
-  await expect(topOffer.getByRole('progressbar')).toHaveAttribute(
-    'aria-valuenow',
-    '30'
+    `${((30 / heroOpportunityCount) * 100).toFixed(1)}%`
   );
 
   const lowSupportPick = picked
     .getByTestId('telemetry-ranking-row')
     .filter({ hasText: '孙权' });
   await expect(lowSupportPick).toContainText('9 次');
-  await expect(lowSupportPick).toContainText('提供后选择率 样本不足');
+  await expect(lowSupportPick).toContainText('样本不足');
+  const zeroPick = picked
+    .getByTestId('telemetry-ranking-row')
+    .filter({ hasText: '周瑜' });
+  await expect(zeroPick).toContainText('0 次');
 
   for (const hiddenText of [
     '有效选择',
@@ -232,12 +259,25 @@ test('Analytics renders schema-v3 top-five offer and pick rankings', async ({
 
   await skillToggle.click();
   await expect(skillToggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(
+    offered.getByRole('region', {
+      name: '系统最常提供战法排行表格，可滚动',
+    })
+  ).toHaveAttribute('tabindex', '0');
+  await expect(offered.getByTestId('telemetry-ranking-row')).toHaveCount(
+    artifact.analytics.items.skills.length
+  );
+  await expect(picked.getByTestId('telemetry-ranking-row')).toHaveCount(
+    artifact.analytics.items.skills.length
+  );
   await expect(offered.getByTestId('telemetry-ranking-name')).toHaveText([
     '万人之敌',
     '一计决胜',
     '七进七出',
     '上兵伐谋',
     '临机制胜',
+    '不屈意志',
+    '临阵突袭',
   ]);
   await expect(picked.getByTestId('telemetry-ranking-name')).toHaveText([
     '一计决胜',
@@ -245,5 +285,7 @@ test('Analytics renders schema-v3 top-five offer and pick rankings', async ({
     '七进七出',
     '万人之敌',
     '不屈意志',
+    '临阵突袭',
+    '临机制胜',
   ]);
 });

--- a/web/tests/playerChoiceAnalytics.spec.js
+++ b/web/tests/playerChoiceAnalytics.spec.js
@@ -176,6 +176,10 @@ test('Analytics separates battle reports and renders full scrollable telemetry r
   await expect(
     section.getByRole('heading', { name: '匿名选项统计' })
   ).toBeVisible();
+  await expect(section).toContainText(
+    '匿名选项统计汇总玩家使用本工具时的匿名选择'
+  );
+  await expect(section).not.toContainText('少于 10 次提供');
   const battleSection = page.getByTestId('battle-report-analytics');
   await expect(battleSection).toBeVisible();
   await expect(
@@ -191,11 +195,11 @@ test('Analytics separates battle reports and renders full scrollable telemetry r
 
   const offered = section.getByTestId('telemetry-ranking-offers');
   const picked = section.getByTestId('telemetry-ranking-picks');
-  await expect(offered.getByRole('heading', { name: '系统最常提供' })).toBeVisible();
+  await expect(offered.getByRole('heading', { name: '游戏最常提供' })).toBeVisible();
   await expect(picked.getByRole('heading', { name: '玩家最常选择' })).toBeVisible();
   await expect(
     offered.getByRole('region', {
-      name: '系统最常提供武将排行表格，可滚动',
+      name: '游戏最常提供武将排行表格，可滚动',
     })
   ).toHaveAttribute('tabindex', '0');
   await expect(
@@ -238,7 +242,7 @@ test('Analytics separates battle reports and renders full scrollable telemetry r
     .getByTestId('telemetry-ranking-row')
     .filter({ hasText: '孙权' });
   await expect(lowSupportPick).toContainText('9 次');
-  await expect(lowSupportPick).toContainText('样本不足');
+  await expect(lowSupportPick).toContainText('100.0%');
   const zeroPick = picked
     .getByTestId('telemetry-ranking-row')
     .filter({ hasText: '周瑜' });
@@ -261,7 +265,7 @@ test('Analytics separates battle reports and renders full scrollable telemetry r
   await expect(skillToggle).toHaveAttribute('aria-pressed', 'true');
   await expect(
     offered.getByRole('region', {
-      name: '系统最常提供战法排行表格，可滚动',
+      name: '游戏最常提供战法排行表格，可滚动',
     })
   ).toHaveAttribute('tabindex', '0');
   await expect(offered.getByTestId('telemetry-ranking-row')).toHaveCount(

--- a/web/tests/playerChoiceAnalytics.spec.js
+++ b/web/tests/playerChoiceAnalytics.spec.js
@@ -17,6 +17,28 @@ const item = (
   rate_suppressed: offerCount < 10,
 });
 
+const phaseTwoArtifact = () => ({
+  catalog_version: telemetry.catalog_version,
+  preference_model: null,
+  rounds: telemetry.rounds.map((round) => ({
+    round_number: round.round_number,
+    round_type: round.round_type,
+    event_count: round.event_count,
+    recommendation_accepted_count: round.recommendation_accepted_count,
+    chosen_position_counts: round.chosen_position_counts,
+    recommended_position_counts: round.recommended_position_counts,
+  })),
+  schema: { version: 2, source_event_schema_version: 1 },
+  summary: {
+    event_count: telemetry.summary.event_count,
+    invalid_event_count: telemetry.summary.invalid_event_count,
+    session_count: telemetry.summary.session_count,
+    preference_event_count: telemetry.summary.preference_event_count,
+    model_versions: telemetry.summary.model_versions,
+    preference_model_versions: telemetry.summary.preference_model_versions,
+  },
+});
+
 const phaseThreeArtifact = () => {
   const eventCount = telemetry.summary.event_count;
   const accepted = telemetry.rounds.reduce(
@@ -112,20 +134,17 @@ const phaseThreeArtifact = () => {
 test('Analytics omits player-choice rankings for a schema-v2 artifact', async ({
   page,
 }) => {
-  const telemetryResponse = page.waitForResponse((response) =>
-    response.url().includes('/game-data/telemetry_data.json')
+  await page.route('**/game-data/telemetry_data.json', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(phaseTwoArtifact()),
+    })
   );
   await page.goto('/analytics');
-  await telemetryResponse;
   await expect(
     page.getByRole('heading', { name: '数据洞察' })
   ).toBeVisible({ timeout: 15000 });
-  await page.evaluate(
-    () =>
-      new Promise((resolve) =>
-        requestAnimationFrame(() => requestAnimationFrame(resolve))
-      )
-  );
 
   await expect(page.getByTestId('player-choice-analytics')).toHaveCount(0);
 });
@@ -134,6 +153,9 @@ test('Analytics renders schema-v3 top-five offer and pick rankings', async ({
   page,
 }) => {
   const artifact = phaseThreeArtifact();
+  const heroOpportunityCount = artifact.rounds
+    .filter((round) => round.round_type === 'hero')
+    .reduce((sum, round) => sum + round.event_count, 0);
   await page.route('**/game-data/telemetry_data.json', (route) =>
     route.fulfill({
       status: 200,
@@ -145,7 +167,9 @@ test('Analytics renders schema-v3 top-five offer and pick rankings', async ({
 
   const section = page.getByTestId('player-choice-analytics');
   await expect(section).toBeVisible({ timeout: 15000 });
-  await expect(section.getByText('玩家最关心的选择排行')).toBeVisible();
+  await expect(
+    section.getByRole('heading', { name: '匿名选项统计' })
+  ).toBeVisible();
 
   const heroToggle = section.getByRole('button', { name: '武将' });
   const skillToggle = section.getByRole('button', { name: '战法' });
@@ -175,7 +199,9 @@ test('Analytics renders schema-v3 top-five offer and pick rankings', async ({
 
   const topOffer = offered.getByTestId('telemetry-ranking-row').first();
   await expect(topOffer).toContainText('30 次');
-  await expect(topOffer).toContainText('提供率 78.9%');
+  await expect(topOffer).toContainText(
+    `提供率 ${((30 / heroOpportunityCount) * 100).toFixed(1)}%`
+  );
   await expect(topOffer.getByRole('progressbar')).toHaveAttribute(
     'aria-valuemax',
     '30'


### PR DESCRIPTION
## Intent

Finalize the existing Phase 3 telemetry follow-up PR with the user-approved Analytics wording and rate presentation. Keep the Option A same-page separation: 匿名选项统计 first and all battle-derived provenance, guidance, filters, win-rate, synergy, usage, and algorithm content inside 历史战报分析. Rename 系统最常提供 to 游戏最常提供. Explain that 匿名选项统计汇总玩家使用本工具时的匿名选择, records only the three option sets offered each round plus the final player choice, never double-counts the existing roster, is not a win rate, and does not alter AI scoring. Retain full bounded scrollable hero/skill rankings and the 武将/战法 toggle. Show the exact offer and picked-when-offered percentage for every aggregated row, including rows with fewer than 10 offers such as a 9-offer item, while retaining the artifact diagnostic marker for compatibility. Remove the player-facing sentence about hiding percentages below 10. Preserve the telemetry JSON schema and aggregation semantics, update documentation and regression coverage, and keep the no-mistakes Cloudflare Node-only toolchain fix.

## What Changed

- Restructured the Analytics page into two same-page sections: `匿名选项统计` (anonymous offer/pick telemetry) first, with all battle-derived provenance, guidance, filters, win-rate, synergy, usage, and algorithm content moved under `历史战报分析`; reworded the explanatory copy, renamed `系统最常提供` to `游戏最常提供`, removed the "percentages hidden below 10 offers" sentence, and dropped the setup-screen disclosure caption — while keeping the bounded scrollable hero/skill rankings and the `武将/战法` toggle.
- Changed the telemetry builder to surface the exact offer count and picked-when-offered percentage for every aggregated row, including sub-10-offer rows, while retaining the artifact diagnostic marker for compatibility; the telemetry JSON schema and aggregation semantics are unchanged.
- Added `web/.tool-versions` to pin the no-mistakes Cloudflare Node-only toolchain, and updated documentation (README, telemetry plan) plus regression coverage (telemetry-builder test, `playerChoiceAnalytics` and `accessibilityLayout` e2e specs).

## Risk Assessment

✅ Low: A well-bounded, intent-conformant UI refactor with matching doc/test coverage and no source bugs; the only notable item is a deliberate, documented privacy-disclosure relocation worth a human confirmation.

## Testing

Ran the scoped suites for the two touched workspaces and captured product-level visual evidence. The telemetry-builder Python suite (make test-telemetry) passes with the new offered-set-only counting test; web typecheck is clean; the two relevant Playwright specs (8 tests) pass. I then drove the real Analytics page against the production schema-v3 artifact and captured screenshots showing: the renamed 匿名选项统计 / 游戏最常提供 rankings with the new disclosure copy, exact percentages on a 9-offer row (22.5%) and other sub-10-offer rows (no 样本不足 / no "hide below 10" text), the retained 武将/战法 toggle over full scrollable tables, and a separate 历史战报分析 section that alone carries the 2822-battle provenance caveat, the 三步看懂这些数字 guide, filters, and win-rate tables — confirming the Option A separation end-to-end. No failures or actionable issues.

- Evidence: Analytics — 匿名选项统计 section (heroes): renamed 游戏最常提供, new disclosure copy, 9-offer row shows exact 22.5% (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY8M8V313Z8XQTKW4C4H4C8J/anonymous-choice-section.png</code>)
- Evidence: Analytics — 匿名选项统计 with 战法 toggle active (skills rankings, exact percentages) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY8M8V313Z8XQTKW4C4H4C8J/anonymous-choice-skills.png</code>)
- Evidence: Analytics — 历史战报分析 (BATTLE ARCHIVE) section owns provenance caveat, 三步看懂 guide, filters, and win-rate tables (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY8M8V313Z8XQTKW4C4H4C8J/battle-report-top.png</code>)
- Evidence: Analytics — full page (telemetry section first, battle-report section second) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY8M8V313Z8XQTKW4C4H4C8J/analytics-full.png</code>)
<details>
<summary>Evidence: Playwright result</summary>

```text
8 passed (playerChoiceAnalytics.spec.js: 2, accessibilityLayout.spec.js: 6)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `web/src/components/setup/SetupForm.tsx:157` - This commit removes the only pre-collection privacy disclosure — the game setup screen caption &#39;本站会匿名记录每轮选项、模型评分和最终选择…&#39; (SetupForm.tsx) — and the matching Phase-1 plan bullet. After this change, the sole user-facing mention of anonymous collection is the descriptive text inside the Analytics &#39;匿名选项统计&#39; section (Analytics.tsx:298), which explains what the aggregated stats show rather than notifying users at/before the point their choices are recorded, and which a user who never opens Analytics will never see. The removal is deliberate and documented, but it is a privacy/consent behavior change not explicitly called out in the intent; confirm this is intended.
- ℹ️ `web/tests/accessibilityLayout.spec.js:80` - The new mobile-disclosure e2e assertions in this test navigate to /analytics without mocking telemetry_data.json, so they hard-depend on the committed public artifact carrying schema-v3 item analytics (it currently does — 75 hero rows). The sibling playerChoiceAnalytics specs mock the artifact via page.route; this one does not. If a future weekly telemetry rebuild ever emits insufficient_evidence (analytics=null), the &#39;匿名选项统计&#39; section is not rendered and &#39;展开游戏最常提供武将排行&#39; never appears, failing this test despite correct app code. Consider routing a fixture like the other telemetry tests.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`make test-telemetry` — 26 telemetry-builder Python tests pass, incl. new `test_item_analytics_count_only_offered_sets_and_chosen_option`</code>
- <code>`cd web &amp;&amp; npm run typecheck` (Node 22, tsc --noEmit) — clean</code>
- <code>`cd web &amp;&amp; npx playwright test tests/playerChoiceAnalytics.spec.js tests/accessibilityLayout.spec.js` — 8 passed</code>
- `Manual: launched the real Analytics page (production schema-v3 telemetry artifact, 75 heroes) and captured full-page + section screenshots incl. the 武将/战法 toggle state`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
