### PR TITLE
fix(telemetry): parse Wrangler database_size in D1 observation report

### DIFF
--- a/.github/workflows/update-telemetry-data.yml
+++ b/.github/workflows/update-telemetry-data.yml
@@ -42,6 +42,7 @@ jobs:
           python -m unittest \
             data/test_build_telemetry_data.py \
             data/test_telemetry_incremental_state.py \
+            data/test_telemetry_observation_report.py \
             -v
 
       - name: Validate Cloudflare configuration
@@ -66,58 +67,10 @@ jobs:
             --remote \
             --command="SELECT COUNT(*) AS older_than_14_days_count FROM round_telemetry WHERE received_at < datetime('now', '-14 days')" \
             --json > "$RUNNER_TEMP/d1-retention.json"
-          python - \
+          python data/telemetry_observation_report.py \
             "$RUNNER_TEMP/d1-info.json" \
             "$RUNNER_TEMP/d1-retention.json" \
-            "$GITHUB_STEP_SUMMARY" <<'PY'
-          import json
-          import sys
-          from pathlib import Path
-
-          def find_field(value, field):
-              if isinstance(value, dict):
-                  if field in value:
-                      return value[field]
-                  for child in value.values():
-                      found = find_field(child, field)
-                      if found is not None:
-                          return found
-              elif isinstance(value, list):
-                  for child in value:
-                      found = find_field(child, field)
-                      if found is not None:
-                          return found
-              return None
-
-          def non_negative_integer(value, description):
-              if isinstance(value, bool):
-                  raise ValueError(f"{description} is not an integer")
-              try:
-                  parsed = int(value)
-              except (TypeError, ValueError) as error:
-                  raise ValueError(f"{description} is not an integer") from error
-              if parsed < 0:
-                  raise ValueError(f"{description} is negative")
-              return parsed
-
-          info = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-          retention = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
-          size_bytes = non_negative_integer(
-              find_field(info, "file_size"),
-              "D1 file_size",
-          )
-          older_rows = non_negative_integer(
-              find_field(retention, "older_than_14_days_count"),
-              "rows-older-than-14-days count",
-          )
-          with Path(sys.argv[3]).open("a", encoding="utf-8") as summary:
-              summary.write("### Telemetry D1 observation report\n\n")
-              summary.write(f"- Database size: {size_bytes:,} bytes\n")
-              summary.write(
-                  f"- Rows older than 14 days: {older_rows:,}\n"
-              )
-              summary.write("- Rows deleted: 0 (deletion is disabled)\n")
-          PY
+            "$GITHUB_STEP_SUMMARY"
 
       - name: Export round telemetry from D1
         env:

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ test:
 
 # Tests for the offline data builders (data/). Fast (no PaddleOCR).
 test-data:
-	uv run pytest data/test_build_recommendation_data.py data/test_build_telemetry_data.py data/test_telemetry_incremental_state.py -v
+	uv run pytest data/test_build_recommendation_data.py data/test_build_telemetry_data.py data/test_telemetry_incremental_state.py data/test_telemetry_observation_report.py -v
 
 test-telemetry:
-	uv run pytest data/test_build_telemetry_data.py data/test_telemetry_incremental_state.py -v
+	uv run pytest data/test_build_telemetry_data.py data/test_telemetry_incremental_state.py data/test_telemetry_observation_report.py -v
 
 # Web service (starts React frontend only - client-side implementation)
 web:

