### PR TITLE
fix(telemetry): apply D1 AUTOINCREMENT upgrade via configless command path

### DIFF
--- a/.github/workflows/update-telemetry-data.yml
+++ b/.github/workflows/update-telemetry-data.yml
@@ -108,16 +108,19 @@ jobs:
             --github-output "$GITHUB_OUTPUT" \
             "${reset_args[@]}"
 
-      - name: Apply pending D1 migrations
+      - name: Apply required D1 AUTOINCREMENT migration
+        if: steps.retention_preflight.outputs.migration_required == 'true'
         working-directory: web
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          npx --yes wrangler@4.112.0 d1 migrations apply \
+          npx --yes wrangler@4.112.0 d1 execute \
             "$CLOUDFLARE_D1_DATABASE_NAME" \
-            --remote
+            --remote \
+            --file=migrations/0002_round_telemetry_autoincrement.sql \
+            --yes
 
       - name: Capture post-migration D1 metadata
         working-directory: web

--- a/data/test_telemetry_retention.py
+++ b/data/test_telemetry_retention.py
@@ -39,6 +39,7 @@ CANONICAL_MIGRATION = ROOT / "web/migrations/0001_round_telemetry.sql"
 UPGRADE_MIGRATION = (
     ROOT / "web/migrations/0002_round_telemetry_autoincrement.sql"
 )
