### PR TITLE
build(web): set pnpm pmOnFail=ignore for externally managed installs

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -36,8 +36,12 @@ for how the model data is generated.
 
 ### Prerequisites
 
-- Node.js 22 (pinned in `.node-version`) and pnpm 11.16
-  (pinned by `packageManager` in `package.json`)
+- Node.js 22 (pinned in `.node-version`) and pnpm 11
+
+CI and Corepack target the exact `packageManager` version in `package.json`.
+Locally, pnpm installation is left to Homebrew, Corepack, mise, or another
+external tool, so compatible pnpm 11 releases do not bootstrap a second CLI
+before running project commands.
 
 ### Installation
 

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -2,6 +2,11 @@
 # worktrees. pnpm automatically disables this optimization in CI.
 enableGlobalVirtualStore: true
 
+# Homebrew/Corepack and the CI setup action own pnpm installation. Do not make
+# an already-installed compatible pnpm bootstrap a second CLI before commands
+# such as `pnpm start` can run.
+pmOnFail: ignore
+
 # This package's /vitest entrypoint imports the app's Vitest instance without
 # declaring it. Make that peer explicit so ESM resolves it from the shared
 # virtual store instead of depending on npm-style flattening.


### PR DESCRIPTION
## Intent

Migrate this repository's web tooling from npm to pnpm so repeated installs, especially in no-mistakes worktrees, are faster and use less per-checkout disk space, while preserving all existing web and telemetry behavior. Follow up on the merged migration because plain 'make web' fails for a developer using Homebrew pnpm 11.17 when the manifest pins pnpm 11.16: pnpm's default pmOnFail=download attempts to bootstrap the older CLI and rejects its temporary package-manager lock metadata before Vite starts. Keep CI and Corepack's exact 11.16 target, but set the documented pmOnFail=ignore workspace behavior so externally managed compatible pnpm 11 installations run commands directly. Verify the exact Homebrew pnpm 11.17 'make web' path, frozen install, type-check, unit tests, Playwright e2e tests, and production build.

## What Changed

- Added `pmOnFail: ignore` to `web/pnpm-workspace.yaml` so an already-installed, compatible pnpm 11 (e.g. Homebrew pnpm 11.17) runs project commands directly instead of pnpm's default `pmOnFail=download` bootstrapping the pinned 11.16 CLI and rejecting its temporary package-manager lock metadata before Vite starts.
- Documented in `web/README.md` that pnpm installation is left to Homebrew, Corepack, mise, or another external tool, and that compatible pnpm 11 releases therefore do not bootstrap a second CLI before running project commands — while CI and Corepack still target the exact `packageManager` version.
- No change to the pinned `packageManager` version, lockfile, or any application/telemetry behavior; the fix is confined to local pnpm invocation. Verified via the Homebrew pnpm 11.17 `make web` path, frozen install, `pnpm typecheck`, `pnpm test` (137/137), `pnpm test:e2e` (35/35), and `pnpm build`.

## Risk Assessment

✅ Low: A two-file change adds a valid pnpm v11 `pmOnFail: ignore` setting (verified against pnpm docs) in the correct config location and updates docs, precisely matching the authoritative intent while leaving CI/Corepack's pinned 11.16 target and all functional code untouched.

## Testing

Ran the complete workspace-scoped verification for this web-tooling change using Homebrew pnpm 11.17.0 on Node 22.17.1 — the precise environment the intent targets. I first reproduced the breakage the fix addresses (forcing pnpm's default pmOnFail=download makes 11.17 reject the pinned 11.16 packageManager lock metadata), then confirmed the workspace's new pmOnFail=ignore makes pnpm run commands directly. From there make web brought up the Vite dev server (HTTP 200), the frozen install ran directly on 11.17, type-check was clean, 137 unit tests and 35 Playwright e2e tests passed, and the production build succeeded; I also captured a screenshot of the built app rendering. The packageManager pin and CI/Corepack targeting of exact 11.16 remain intact. All green; transient build artifacts are gitignored and the worktree is clean.

<details>
<summary>Evidence: Fix vs pre-fix pmOnFail behavior (Homebrew pnpm 11.17)</summary>

```text
WITH fix (pmOnFail: ignore): pnpm exec vite --version -> vite/8.1.4 darwin-arm64 node-v22.17.1
FORCING pre-fix default (--config.pmOnFail=download): [ERROR] The packageManager dependency "pnpm@11.16.0" in pnpm-lock.yaml must use a registry package path and an integrity-only resolution
```
</details>
<details>
<summary>Evidence: make web -&gt; Vite dev server</summary>

```text
cd web && pnpm start
$ vite
VITE v8.1.4 ready in 93 ms
➜ Local: http://localhost:3000/
curl http://localhost:3000/ -> HTTP 200, 1396 bytes (index.html)
```
</details>
- Evidence: Served production app (screenshot) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY9N820KSKY3QTDJJ71FM8A7/app-served.png</code>)
<details>
<summary>Evidence: make web log</summary>

```text
cd web && pnpm start
$ vite

  VITE v8.1.4  ready in 93 ms

  ➜  Local:   http://localhost:3000/
  ➜  Network: use --host to expose
make: *** [web] Terminated: 15
[ELIFECYCLE] Command failed with exit code 143.
```
</details>
<details>
<summary>Evidence: Unit + e2e + build results</summary>

```text
typecheck: clean
vitest: 137 passed (137)
vite build: built in 162ms (build/index.html + assets)
playwright: 35 passed (20.5s)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Env confirmed: `/opt/homebrew/bin/pnpm --version` = 11.17.0, `node --version` = v22.17.1, packageManager pinned to pnpm@11.16.0</code>
- <code>Fix demo (fixed state): `pnpm exec vite --version` -&gt; vite/8.1.4 runs directly</code>
- <code>Fix demo (pre-fix default): `pnpm --config.pmOnFail=download exec vite --version` -&gt; ERROR rejecting packageManager pnpm@11.16.0 lock resolution</code>
- <code>`pnpm install --frozen-lockfile` — ran directly on pnpm v11.17.0</code>
- <code>`make web` -&gt; `cd web &amp;&amp; pnpm start` -&gt; Vite dev server on http://localhost:3000/, curl returned HTTP 200</code>
- <code>`pnpm typecheck` — clean</code>
- <code>`pnpm test` — 137/137 Vitest pass</code>
- <code>`pnpm build` — production build succeeded</code>
- <code>`pnpm test:e2e` — 35/35 Playwright pass</code>
- `Playwright screenshot of the served production build rendering the app`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