--- a/data/telemetry_observation_report.py
+++ b/data/telemetry_observation_report.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Render the aggregate-only D1 observation section for GitHub Actions."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+class ObservationReportError(ValueError):
+    """Raised when Wrangler output does not match the expected contract."""
+
+
+def find_field(value: Any, field: str) -> Any:
+    """Find the first matching field in Wrangler's nested JSON responses."""
+    if isinstance(value, dict):
+        if field in value:
+            return value[field]
+        for child in value.values():
+            found = find_field(child, field)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            found = find_field(child, field)
+            if found is not None:
+                return found
+    return None
+
+
+def non_negative_integer(value: Any, description: str) -> int:
+    if isinstance(value, bool):
+        raise ObservationReportError(f"{description} is not an integer")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str) and value.isdecimal():
+        parsed = int(value)
+    else:
+        raise ObservationReportError(f"{description} is not an integer")
+    if parsed < 0:
+        raise ObservationReportError(f"{description} is negative")
+    return parsed
+
+
+def parse_observation(
+    info: Any,
+    retention: Any,
+) -> tuple[int, int]:
+    """Extract database bytes and old-row count from pinned Wrangler output."""
+    # Wrangler 4.112.0 converts the Cloudflare API's `file_size` field to
+    # `database_size` before emitting JSON. Retain the API name as a
+    # compatibility fallback for older/newer output shapes.
+    size_value = find_field(info, "database_size")
+    if size_value is None:
+        size_value = find_field(info, "file_size")
+    size_bytes = non_negative_integer(
+        size_value,
+        "D1 database_size/file_size",
+    )
+    older_rows = non_negative_integer(
+        find_field(retention, "older_than_14_days_count"),
+        "rows-older-than-14-days count",
+    )
+    return size_bytes, older_rows
+
+
+def append_summary(
+    path: Path,
+    size_bytes: int,
+    older_rows: int,
+) -> None:
+    with path.open("a", encoding="utf-8") as summary:
+        summary.write("### Telemetry D1 observation report\n\n")
+        summary.write(f"- Database size: {size_bytes:,} bytes\n")
+        summary.write(f"- Rows older than 14 days: {older_rows:,}\n")
+        summary.write("- Rows deleted: 0 (deletion is disabled)\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Append aggregate D1 telemetry observations to a job summary."
+    )
+    parser.add_argument("info", type=Path, help="wrangler d1 info --json output")
+    parser.add_argument(
+        "retention",
+        type=Path,
+        help="wrangler d1 execute --json retention-count output",
+    )
+    parser.add_argument("summary", type=Path, help="GitHub job summary path")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        info = json.loads(args.info.read_text(encoding="utf-8"))
+        retention = json.loads(args.retention.read_text(encoding="utf-8"))
+        size_bytes, older_rows = parse_observation(info, retention)
+        append_summary(args.summary, size_bytes, older_rows)
+    except (OSError, json.JSONDecodeError, ObservationReportError) as error:
+        print(f"D1 observation report failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/data/test_telemetry_observation_report.py
+++ b/data/test_telemetry_observation_report.py
@@ -1,0 +1,103 @@
+"""Tests for the aggregate-only D1 workflow observation report."""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from data.telemetry_observation_report import (
+    ObservationReportError,
+    main,
+    parse_observation,
+)
+
+
+class TelemetryObservationReportTests(unittest.TestCase):
+    def test_parses_wrangler_4_112_database_size_and_nested_query_result(
+        self,
+    ) -> None:
+        info = {
+            "uuid": "database-id",
+            "name": "TELEMETRY_DB",
+            "database_size": 1_234_567,
+        }
+        retention = [
+            {
+                "results": [{"older_than_14_days_count": 42}],
+                "success": True,
+            }
+        ]
+
+        self.assertEqual(
+            parse_observation(info, retention),
+            (1_234_567, 42),
+        )
+
+    def test_accepts_file_size_as_compatibility_fallback(self) -> None:
+        self.assertEqual(
+            parse_observation(
+                {"file_size": "4096"},
+                {"older_than_14_days_count": "0"},
+            ),
+            (4096, 0),
+        )
+
+    def test_rejects_missing_or_invalid_values(self) -> None:
+        cases = (
+            ({}, {"older_than_14_days_count": 0}),
+            ({"database_size": -1}, {"older_than_14_days_count": 0}),
+            ({"database_size": True}, {"older_than_14_days_count": 0}),
+            ({"database_size": 1.5}, {"older_than_14_days_count": 0}),
+            ({"database_size": 1}, {}),
+        )
+        for info, retention in cases:
+            with self.subTest(info=info, retention=retention):
+                with self.assertRaises(ObservationReportError):
+                    parse_observation(info, retention)
+
+    def test_main_appends_only_aggregate_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as directory_name:
+            directory = Path(directory_name)
+            info_path = directory / "info.json"
+            retention_path = directory / "retention.json"
+            summary_path = directory / "summary.md"
+            info_path.write_text(
+                json.dumps({"database_size": 2048}),
+                encoding="utf-8",
+            )
+            retention_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "results": [
+                                {"older_than_14_days_count": 7}
+                            ]
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            exit_code = main(
+                [
+                    str(info_path),
+                    str(retention_path),
+                    str(summary_path),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(
+                summary_path.read_text(encoding="utf-8"),
+                (
+                    "### Telemetry D1 observation report\n\n"
+                    "- Database size: 2,048 bytes\n"
+                    "- Rows older than 14 days: 7\n"
+                    "- Rows deleted: 0 (deletion is disabled)\n"
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Intent

Fix the failed Update telemetry data workflow run 30065395278. Wrangler 4.112.0 d1 info --json deliberately emits database_size after renaming the API file_size field, while the workflow expected only file_size and crashed before export. Parse database_size with file_size as a compatibility fallback, keep the report aggregate-only, fail closed on missing or invalid values, and add regression tests using the real Wrangler JSON shape plus the nested D1 execute result. Preserve the approved observation rollout: do not delete D1 rows and do not change telemetry artifact or checkpoint semantics. Push the fix and create a follow-up PR only after scoped tests and CI pass.

## What Changed

- Extracted the weekly telemetry workflow's inline heredoc Python into a standalone `data/telemetry_observation_report.py`, and switched D1 size parsing to read Wrangler 4.112.0's renamed `database_size` field with `file_size` retained as a compatibility fallback — fixing the crash that failed run 30065395278 before export. Parsing stays fail-closed on missing/negative/non-integer values and the emitted step summary remains aggregate-only (size, rows-older-than-14-days, "Rows deleted: 0").
- Added `data/test_telemetry_observation_report.py` covering the real `database_size` shape, nested `d1 execute` retention results, the `file_size` fallback, fail-closed errors, and aggregate-only summary output.
- Wired the new test suite into the `update-telemetry-data.yml` workflow's unittest step and into the `test-data`/`test-telemetry` Makefile targets. No D1 row deletion or telemetry artifact/checkpoint semantics were changed.

## Risk Assessment

✅ Low: A well-bounded fix that extracts the inline observation script, adds database_size parsing with a file_size fallback, preserves fail-closed and aggregate-only behavior, changes no telemetry artifact/checkpoint semantics, and adds targeted regression tests that resolve correctly under both pytest and unittest.

## Testing

Ran the targeted `data/test_telemetry_observation_report.py` suite (all pass) and drove the new report script end-to-end against realistic Wrangler 4.112.0 JSON: I reproduced the original workflow crash (old `file_size`-only logic aborts on the renamed `database_size` field), then showed the fix renders the aggregate-only step summary from `database_size`, still honors the legacy `file_size` fallback, and fails closed when the size field is missing or invalid. Confirmed the workflow introduces no D1 deletion and keeps the observation-rollout semantics unchanged. This is a CLI/workflow change with no rendered UI surface, so evidence is a CLI transcript plus the rendered markdown summary rather than a screenshot. Overall result: pass.

<details>
<summary>Evidence: Rendered GitHub step summary (database_size path)</summary>

<code>### Telemetry D1 observation report&#10;&#10;- Database size: 4,358,144 bytes&#10;- Rows older than 14 days: 137&#10;- Rows deleted: 0 (deletion is disabled)</code>

```text
### Telemetry D1 observation report

- Database size: 4,358,144 bytes
- Rows older than 14 days: 137
- Rows deleted: 0 (deletion is disabled)
```
</details>
<details>
<summary>Evidence: End-to-end transcript: crash repro + fixed database_size/file_size paths + fail-closed</summary>

```text
############################################################
# Scenario A: OLD workflow logic against Wrangler 4.112.0  #
#   (reproduces the crash from run 30065395278)            #
############################################################
$ python -c "find file_size only" d1-info.json  (database_size present, file_size absent)
CRASH: D1 file_size is not an integer  (value was: None )
exit=1  <-- workflow aborted before export (matches the reported failure)

############################################################
# Scenario B: FIXED report, database_size path             #
############################################################
$ uv run python data/telemetry_observation_report.py /var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY94RR4WYTQY4WD67GVYXKXN/d1-info.json /var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY94RR4WYTQY4WD67GVYXKXN/d1-retention.json /dev/stdout
### Telemetry D1 observation report

- Database size: 4,358,144 bytes
- Rows older than 14 days: 137
- Rows deleted: 0 (deletion is disabled)
exit=0

############################################################
# Scenario C: FIXED report, file_size compatibility path   #
############################################################
$ uv run python data/telemetry_observation_report.py /var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY94RR4WYTQY4WD67GVYXKXN/d1-info-legacy.json /var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY94RR4WYTQY4WD67GVYXKXN/d1-retention-zero.json /dev/stdout
### Telemetry D1 observation report

- Database size: 999,424 bytes
- Rows older than 14 days: 0
- Rows deleted: 0 (deletion is disabled)
exit=0

############################################################
# Scenario D: fail-closed on missing size field            #
############################################################
$ uv run python data/telemetry_observation_report.py /var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY94RR4WYTQY4WD67GVYXKXN/d1-info-nosize.json /var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY94RR4WYTQY4WD67GVYXKXN/d1-retention.json /dev/stdout
D1 observation report failed: D1 database_size/file_size is not an integer
exit=1
```
</details>
<details>
<summary>Evidence: Scoped test result</summary>

```text
data/test_telemetry_observation_report.py: 4 passed, 5 subtests passed in 0.02s (parses Wrangler 4.112 database_size + nested query result; file_size fallback; rejects missing/negative/bool/float; aggregate-only summary)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run python -m pytest data/test_telemetry_observation_report.py -v` — 4 tests + 5 subtests pass (real Wrangler `database_size` shape, nested d1 execute result, `file_size` fallback, fail-closed on missing/negative/bool/float, aggregate-only summary output)</code>
- <code>End-to-end CLI: reproduced the run 30065395278 crash by running the pre-fix `file_size`-only logic against Wrangler 4.112.0 `database_size` JSON (exit 1, &#39;file_size is not an integer&#39; before export)</code>
- <code>End-to-end CLI: `data/telemetry_observation_report.py` on realistic `database_size` info + nested `d1 execute` retention JSON renders the correct aggregate step summary (exit 0)</code>
- <code>End-to-end CLI: `file_size` compatibility fallback path renders correctly (exit 0)</code>
- `End-to-end CLI: fail-closed on info JSON missing both size fields (exit 1, non-zero, no summary written)`
- <code>`grep -niE &#39;delete|drop|truncate&#39; .github/workflows/update-telemetry-data.yml` — confirmed no D1 row deletion introduced; report still states &#39;Rows deleted: 0 (deletion is disabled)&#39;</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