+UPDATE_WORKFLOW = ROOT / ".github/workflows/update-telemetry-data.yml"
 INSERT_SQL = """
 INSERT INTO "round_telemetry" (
     "id",
@@ -243,6 +244,19 @@ class TelemetryMigrationTests(unittest.TestCase):
                 load_canonical_table_sql(CANONICAL_MIGRATION)
             )
         )
+
+    def test_workflow_executes_upgrade_without_a_wrangler_config(self) -> None:
+        source = UPDATE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "if: steps.retention_preflight.outputs.migration_required "
+            "== 'true'",
+            source,
+        )
+        self.assertIn(
+            "--file=migrations/0002_round_telemetry_autoincrement.sql",
+            source,
+        )
+        self.assertNotIn("d1 migrations apply", source)
 
 
 class TelemetryRetentionMetadataTests(unittest.TestCase):

--- a/web/README.md
+++ b/web/README.md
@@ -225,10 +225,11 @@ source of truth; no Wrangler configuration file is required.
 2. In the Pages project, add a production D1 binding named exactly
    `TELEMETRY_DB`, pointing at that database. Add a separate preview binding if
    preview deployments should accept telemetry.
-3. Apply all migrations from `web/` (replace the database name):
+3. Initialize a new database from `web/` (replace the database name or ID):
 
    ```bash
-   npx wrangler d1 migrations apply <database-name> --remote
+   npx wrangler d1 execute <database-name-or-id> --remote \
+     --file=migrations/0001_round_telemetry.sql --yes
    ```
 
 4. Redeploy after adding the binding. `/api/health` and
@@ -249,12 +250,14 @@ manually. Configure it in the repository settings:
 4. Allow GitHub Actions to read and write repository contents so the workflow's
    scoped `contents: write` permission can push the changed generated file.
 
-The workflow first validates and applies the repository's D1 migrations, then
-exports the currently retained `round_telemetry` rows to `$RUNNER_TEMP`. The
-builder folds only IDs newer than the committed cursor into
-`../data/telemetry_state.json` and renders the cumulative public schema-v4
-artifact solely from that checkpoint. It then runs the web type-check, unit
-tests, and production build. Exactly the checkpoint and
+The workflow first validates the D1 schema and conditionally executes the
+AUTOINCREMENT upgrade file when an existing table still needs it, then exports
+the currently retained `round_telemetry` rows to `$RUNNER_TEMP`. This direct
+execution keeps the dashboard-managed Pages project free of a committed
+Wrangler configuration. The builder folds only IDs newer than the committed
+cursor into `../data/telemetry_state.json` and renders the cumulative public
+schema-v4 artifact solely from that checkpoint. It then runs the web type-check,
+unit tests, and production build. Exactly the checkpoint and
 `public/game-data/telemetry_data.json` are eligible for staging, and they are
 committed together when either changes.
 
@@ -294,13 +297,13 @@ Manual workflow dispatch exposes an explicit checkpoint-reset option for a
 deliberate catalog/algorithm reset. Normal runs fail if the checkpoint is
 missing or incompatible; they never silently discard cumulative history.
 
-If the D1 database is deliberately replaced, first apply all migrations to the
-empty replacement database, then manually dispatch `Update telemetry data`
-once with `reset_checkpoint` enabled. That explicit run validates the existing
-checkpoint, treats its cursor as zero for replacement-database sequence checks,
-discards its prior aggregates, and advances the new checkpoint past any rows
-already present in the replacement database. Do not enable the reset option
-for routine weekly retention.
+If the D1 database is deliberately replaced, first initialize the empty
+replacement database with `migrations/0001_round_telemetry.sql`, then manually
+dispatch `Update telemetry data` once with `reset_checkpoint` enabled. That
+explicit run validates the existing checkpoint, treats its cursor as zero for
+replacement-database sequence checks, discards its prior aggregates, and
+advances the new checkpoint past any rows already present in the replacement
+database. Do not enable the reset option for routine weekly retention.
 
 The builder recomputes event scores and tie-breaks from the recorded paired
 model version. Before deploying a new `src/recommendation_data.json`, retain the


### PR DESCRIPTION
## Intent

Repair the failed Update telemetry data workflow run 30072274592. Keep the Cloudflare Pages project dashboard-managed with no committed Wrangler config, and safely apply the existing AUTOINCREMENT upgrade only when retention preflight says it is required, using the configless D1 command path that already works with the configured database identifier. Preserve cumulative telemetry history, post-migration row/sequence verification, and the rule that no purge occurs until the checkpoint and artifact are successfully published. Add regression coverage and make the setup documentation consistent with the configless workflow.

## What Changed

- Reworked the `Update telemetry data` workflow so the AUTOINCREMENT upgrade is applied with the configless `wrangler d1 execute --file=migrations/0002_round_telemetry_autoincrement.sql --yes` path against the configured database name, gated on the retention preflight's `migration_required` output — keeping the Cloudflare Pages project dashboard-managed with no committed Wrangler config, and preserving the existing post-migration row/sequence verification and publish-before-purge ordering.
- Added `test_workflow_executes_upgrade_without_a_wrangler_config` (and supporting assertions) in `data/test_telemetry_retention.py` to lock in that the workflow references the `0002` migration file and no longer uses `d1 migrations apply`.
- Updated `web/README.md` to describe the direct configless execution of the upgrade file, consistent with the workflow.

## Risk Assessment

✅ Low: A tightly scoped, correct fix that swaps the config-requiring `d1 migrations apply` for the configless `d1 execute --file` gated on the preflight's `migration_required` output, preserving all history/verification/purge invariants, with matching regression coverage and consistent docs.

## Testing

Ran the scoped `data/` telemetry-retention suite (`pytest data/test_telemetry_retention.py`) — all 16 tests and 21 subtests pass, including the new regression test asserting the workflow uses the configless conditional `d1 execute --file=…0002…` path and dropped `d1 migrations apply`. To demonstrate the intent as the workflow actually experiences it, I drove the preflight CLI exactly as the retention_preflight step does: a legacy unquoted/no-AUTOINCREMENT table (the state that broke run 30072274592) emits `migration_required=true`, so the gated configless AUTOINCREMENT `d1 execute` runs, while an already-migrated table emits `migration_required=false`, so the step is skipped (idempotent, no repeated migration). I also confirmed the referenced `0002` migration file exists, no Wrangler config is committed, and the README no longer references `d1 migrations apply`. No UI surface is involved (workflow/CLI/docs change), so evidence is a CLI transcript rather than a screenshot. No failures or setup issues.

<details>
<summary>Evidence: Preflight gate decision (configless conditional migration) — CLI transcript</summary>

<code>=== LEGACY table (no AUTOINCREMENT) -- what run 30072274592 hit ===&#10;preflight exit code: 0&#10;GITHUB_OUTPUT emitted:&#10;migration_safe=true&#10;migration_required=true&#10;migration_status=required&#10;=&gt; step gated by if: migration_required==&#39;true&#39; : RUNS d1 execute --file=0002_round_telemetry_autoincrement.sql&#10;&#10;=== ALREADY-MIGRATED table (AUTOINCREMENT present) ===&#10;preflight exit code: 0&#10;GITHUB_OUTPUT emitted:&#10;migration_safe=true&#10;migration_required=false&#10;migration_status=already-applied&#10;=&gt; step gated by if: migration_required==&#39;true&#39; : SKIPPED</code>

```text
=== LEGACY table (no AUTOINCREMENT) -- what run 30072274592 hit ===
  preflight exit code: 0
  GITHUB_OUTPUT emitted:
    migration_safe=true
    migration_required=true
    migration_status=required
  => step gated by if: migration_required=='true' : RUNS d1 execute --file=0002_round_telemetry_autoincrement.sql

=== ALREADY-MIGRATED table (AUTOINCREMENT present) ===
  preflight exit code: 0
  GITHUB_OUTPUT emitted:
    migration_safe=true
    migration_required=false
    migration_status=already-applied
  => step gated by if: migration_required=='true' : SKIPPED
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run python -m pytest data/test_telemetry_retention.py -v` — 16 tests + 21 subtests pass, incl. the new `test_workflow_executes_upgrade_without_a_wrangler_config`</code>
- <code>Drove `data/telemetry_retention.py preflight` (as the workflow&#39;s retention_preflight step does) against a legacy no-AUTOINCREMENT schema → `migration_required=true` (gate RUNS the configless 0002 d1 execute), and an already-migrated schema → `migration_required=false` (gate SKIPPED) — CLI transcript captured</code>
- <code>Confirmed `web/migrations/0002_round_telemetry_autoincrement.sql` exists and is the file the workflow references</code>
- <code>Confirmed no committed Wrangler config under `web/` (`find web -iname &#39;wrangler.*&#39;` empty) and README has no stray `d1 migrations apply` references</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
