### PR TITLE
feat(web): add season selector gating support hero and skill availability

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -10,7 +10,7 @@ for how the model data is generated.
 
 ## Features
 
-- **Setup Phase**: Select starting heroes and skills with pinyin search support
+- **Setup Phase**: Select starting heroes and skills with pinyin search support, and pick the current season (defaults to the latest available; the season only limits support hero/skill availability, not initial setup or round inputs)
 - **Game Flow**: Round-by-round draft with recommendations for optimal team building (see [GAME_RULE.md](../GAME_RULE.md))
 - **Manual Editing**: Edit team composition manually at any time
 - **Analytics Dashboard**: Player-friendly, question-led analytics — hero/skill rankings by 胜率参考 (smoothed win rate, with 参考场次 as supporting context), 组合分 synergy tables, usage, and optional (collapsed) model diagnostics
@@ -201,6 +201,11 @@ Game progress is automatically saved to cookies with a 1-year expiry:
 - Current game state
 - Round inputs
 - Automatically restored on page load
+
+The selected season is persisted in its own `selectedSeason` cookie, kept
+separate from game progress so it survives a game reset; when the cookie is
+missing, malformed, or out of range it falls back to the latest available
+season.
 
 Anonymous telemetry uses a capped `localStorage` retry queue and a tab-owned
 per-game session ID. Its aggregate data contract and retention workflow are

--- a/web/src/components/game/CurrentTeam.tsx
+++ b/web/src/components/game/CurrentTeam.tsx
@@ -164,7 +164,11 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
   };
 
   return (
-    <Paper sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
+    <Paper
+      component="section"
+      aria-label="当前阵容"
+      sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, borderTop: '3px solid', borderTopColor: 'text.primary' }}
+    >
       <Box sx={{ mb: 2 }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 2, flexWrap: 'wrap' }}>
           <Box sx={{ minWidth: 0 }}>
@@ -221,42 +225,46 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
           )}
         </Box>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mt: 1.5 }}>
-          {heroes.length <= 10 && !hasSupportHero && (
-            <Button
-              size="small"
-              variant="outlined"
-              color="primary"
-              startIcon={<AutoAwesomeIcon />}
-              onClick={handleRecommendHero}
-              disabled={!availableHeroes || availableHeroes.length === 0}
-            >
-              推荐自选武将
-            </Button>
-          )}
-          {skills.length <= 20 && !hasSupportSkills && (
-            <Button
-              size="small"
-              variant="outlined"
-              color="secondary"
-              startIcon={<AutoAwesomeIcon />}
-              onClick={handleRecommendSkills}
-              disabled={!availableSkills || availableSkills.length === 0}
-            >
-              推荐自选战法
-            </Button>
-          )}
-        </Box>
+        {editable && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mt: 1.5 }}>
+            {heroes.length <= 10 && !hasSupportHero && (
+              <Button
+                size="small"
+                variant="outlined"
+                color="primary"
+                startIcon={<AutoAwesomeIcon />}
+                onClick={handleRecommendHero}
+                disabled={!availableHeroes || availableHeroes.length === 0}
+              >
+                推荐支援武将
+              </Button>
+            )}
+            {skills.length <= 20 && !hasSupportSkills && (
+              <Button
+                size="small"
+                variant="outlined"
+                color="secondary"
+                startIcon={<AutoAwesomeIcon />}
+                onClick={handleRecommendSkills}
+                disabled={!availableSkills || availableSkills.length === 0}
+              >
+                推荐支援战法
+              </Button>
+            )}
+          </Box>
+        )}
 
-        <Alert
-          severity="info"
-          variant="outlined"
-          sx={{ mt: 1.25, py: 0.5, alignItems: 'center' }}
-        >
-          <Typography variant="body2" fontWeight={600}>
-            提示：建议先确认核心武将，再围绕核心挑选其余武将与战法。请尽早确认自选武将，AI 才能据此给出更精准的推荐。
-          </Typography>
-        </Alert>
+        {editable && (!hasSupportHero || !hasSupportSkills) && (
+          <Alert
+            severity="info"
+            variant="outlined"
+            sx={{ mt: 1.25, py: 0.5, alignItems: 'center' }}
+          >
+            <Typography variant="body2" fontWeight={600}>
+              提示：建议先确认核心武将，再围绕核心挑选其余武将与战法。请尽早确认支援选择，AI 才能据此给出更精准的推荐。
+            </Typography>
+          </Alert>
+        )}
       </Box>
       
       <Collapse in={editMode}>
@@ -286,7 +294,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
                 onRemove={handleRemoveHero}
                 color="primary"
                 highlightItems={supportHero ? [supportHero] : []}
-                onRemoveHighlight={handleRemoveSupportHero}
+                onRemoveHighlight={editable ? handleRemoveSupportHero : undefined}
                 heroMetadata={heroMetadata}
               />
             </>
@@ -296,7 +304,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
               color="primary" 
               editable={false}
               highlightItems={supportHero ? [supportHero] : []}
-              onRemoveHighlight={handleRemoveSupportHero}
+              onRemoveHighlight={editable ? handleRemoveSupportHero : undefined}
               heroMetadata={heroMetadata}
             />
           )}
@@ -322,7 +330,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
                 onRemove={handleRemoveSkill}
                 color="secondary"
                 highlightItems={supportSkills || []}
-                onRemoveHighlight={handleRemoveSupportSkill}
+                onRemoveHighlight={editable ? handleRemoveSupportSkill : undefined}
                 skillMetadata={skillMetadata}
               />
             </>
@@ -332,7 +340,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
               color="secondary" 
               editable={false}
               highlightItems={supportSkills || []}
-              onRemoveHighlight={handleRemoveSupportSkill}
+              onRemoveHighlight={editable ? handleRemoveSupportSkill : undefined}
               skillMetadata={skillMetadata}
             />
           )}
@@ -340,7 +348,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
       </Grid>
 
       {/* Hero Recommendation Dialog */}
-      <Dialog open={heroRecDialog} onClose={() => setHeroRecDialog(false)} maxWidth="sm" fullWidth>
+      <Dialog open={editable && heroRecDialog} onClose={() => setHeroRecDialog(false)} maxWidth="sm" fullWidth>
         <DialogTitle>推荐支援武将</DialogTitle>
         <DialogContent>
           <Box sx={{ mb: 2 }}>
@@ -420,7 +428,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
       </Dialog>
 
       {/* Skill Recommendation Dialog */}
-      <Dialog open={skillRecDialog} onClose={() => setSkillRecDialog(false)} maxWidth="sm" fullWidth>
+      <Dialog open={editable && skillRecDialog} onClose={() => setSkillRecDialog(false)} maxWidth="sm" fullWidth>
         <DialogTitle>推荐支援战法</DialogTitle>
         <DialogContent>
           <Box sx={{ mb: 2 }}>

--- a/web/src/components/game/CurrentTeam.tsx
+++ b/web/src/components/game/CurrentTeam.tsx
@@ -37,7 +37,10 @@ interface CurrentTeamProps {
 const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, skillMetadata = null, availableSkills, onUpdateTeam, editable = true, supportHero = null, supportSkills = [] }: CurrentTeamProps) => {
   // Support-team actions dispatch straight to the shared game state instead of
   // requiring every parent to thread `dispatch` down as a prop.
-  const { dispatch } = useGame();
+  const { state, dispatch } = useGame();
+  const { selectedSeason } = state;
+  const seasonHeroMetadata = heroMetadata ?? state.heroMetadata;
+  const seasonSkillMetadata = skillMetadata ?? state.skillMetadata;
   const [editMode, setEditMode] = useState(false);
   const [editedHeroes, setEditedHeroes] = useState<string[]>(heroes);
   const [editedSkills, setEditedSkills] = useState<string[]>(skills);
@@ -50,6 +53,14 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
 
   const hasSupportHero = !!supportHero;
   const hasSupportSkills = (supportSkills || []).length >= 2;
+  const isAvailableInSelectedSeason = (season: number | undefined) =>
+    selectedSeason === null || season === undefined || season <= selectedSeason;
+  const supportAvailableHeroes = (availableHeroes || []).filter((hero) =>
+    isAvailableInSelectedSeason(seasonHeroMetadata[hero]?.season)
+  );
+  const supportAvailableSkills = (availableSkills || []).filter((skill) =>
+    isAvailableInSelectedSeason(seasonSkillMetadata[skill]?.season)
+  );
 
   // Current-roster score (display units, one decimal) for the whole pool —
   // main heroes/skills plus any support hero/skills. Uses the same paired-model
@@ -101,7 +112,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
   const handleRecommendHero = () => {
     const allHeroesForRec = [...heroes, ...(supportHero ? [supportHero] : [])];
     const allSkillsForRec = [...skills, ...(supportSkills || [])];
-    const unchosenHeroes = (availableHeroes || []).filter(h => !allHeroesForRec.includes(h));
+    const unchosenHeroes = supportAvailableHeroes.filter(h => !allHeroesForRec.includes(h));
     const result = recommendSingleHero(
       unchosenHeroes,
       allHeroesForRec,
@@ -117,7 +128,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
   const handleRecommendSkills = () => {
     const allHeroesForRec = [...heroes, ...(supportHero ? [supportHero] : [])];
     const allSkillsForRec = [...skills, ...(supportSkills || [])];
-    const unchosenSkills = (availableSkills || []).filter(s => !allSkillsForRec.includes(s));
+    const unchosenSkills = supportAvailableSkills.filter(s => !allSkillsForRec.includes(s));
     const result = recommendTwoSkills(unchosenSkills, allHeroesForRec, allSkillsForRec, recommendationData);
     setSkillRecResult(result);
     setSelectedRecSkills(result.skills ? [...result.skills] : []);
@@ -155,10 +166,10 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
   return (
     <Paper sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
       <Box sx={{ mb: 2 }}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 2, flexWrap: 'wrap' }}>
           <Box sx={{ minWidth: 0 }}>
             <Typography variant="overline" color="error.main" sx={{ display: 'block', lineHeight: 1.2 }}>CURRENT ROSTER</Typography>
-            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, flexWrap: 'nowrap', minWidth: 0 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', columnGap: 1, rowGap: 0.5, flexWrap: 'wrap', minWidth: 0 }}>
               <Typography
                 component="h2"
                 variant="h5"
@@ -166,6 +177,15 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
               >
                 当前阵容
               </Typography>
+              {selectedSeason !== null && (
+                <Chip
+                  label={`赛季 ${selectedSeason}`}
+                  size="small"
+                  variant="outlined"
+                  color="primary"
+                  data-testid="current-season-chip"
+                />
+              )}
               <Typography
                 component="span"
                 variant="subtitle1"
@@ -328,7 +348,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
               手动搜索武将：
             </Typography>
             <AutocompleteInput
-              items={(availableHeroes || []).filter(h => !heroes.includes(h) && h !== supportHero)}
+              items={supportAvailableHeroes.filter(h => !heroes.includes(h) && h !== supportHero)}
               selectedItems={selectedRecHero ? [selectedRecHero] : []}
               onAdd={(hero) => setSelectedRecHero(hero)}
               label="搜索武将..."
@@ -408,7 +428,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
               手动搜索战法（最多选2个）：
             </Typography>
             <AutocompleteInput
-              items={(availableSkills || []).filter(s => !skills.includes(s) && !(supportSkills || []).includes(s) && !selectedRecSkills.includes(s))}
+              items={supportAvailableSkills.filter(s => !skills.includes(s) && !(supportSkills || []).includes(s) && !selectedRecSkills.includes(s))}
               selectedItems={selectedRecSkills}
               onAdd={(skill) => {
                 if (selectedRecSkills.length < 2 && !selectedRecSkills.includes(skill)) {

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -73,9 +73,25 @@ const GameBoard = () => {
           <RoundInfo roundNumber={7} />
           <Paper sx={{ p: 3, mb: 3, textAlign: "center" }}>
             <Typography variant="overline" color="error.main">州内小组赛</Typography>
-            <Typography component="h2" variant="h4" gutterBottom sx={{ mb: 3 }}>
+            <Typography component="h2" variant="h4" gutterBottom sx={{ mb: { xs: 0, md: 3 } }}>
               整军再战
             </Typography>
+            <Button
+              variant="contained"
+              color="primary"
+              size="large"
+              fullWidth
+              sx={{
+                display: { xs: "flex", md: "none" },
+                mt: 2,
+                mb: 3,
+                maxWidth: 360,
+                mx: "auto",
+              }}
+              onClick={() => dispatch({ type: "DISMISS_ROUND7_INTERSTITIAL" })}
+            >
+              我赢了，进入下一轮
+            </Button>
             <CurrentTeam
               heroes={gameState.current_heroes}
               skills={gameState.current_skills}
@@ -93,7 +109,12 @@ const GameBoard = () => {
               color="primary"
               size="large"
               fullWidth
-              sx={{ mt: 3, maxWidth: 360, mx: "auto", display: "block" }}
+              sx={{
+                display: { xs: "none", md: "flex" },
+                mt: 3,
+                maxWidth: 360,
+                mx: "auto",
+              }}
               onClick={() => dispatch({ type: "DISMISS_ROUND7_INTERSTITIAL" })}
             >
               我赢了，进入下一轮
@@ -110,8 +131,9 @@ const GameBoard = () => {
       <Container maxWidth="xl" disableGutters>
         <Box>
           <Alert severity="success" sx={{ mb: 3 }}>
-            <strong>对局完成</strong>
-            <br />
+            <Typography component="h1" variant="h4" gutterBottom>
+              对局完成
+            </Typography>
             你已完成全部 8 轮。可查看最终队伍配置。
           </Alert>
 

--- a/web/src/components/setup/SetupForm.tsx
+++ b/web/src/components/setup/SetupForm.tsx
@@ -105,11 +105,8 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
         <Typography component="h1" variant="h4" gutterBottom>
           录入当前阵容
         </Typography>
-        <Typography variant="body1" color="text.secondary" paragraph>
-          输入初始 4 个武将和 8 个战法以开始对局。
-        </Typography>
 
-        <FormControl size="small" sx={{ width: { xs: '100%', sm: 160 }, mb: 3 }}>
+        <FormControl size="small" sx={{ width: { xs: '100%', sm: 160 }, mb: 1 }}>
           <InputLabel id="season-select-label">当前赛季</InputLabel>
           <Select
             labelId="season-select-label"
@@ -126,6 +123,9 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
             ))}
           </Select>
         </FormControl>
+        <Typography variant="body1" color="text.secondary" paragraph>
+          输入初始 4 个武将和 8 个战法以开始对局。
+        </Typography>
 
         {error && (
           <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>

--- a/web/src/components/setup/SetupForm.tsx
+++ b/web/src/components/setup/SetupForm.tsx
@@ -1,5 +1,17 @@
 import { useState } from 'react';
-import { Card, CardContent, Typography, Button, Box, Alert, CircularProgress } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material';
 import AutocompleteInput from '../common/AutocompleteInput';
 import TagList from '../common/TagList';
 import { useGame } from '../../context/GameContext';
@@ -16,7 +28,16 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
   const [error, setError] = useState<string | null>(null);
   const { state, dispatch } = useGame();
   
-  const { availableHeroes, heroMetadata, availableSkills, skillMetadata, heroSkills, databaseLoaded } = state;
+  const {
+    availableHeroes,
+    heroMetadata,
+    availableSkills,
+    skillMetadata,
+    heroSkills,
+    databaseLoaded,
+    maxSeason,
+    selectedSeason,
+  } = state;
 
   // Hero skills already selected count
   const heroSkillSet = new Set(heroSkills);
@@ -87,6 +108,24 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
         <Typography variant="body1" color="text.secondary" paragraph>
           输入初始 4 个武将和 8 个战法以开始对局。
         </Typography>
+
+        <FormControl size="small" sx={{ width: { xs: '100%', sm: 160 }, mb: 3 }}>
+          <InputLabel id="season-select-label">当前赛季</InputLabel>
+          <Select
+            labelId="season-select-label"
+            id="season-select"
+            data-testid="season-select"
+            value={selectedSeason ?? ''}
+            label="当前赛季"
+            onChange={(event) => dispatch({ type: 'SET_SEASON', season: Number(event.target.value) })}
+          >
+            {Array.from({ length: maxSeason }, (_, index) => index + 1).map((season) => (
+              <MenuItem key={season} value={season}>
+                赛季 {season}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
 
         {error && (
           <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>

--- a/web/src/context/GameContext.tsx
+++ b/web/src/context/GameContext.tsx
@@ -30,6 +30,8 @@ export const initialState: ReducerState = {
   regularSkills: [],
   orangeRegularSkills: [],
   heroSkills: [],
+  maxSeason: 1,
+  selectedSeason: 1,
   databaseLoaded: false,
 };
 
@@ -80,6 +82,17 @@ export const gameReducer = (state: ReducerState, action: GameAction): ReducerSta
         selectedOptionIndex: action.index,
       };
 
+    case 'SET_SEASON':
+      return {
+        ...state,
+        selectedSeason:
+          Number.isInteger(action.season) &&
+          action.season >= 1 &&
+          action.season <= state.maxSeason
+            ? action.season
+            : state.maxSeason,
+      };
+
     case 'RECORD_CHOICE': {
       const { roundType, chosenSet, setIndex } = action;
       const result = updateGameState(state.gameState!, roundType, chosenSet, setIndex);
@@ -105,6 +118,8 @@ export const gameReducer = (state: ReducerState, action: GameAction): ReducerSta
         regularSkills: state.regularSkills,
         orangeRegularSkills: state.orangeRegularSkills,
         heroSkills: state.heroSkills,
+        maxSeason: state.maxSeason,
+        selectedSeason: state.selectedSeason,
         databaseLoaded: state.databaseLoaded,
       };
 
@@ -115,7 +130,18 @@ export const gameReducer = (state: ReducerState, action: GameAction): ReducerSta
         isLoading: false,
       };
 
-    case 'LOAD_DATABASE':
+    case 'LOAD_DATABASE': {
+      const maxSeason =
+        Number.isInteger(action.maxSeason) && action.maxSeason! >= 1
+          ? action.maxSeason!
+          : state.maxSeason;
+      const selectedSeason =
+        Number.isInteger(action.selectedSeason) &&
+        action.selectedSeason! >= 1 &&
+        action.selectedSeason! <= maxSeason
+          ? action.selectedSeason!
+          : maxSeason;
+
       return {
         ...state,
         availableHeroes: action.heroes,
@@ -125,8 +151,11 @@ export const gameReducer = (state: ReducerState, action: GameAction): ReducerSta
         regularSkills: action.regularSkills || [],
         orangeRegularSkills: action.orangeRegularSkills || [],
         heroSkills: action.heroSkills || [],
+        maxSeason,
+        selectedSeason,
         databaseLoaded: true,
       };
+    }
 
     case 'DISMISS_ROUND7_INTERSTITIAL':
       return {
@@ -221,6 +250,16 @@ export const GameProvider = ({ children, databaseItems }: GameProviderProps) => 
   // Load database items from props (passed from index.tsx)
   useEffect(() => {
     if (databaseItems) {
+      const maxSeason =
+        Number.isInteger(databaseItems.maxSeason) && databaseItems.maxSeason >= 1
+          ? databaseItems.maxSeason
+          : 1;
+      const storedSeason = storage.loadSelectedSeason();
+      const selectedSeason =
+        storedSeason !== null && storedSeason <= maxSeason
+          ? storedSeason
+          : maxSeason;
+
       dispatch({
         type: 'LOAD_DATABASE',
         heroes: databaseItems.heroes || [],
@@ -230,9 +269,18 @@ export const GameProvider = ({ children, databaseItems }: GameProviderProps) => 
         regularSkills: databaseItems.regularSkills || [],
         orangeRegularSkills: databaseItems.orangeRegularSkills || [],
         heroSkills: databaseItems.heroSkills || [],
+        maxSeason,
+        selectedSeason,
       });
     }
   }, [databaseItems]);
+
+  // Keep season preference separate from resettable in-progress game data.
+  useEffect(() => {
+    if (state.databaseLoaded) {
+      storage.saveSelectedSeason(state.selectedSeason);
+    }
+  }, [state.databaseLoaded, state.selectedSeason]);
 
   // Auto-save game progress to cookies whenever it changes
   useEffect(() => {

--- a/web/src/context/__tests__/GameProvider.test.tsx
+++ b/web/src/context/__tests__/GameProvider.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Cookies from 'js-cookie';
+import type { DatabaseItems } from '../../types/game';
+import { storage } from '../../utils/storage';
+import { GameProvider, useGame } from '../GameContext';
+
+vi.mock('../../services/telemetry', () => ({
+  initializeTelemetry: vi.fn(),
+}));
+
+vi.mock('../../services/telemetryData', () => ({
+  preloadTelemetryData: vi.fn(),
+}));
+
+const makeDatabaseItems = (maxSeason: number): DatabaseItems => ({
+  heroes: ['旧武将', '新武将'],
+  heroMetadata: {
+    旧武将: { season: 1 },
+    新武将: { season: maxSeason },
+  },
+  skills: ['旧战法', '新战法'],
+  skillMetadata: {
+    旧战法: { season: 1 },
+    新战法: { season: maxSeason },
+  },
+  regularSkills: ['旧战法', '新战法'],
+  orangeRegularSkills: ['旧战法', '新战法'],
+  heroSkills: [],
+  maxSeason,
+});
+
+const StateProbe = () => {
+  const { state, dispatch } = useGame();
+  return (
+    <>
+      <output data-testid="season-state">
+        {state.databaseLoaded
+          ? `${state.maxSeason}:${state.selectedSeason}`
+          : 'loading'}
+      </output>
+      <button type="button" onClick={() => dispatch({ type: 'SET_SEASON', season: 7 })}>
+        select seven
+      </button>
+      <button type="button" onClick={() => dispatch({ type: 'RESET_GAME' })}>
+        reset
+      </button>
+    </>
+  );
+};
+
+const renderProvider = (databaseItems: DatabaseItems) =>
+  render(
+    <GameProvider databaseItems={databaseItems}>
+      <StateProbe />
+    </GameProvider>
+  );
+
+describe('GameProvider season persistence', () => {
+  beforeEach(() => {
+    Cookies.remove('gameProgress', { path: '/' });
+    Cookies.remove('selectedSeason', { path: '/' });
+  });
+
+  afterEach(() => {
+    Cookies.remove('gameProgress', { path: '/' });
+    Cookies.remove('selectedSeason', { path: '/' });
+  });
+
+  test.each([
+    ['missing', null],
+    ['malformed', 'not-a-season'],
+    ['out of range', '17'],
+  ])('falls back to the latest season when the saved value is %s', async (_label, value) => {
+    if (value !== null) Cookies.set('selectedSeason', value, { path: '/' });
+
+    renderProvider(makeDatabaseItems(16));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('season-state')).toHaveTextContent('16:16');
+      expect(Cookies.get('selectedSeason')).toBe('16');
+    });
+  });
+
+  test('preserves a valid lower season when the catalog maximum increases', async () => {
+    storage.saveSelectedSeason(5);
+    const view = renderProvider(makeDatabaseItems(12));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('season-state')).toHaveTextContent('12:5');
+    });
+
+    view.rerender(
+      <GameProvider databaseItems={makeDatabaseItems(16)}>
+        <StateProbe />
+      </GameProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('season-state')).toHaveTextContent('16:5');
+      expect(Cookies.get('selectedSeason')).toBe('5');
+    });
+  });
+
+  test('saves a changed season and RESET_GAME preserves it', async () => {
+    storage.saveSelectedSeason(5);
+    renderProvider(makeDatabaseItems(16));
+    await waitFor(() => {
+      expect(screen.getByTestId('season-state')).toHaveTextContent('16:5');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'select seven' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('season-state')).toHaveTextContent('16:7');
+      expect(Cookies.get('selectedSeason')).toBe('7');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'reset' }));
+    expect(screen.getByTestId('season-state')).toHaveTextContent('16:7');
+    expect(Cookies.get('selectedSeason')).toBe('7');
+  });
+});

--- a/web/src/context/__tests__/gameReducer.test.ts
+++ b/web/src/context/__tests__/gameReducer.test.ts
@@ -101,8 +101,41 @@ describe('gameReducer', () => {
       type: 'LOAD_DATABASE',
       heroes: ['孙权'],
       skills: ['skillA'],
+      maxSeason: 16,
+      selectedSeason: 5,
     });
     expect(next.databaseLoaded).toBe(true);
     expect(next.availableHeroes).toEqual(['孙权']);
+    expect(next.maxSeason).toBe(16);
+    expect(next.selectedSeason).toBe(5);
+  });
+
+  test('SET_SEASON updates a valid season and falls back to latest for invalid values', () => {
+    const state = {
+      ...initialState,
+      maxSeason: 16,
+      selectedSeason: 5,
+    };
+
+    expect(gameReducer(state, { type: 'SET_SEASON', season: 9 }).selectedSeason).toBe(9);
+    expect(gameReducer(state, { type: 'SET_SEASON', season: 17 }).selectedSeason).toBe(16);
+    expect(gameReducer(state, { type: 'SET_SEASON', season: 1.5 }).selectedSeason).toBe(16);
+  });
+
+  test('RESET_GAME preserves database and season state', () => {
+    const next = gameReducer({
+      ...initialState,
+      availableHeroes: ['孙权'],
+      maxSeason: 16,
+      selectedSeason: 5,
+      databaseLoaded: true,
+    }, {
+      type: 'RESET_GAME',
+    });
+
+    expect(next.availableHeroes).toEqual(['孙权']);
+    expect(next.maxSeason).toBe(16);
+    expect(next.selectedSeason).toBe(5);
+    expect(next.databaseLoaded).toBe(true);
   });
 });

--- a/web/src/services/__tests__/api.test.ts
+++ b/web/src/services/__tests__/api.test.ts
@@ -2,6 +2,29 @@ import { database } from '../../data';
 import { api } from '../api';
 import { clearTelemetryDataCacheForTests } from '../telemetryData';
 
+describe('database items', () => {
+  test('keeps full catalogs and exposes season metadata with a combined maximum', async () => {
+    const items = await api.getDatabaseItems();
+    const heroNames = Object.keys(database.heroes);
+    const skillNames = Object.keys(database.skills);
+    const expectedMaxSeason = Math.max(
+      ...Object.values(database.heroes).map((hero) => hero.season),
+      ...Object.values(database.skills).map((skill) => skill.season)
+    );
+
+    expect(new Set(items.heroes)).toEqual(new Set(heroNames));
+    expect(new Set(items.skills)).toEqual(new Set(skillNames));
+    expect(items.maxSeason).toBe(expectedMaxSeason);
+
+    for (const name of heroNames) {
+      expect(items.heroMetadata[name]?.season).toBe(database.heroes[name].season);
+    }
+    for (const name of skillNames) {
+      expect(items.skillMetadata[name]?.season).toBe(database.skills[name].season);
+    }
+  });
+});
+
 describe('recommendation telemetry isolation', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -46,6 +46,7 @@ export const api = {
       heroEntries.map(([name, hero]) => [name, {
         label: hero.label,
         rank: hero.rank,
+        season: hero.season,
       }])
     );
 
@@ -66,6 +67,7 @@ export const api = {
       allSkillEntries.map(([name, skill]) => [name, {
         tier: skill.tier,
         note: skill.note,
+        season: skill.season,
       }])
     );
     const regularSkills = allSkillEntries
@@ -77,6 +79,13 @@ export const api = {
       .sort(compareSkills)
       .map(([name]) => name);
     const allSkills = [...new Set([...regularSkills, ...heroSkills])].sort((a, b) => compareSkills([a, database.skills?.[a] || {}], [b, database.skills?.[b] || {}]));
+    const maxSeason = [...heroEntries, ...allSkillEntries].reduce(
+      (latest, [, item]) =>
+        Number.isInteger(item.season) && item.season >= 1
+          ? Math.max(latest, item.season)
+          : latest,
+      1
+    );
 
     return {
       heroes,
@@ -86,6 +95,7 @@ export const api = {
       regularSkills,
       orangeRegularSkills,
       heroSkills,
+      maxSeason,
     };
   },
 

--- a/web/src/types/domain.ts
+++ b/web/src/types/domain.ts
@@ -16,6 +16,8 @@ export interface Hero {
   camp: string;
   troop: string;
   stats: HeroStats;
+  /** First season in which the hero is available. */
+  season: number;
   label?: string;
   rank?: number;
 }
@@ -28,6 +30,8 @@ export interface Skill {
   type: SkillType;
   prob: number;
   desc: string;
+  /** First season in which the skill is available. */
+  season: number;
   tier?: string;
   note?: string;
   /** Optional numeric estimate fields, e.g. `damageEstimate`, `critEstimate`. */

--- a/web/src/types/game.ts
+++ b/web/src/types/game.ts
@@ -32,10 +32,12 @@ export interface GameState {
 export interface HeroMeta {
   label?: string;
   rank?: number;
+  season?: number;
 }
 export interface SkillMeta {
   tier?: string;
   note?: string;
+  season?: number;
 }
 
 /** Database items loaded into state (also the shape api.getDatabaseItems returns). */
@@ -47,6 +49,8 @@ export interface DatabaseItems {
   regularSkills: string[];
   orangeRegularSkills: string[];
   heroSkills: string[];
+  /** Latest season represented by either the hero or skill catalog. */
+  maxSeason: number;
 }
 
 /**
@@ -77,6 +81,8 @@ export interface ReducerState {
   regularSkills: string[];
   orangeRegularSkills: string[];
   heroSkills: string[];
+  maxSeason: number;
+  selectedSeason: number;
   databaseLoaded: boolean;
   /** Set by RECORD_CHOICE; absent until the first choice is recorded. */
   gameComplete?: boolean;
@@ -88,6 +94,7 @@ export type GameAction =
   | { type: 'UPDATE_ROUND_INPUT'; setName: SetName; items: string[] }
   | { type: 'SET_RECOMMENDATION'; recommendation: Recommendation }
   | { type: 'SELECT_OPTION'; index: number }
+  | { type: 'SET_SEASON'; season: number }
   | { type: 'RECORD_CHOICE'; roundType: RoundType; chosenSet: string[]; setIndex: number }
   | { type: 'RESET_GAME' }
   | { type: 'SET_ERROR'; error: string }
@@ -100,6 +107,8 @@ export type GameAction =
       regularSkills?: string[];
       orangeRegularSkills?: string[];
       heroSkills?: string[];
+      maxSeason?: number;
+      selectedSeason?: number;
     }
   | { type: 'DISMISS_ROUND7_INTERSTITIAL' }
   | { type: 'UPDATE_TEAM'; heroes: string[]; skills: string[] }

--- a/web/src/utils/__tests__/storage.test.ts
+++ b/web/src/utils/__tests__/storage.test.ts
@@ -1,0 +1,56 @@
+import Cookies from 'js-cookie';
+import { storage } from '../storage';
+
+const emptyInputs = { set1: [], set2: [], set3: [] };
+const gameState = {
+  current_heroes: [],
+  current_skills: [],
+  support_hero: null,
+  support_skills: [],
+  round_number: 1,
+  round_history: [],
+};
+
+describe('storage season preference', () => {
+  beforeEach(() => {
+    Cookies.remove('gameProgress', { path: '/' });
+    Cookies.remove('selectedSeason', { path: '/' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Cookies.remove('gameProgress', { path: '/' });
+    Cookies.remove('selectedSeason', { path: '/' });
+  });
+
+  test('uses the same persistent cookie options as other saved state', () => {
+    const setCookie = vi.spyOn(Cookies, 'set');
+
+    storage.saveSelectedSeason(7);
+
+    expect(setCookie).toHaveBeenCalledWith('selectedSeason', '7', {
+      expires: 365,
+      path: '/',
+      sameSite: 'Lax',
+    });
+    expect(storage.loadSelectedSeason()).toBe(7);
+  });
+
+  test.each(['not-a-season', '0', '-1', '2.5'])(
+    'treats %s as an invalid saved season',
+    (value) => {
+      Cookies.set('selectedSeason', value, { path: '/' });
+      expect(storage.loadSelectedSeason()).toBeNull();
+    }
+  );
+
+  test('clearing game progress does not remove the season preference', () => {
+    storage.saveGameProgress(gameState, emptyInputs);
+    storage.saveSelectedSeason(5);
+
+    storage.clearGameProgress();
+
+    expect(storage.loadGameProgress()).toBeNull();
+    expect(storage.loadSelectedSeason()).toBe(5);
+  });
+});

--- a/web/src/utils/storage.ts
+++ b/web/src/utils/storage.ts
@@ -3,6 +3,7 @@ import type { CurrentRoundInputs, GameState } from '../types/game';
 
 const GAME_PROGRESS_KEY = 'gameProgress';
 const TEAM_BUILDER_KEY = 'teamBuilder';
+const SELECTED_SEASON_KEY = 'selectedSeason';
 
 const COOKIE_OPTS: Cookies.CookieAttributes = { expires: 365, path: '/', sameSite: 'Lax' };
 
@@ -31,6 +32,18 @@ export const storage = {
 
   clearGameProgress: (): void => {
     Cookies.remove(GAME_PROGRESS_KEY, { path: '/' });
+  },
+
+  saveSelectedSeason: (season: number): void => {
+    Cookies.set(SELECTED_SEASON_KEY, String(season), COOKIE_OPTS);
+  },
+
+  loadSelectedSeason: (): number | null => {
+    const data = Cookies.get(SELECTED_SEASON_KEY);
+    if (!data) return null;
+
+    const season = Number(data);
+    return Number.isInteger(season) && season >= 1 ? season : null;
   },
 
   /**

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -21,7 +21,49 @@ const lateRoundInputs = () => ({
   set3: heroesWithMeta.slice(13, 15),
 });
 
+const completedState = () => {
+  const rosterSkills = anySkills(19);
+
+  return {
+    ...makeGameState({
+      roundNumber: 9,
+      heroes: heroesWithMeta.slice(0, 9),
+      skills: rosterSkills.slice(0, 18),
+    }),
+    support_hero: heroesWithMeta[9],
+    // One support skill is a valid UI state and ensures read-only rendering,
+    // rather than a full-support conditional, is what hides coaching controls.
+    support_skills: rosterSkills.slice(18, 19),
+    round7_interstitial_dismissed: true,
+  };
+};
+
 test.describe('Accessibility and responsive layout', () => {
+  test('setup instructions render vertically below the season selector', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.context().clearCookies();
+    await page.goto('/');
+
+    const selector = page.getByRole('combobox', { name: '当前赛季' });
+    const instructions = page.getByText(
+      '输入初始 4 个武将和 8 个战法以开始对局。',
+      { exact: true },
+    );
+    await expect(selector).toBeVisible({ timeout: 30000 });
+    await expect(instructions).toBeVisible();
+
+    const [selectorBox, instructionsBox] = await Promise.all([
+      selector.boundingBox(),
+      instructions.boundingBox(),
+    ]);
+    expect(selectorBox).not.toBeNull();
+    expect(instructionsBox).not.toBeNull();
+    expect(
+      instructionsBox.y,
+      'setup instructions should start below the bottom of the season selector',
+    ).toBeGreaterThanOrEqual(selectorBox.y + selectorBox.height);
+  });
+
   test('each primary page exposes one level-one heading', async ({ page }) => {
     await page.context().clearCookies();
     await page.goto('/');
@@ -38,6 +80,76 @@ test.describe('Accessibility and responsive layout', () => {
 
     await page.goto('/build-a-team');
     await expect(page.getByRole('heading', { level: 1, name: '组队 / Build a Team' })).toBeVisible();
+  });
+
+  test('completed game has one h1 and keeps its support roster read-only', async ({ page }) => {
+    const gameState = completedState();
+    expect(gameState.support_hero).toBeTruthy();
+    expect(gameState.support_skills).toHaveLength(1);
+
+    await seedGame(page, gameState);
+
+    const levelOneHeadings = page.getByRole('heading', { level: 1 });
+    await expect(levelOneHeadings).toHaveCount(1);
+    await expect(levelOneHeadings).toHaveAccessibleName('对局完成');
+
+    const roster = page.getByRole('region', { name: '当前阵容' });
+    await expect(roster).toBeVisible();
+    await expect(
+      roster.getByText(`⭐支援 ${gameState.support_hero}`, { exact: true }),
+    ).toBeVisible();
+    await expect(
+      roster.getByText(`⭐支援 ${gameState.support_skills[0]}`, { exact: true }),
+    ).toBeVisible();
+
+    await expect(roster.getByTestId('CancelIcon')).toHaveCount(0);
+    await expect(
+      roster.getByRole('button', {
+        name: /^推荐(?:支援|自选)(?:武将|战法)$/,
+      }),
+    ).toHaveCount(0);
+    await expect(roster.getByRole('button', { name: '编辑队伍' })).toHaveCount(0);
+  });
+
+  test('support recommendation actions use support wording', async ({ page }) => {
+    await seedGame(page, lateRoundState(), lateRoundInputs());
+
+    const roster = page.getByRole('region', { name: '当前阵容' });
+    await expect(roster.getByRole('button', { name: '推荐支援武将' })).toBeVisible();
+    await expect(roster.getByRole('button', { name: '推荐支援战法' })).toBeVisible();
+    await expect(
+      roster.getByRole('button', { name: /^推荐自选(?:武将|战法)$/ }),
+    ).toHaveCount(0);
+  });
+
+  test('mobile round-7 interstitial puts its primary action before the roster', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await seedGame(
+      page,
+      {
+        ...lateRoundState(),
+        round7_interstitial_dismissed: false,
+      },
+      lateRoundInputs(),
+    );
+
+    const action = page.getByRole('button', { name: '我赢了，进入下一轮' });
+    const rosterMarker = page.getByText('CURRENT ROSTER', { exact: true });
+    await expect(action).toBeVisible();
+    await expect(rosterMarker).toBeVisible();
+
+    const [actionBox, rosterBox] = await Promise.all([
+      action.boundingBox(),
+      rosterMarker.boundingBox(),
+    ]);
+    expect(actionBox).not.toBeNull();
+    expect(rosterBox).not.toBeNull();
+    expect(
+      actionBox.y + actionBox.height,
+      'mobile primary action should end above the current-roster region',
+    ).toBeLessThanOrEqual(rosterBox.y);
   });
 
   test('mobile round progress uses a complete non-scrolling grid', async ({ page }) => {

--- a/web/tests/seasonSelection.spec.js
+++ b/web/tests/seasonSelection.spec.js
@@ -1,0 +1,156 @@
+const { test, expect } = require('@playwright/test');
+const database = require('../public/game-data/database.json');
+
+const heroEntries = Object.entries(database.heroes || {});
+const skillEntries = Object.entries(database.skills || {});
+const HERO_SKILL_SET = new Set(
+  heroEntries.map(([, hero]) => hero.skill).filter(Boolean)
+);
+const maxSeason = Math.max(
+  ...heroEntries.map(([, hero]) => hero.season),
+  ...skillEntries.map(([, skill]) => skill.season)
+);
+const olderSeason = maxSeason - 1;
+
+const futureHeroes = heroEntries
+  .filter(([, hero]) => hero.season > olderSeason)
+  .map(([name]) => name);
+const eligibleHeroes = heroEntries
+  .filter(([, hero]) => hero.season <= olderSeason)
+  .map(([name]) => name);
+const regularSkillEntries = skillEntries.filter(
+  ([name]) => !HERO_SKILL_SET.has(name)
+);
+const futureRegularSkills = regularSkillEntries
+  .filter(([, skill]) => skill.season > olderSeason)
+  .map(([name]) => name);
+const eligiblePurpleSkills = regularSkillEntries
+  .filter(
+    ([, skill]) =>
+      skill.season <= olderSeason && skill.color === 'purple'
+  )
+  .map(([name]) => name);
+const eligibleOrangeSkills = regularSkillEntries
+  .filter(
+    ([, skill]) =>
+      skill.season <= olderSeason && skill.color === 'orange'
+  )
+  .map(([name]) => name);
+
+const setupHeroes = [futureHeroes[0], ...eligibleHeroes.slice(0, 3)];
+const setupSkills = [
+  ...eligiblePurpleSkills.slice(0, 4),
+  ...eligibleOrangeSkills.slice(0, 3),
+  futureRegularSkills[0],
+];
+const futureRoundHero = futureHeroes.find(
+  (hero) => !setupHeroes.includes(hero)
+);
+const futureSupportSkill = futureRegularSkills.find(
+  (skill) => !setupSkills.includes(skill)
+);
+const eligibleSupportHero = eligibleHeroes.find(
+  (hero) => !setupHeroes.includes(hero)
+);
+const eligibleSupportSkill = eligibleOrangeSkills.find(
+  (skill) => !setupSkills.includes(skill)
+);
+
+async function chooseSeason(page, season) {
+  const selector = page.getByRole('combobox', { name: '当前赛季' });
+  await selector.click();
+  await page.getByRole('option', { name: `赛季 ${season}` }).click();
+  await expect(selector).toHaveText(`赛季 ${season}`);
+}
+
+async function selectSetupItems(page) {
+  for (const hero of setupHeroes) {
+    const input = page.getByLabel('输入武将名或拼音...');
+    await input.fill(hero);
+    await page.getByRole('option', { name: hero }).click();
+  }
+
+  for (const skill of setupSkills) {
+    const input = page.getByLabel('输入战法名或拼音...');
+    await input.fill(skill);
+    await page.getByRole('option', { name: skill }).click();
+  }
+}
+
+test.describe('Season selection', () => {
+  test('defaults to the latest database season and remembers changes', async ({
+    page,
+  }) => {
+    await page.context().clearCookies();
+    await page.goto('/');
+
+    const selector = page.getByRole('combobox', { name: '当前赛季' });
+    await expect(selector).toBeVisible({ timeout: 30000 });
+    await expect(selector).toHaveText(`赛季 ${maxSeason}`);
+
+    await chooseSeason(page, olderSeason);
+    await page.reload();
+    await expect(
+      page.getByRole('combobox', { name: '当前赛季' })
+    ).toHaveText(`赛季 ${olderSeason}`);
+  });
+
+  test('limits only support candidates while newer items remain enterable', async ({
+    page,
+  }) => {
+    expect(futureHeroes.length).toBeGreaterThanOrEqual(2);
+    expect(futureRegularSkills.length).toBeGreaterThanOrEqual(2);
+    expect(setupHeroes).toHaveLength(4);
+    expect(setupSkills).toHaveLength(8);
+    expect(futureRoundHero).toBeTruthy();
+    expect(futureSupportSkill).toBeTruthy();
+    expect(eligibleSupportHero).toBeTruthy();
+    expect(eligibleSupportSkill).toBeTruthy();
+
+    await page.context().clearCookies();
+    await page.goto('/');
+    await expect(
+      page.getByRole('combobox', { name: '当前赛季' })
+    ).toBeVisible({ timeout: 30000 });
+    await chooseSeason(page, olderSeason);
+
+    // A newer-season hero and skill remain valid initial-setup entries.
+    await selectSetupItems(page);
+    await page.getByRole('button', { name: '开始对局' }).click();
+
+    await expect(page.getByText(`赛季 ${olderSeason}`, { exact: true })).toBeVisible();
+    await expect(page.getByText('第 1 轮：选择武将')).toBeVisible();
+
+    // Newer-season heroes also remain valid offered-set entries.
+    const roundInput = page.getByLabel('添加武将...').first();
+    await roundInput.fill(futureRoundHero);
+    await expect(
+      page.getByRole('option', { name: futureRoundHero })
+    ).toBeVisible();
+    await page.getByRole('option', { name: futureRoundHero }).click();
+
+    // The same newer-season hero is absent from both support recommendation
+    // results and manual support search, while an eligible hero remains.
+    await page.getByRole('button', { name: '推荐自选武将' }).click();
+    const heroDialog = page.getByRole('dialog');
+    await expect(heroDialog).toContainText(eligibleSupportHero);
+    await expect(
+      heroDialog.getByText(futureRoundHero, { exact: true })
+    ).toHaveCount(0);
+    const heroSearch = heroDialog.getByLabel('搜索武将...');
+    await heroSearch.fill(futureRoundHero);
+    await expect(page.getByText('无匹配结果')).toBeVisible();
+    await heroDialog.getByRole('button', { name: '关闭' }).click();
+
+    // Support skills use the same season boundary.
+    await page.getByRole('button', { name: '推荐自选战法' }).click();
+    const skillDialog = page.getByRole('dialog');
+    await expect(skillDialog).toContainText(eligibleSupportSkill);
+    await expect(
+      skillDialog.getByText(futureSupportSkill, { exact: true })
+    ).toHaveCount(0);
+    const skillSearch = skillDialog.getByLabel('搜索战法...');
+    await skillSearch.fill(futureSupportSkill);
+    await expect(page.getByText('无匹配结果')).toBeVisible();
+  });
+});

--- a/web/tests/seasonSelection.spec.js
+++ b/web/tests/seasonSelection.spec.js
@@ -131,7 +131,7 @@ test.describe('Season selection', () => {
 
     // The same newer-season hero is absent from both support recommendation
     // results and manual support search, while an eligible hero remains.
-    await page.getByRole('button', { name: '推荐自选武将' }).click();
+    await page.getByRole('button', { name: '推荐支援武将' }).click();
     const heroDialog = page.getByRole('dialog');
     await expect(heroDialog).toContainText(eligibleSupportHero);
     await expect(
@@ -143,7 +143,7 @@ test.describe('Season selection', () => {
     await heroDialog.getByRole('button', { name: '关闭' }).click();
 
     // Support skills use the same season boundary.
-    await page.getByRole('button', { name: '推荐自选战法' }).click();
+    await page.getByRole('button', { name: '推荐支援战法' }).click();
     const skillDialog = page.getByRole('dialog');
     await expect(skillDialog).toContainText(eligibleSupportSkill);
     await expect(

--- a/web/tests/supportHeroSkills.spec.js
+++ b/web/tests/supportHeroSkills.spec.js
@@ -99,13 +99,13 @@ test.describe('Support Hero & Skills', () => {
   test('can set a support hero via dialog and button disappears', async ({ page }) => {
     await setupGameAndCompleteRound1(page);
 
-    // Verify 推荐自选武将 button is visible initially
-    const heroButton = page.getByRole('button', { name: '推荐自选武将' });
+    // Verify 推荐支援武将 button is visible initially
+    const heroButton = page.getByRole('button', { name: '推荐支援武将' });
     await expect(heroButton).toBeVisible();
 
     // Click to open the support hero dialog
     await heroButton.click();
-    await expect(page.getByText('推荐支援武将')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { name: '推荐支援武将' })).toBeVisible({ timeout: 5000 });
 
     // Use the search autocomplete to pick a hero
     const searchInput = page.getByLabel('搜索武将...');
@@ -117,25 +117,25 @@ test.describe('Support Hero & Skills', () => {
     await page.getByRole('button', { name: '设为支援武将' }).click();
 
     // Dialog should close
-    await expect(page.getByText('推荐支援武将')).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('heading', { name: '推荐支援武将' })).not.toBeVisible({ timeout: 3000 });
 
     // Support hero should appear in the team with "⭐支援" prefix
     await expect(page.getByText(`⭐支援 ${supportHeroCandidate}`)).toBeVisible();
 
-    // 推荐自选武将 button should now be hidden
+    // 推荐支援武将 button should now be hidden
     await expect(heroButton).not.toBeVisible();
   });
 
   test('can set support skills via dialog and button disappears', async ({ page }) => {
     await setupGameAndCompleteRound1(page);
 
-    // Verify 推荐自选战法 button is visible initially
-    const skillButton = page.getByRole('button', { name: '推荐自选战法' });
+    // Verify 推荐支援战法 button is visible initially
+    const skillButton = page.getByRole('button', { name: '推荐支援战法' });
     await expect(skillButton).toBeVisible();
 
     // Click to open the support skills dialog
     await skillButton.click();
-    await expect(page.getByText('推荐支援战法')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { name: '推荐支援战法' })).toBeVisible({ timeout: 5000 });
 
     // The dialog opens with pre-selected recommended skills from the engine
     const dialog = page.getByRole('dialog');
@@ -174,14 +174,14 @@ test.describe('Support Hero & Skills', () => {
     await page.getByRole('button', { name: '设为支援战法' }).click();
 
     // Dialog should close
-    await expect(page.getByText('推荐支援战法')).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('heading', { name: '推荐支援战法' })).not.toBeVisible({ timeout: 3000 });
 
     // Support skills should appear in the team with "⭐支援" prefix
     for (const skillName of supportSkillCandidates) {
       await expect(page.getByText(`⭐支援 ${skillName}`)).toBeVisible();
     }
 
-    // 推荐自选战法 button should now be hidden
+    // 推荐支援战法 button should now be hidden
     await expect(skillButton).not.toBeVisible();
   });
 
@@ -189,15 +189,15 @@ test.describe('Support Hero & Skills', () => {
     await setupGameAndCompleteRound1(page);
 
     // Set a support hero first
-    const heroButton = page.getByRole('button', { name: '推荐自选武将' });
+    const heroButton = page.getByRole('button', { name: '推荐支援武将' });
     await heroButton.click();
-    await expect(page.getByText('推荐支援武将')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { name: '推荐支援武将' })).toBeVisible({ timeout: 5000 });
     const searchInput = page.getByLabel('搜索武将...');
     await searchInput.click();
     await searchInput.fill(supportHeroCandidate);
     await page.getByRole('option', { name: supportHeroCandidate }).click();
     await page.getByRole('button', { name: '设为支援武将' }).click();
-    await expect(page.getByText('推荐支援武将')).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('heading', { name: '推荐支援武将' })).not.toBeVisible({ timeout: 3000 });
 
     // Verify support hero chip is displayed
     await expect(page.getByText(`⭐支援 ${supportHeroCandidate}`)).toBeVisible();
@@ -205,21 +205,21 @@ test.describe('Support Hero & Skills', () => {
     // Now on round 2 (skill round) - advance to round 4 (hero round) would be complex,
     // so instead verify the support hero appears in the team display
     // and the button is gone
-    await expect(page.getByRole('button', { name: '推荐自选武将' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: '推荐支援武将' })).not.toBeVisible();
   });
 
   test('support hero and skills appear exactly once in the team display', async ({ page }) => {
     await setupGameAndCompleteRound1(page);
 
     // Set a support hero
-    await page.getByRole('button', { name: '推荐自选武将' }).click();
-    await expect(page.getByText('推荐支援武将')).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: '推荐支援武将' }).click();
+    await expect(page.getByRole('heading', { name: '推荐支援武将' })).toBeVisible({ timeout: 5000 });
     const heroSearchInput = page.getByLabel('搜索武将...');
     await heroSearchInput.click();
     await heroSearchInput.fill(supportHeroCandidate);
     await page.getByRole('option', { name: supportHeroCandidate }).click();
     await page.getByRole('button', { name: '设为支援武将' }).click();
-    await expect(page.getByText('推荐支援武将')).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('heading', { name: '推荐支援武将' })).not.toBeVisible({ timeout: 3000 });
 
     // Verify support hero chip appears exactly once (with ⭐支援 prefix)
     const supportHeroChips = page.getByText(`⭐支援 ${supportHeroCandidate}`);
@@ -231,8 +231,8 @@ test.describe('Support Hero & Skills', () => {
     await expect(allHeroOccurrences).toHaveCount(1);
 
     // Set support skills
-    await page.getByRole('button', { name: '推荐自选战法' }).click();
-    await expect(page.getByText('推荐支援战法')).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: '推荐支援战法' }).click();
+    await expect(page.getByRole('heading', { name: '推荐支援战法' })).toBeVisible({ timeout: 5000 });
     const dialog = page.getByRole('dialog');
     await expect(dialog.getByText(/已选择 2\/2 个战法/)).toBeVisible({ timeout: 5000 });
     const preSelectedChips = dialog.locator('.MuiChip-deleteIcon');
@@ -249,7 +249,7 @@ test.describe('Support Hero & Skills', () => {
     await page.getByRole('option', { name: supportSkillCandidates[1] }).click();
     await expect(dialog.getByText('已选择 2/2 个战法')).toBeVisible({ timeout: 3000 });
     await page.getByRole('button', { name: '设为支援战法' }).click();
-    await expect(page.getByText('推荐支援战法')).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('heading', { name: '推荐支援战法' })).not.toBeVisible({ timeout: 3000 });
 
     // Each support skill should appear exactly once
     for (const skillName of supportSkillCandidates) {
@@ -282,24 +282,24 @@ test.describe('Support Hero & Skills', () => {
     await setupGameAndCompleteRound1(page);
 
     // Set a support hero
-    await page.getByRole('button', { name: '推荐自选武将' }).click();
-    await expect(page.getByText('推荐支援武将')).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: '推荐支援武将' }).click();
+    await expect(page.getByRole('heading', { name: '推荐支援武将' })).toBeVisible({ timeout: 5000 });
     const searchInput = page.getByLabel('搜索武将...');
     await searchInput.click();
     await searchInput.fill(supportHeroCandidate);
     await page.getByRole('option', { name: supportHeroCandidate }).click();
     await page.getByRole('button', { name: '设为支援武将' }).click();
-    await expect(page.getByText('推荐支援武将')).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('heading', { name: '推荐支援武将' })).not.toBeVisible({ timeout: 3000 });
 
     // Verify button is hidden
-    await expect(page.getByRole('button', { name: '推荐自选武将' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: '推荐支援武将' })).not.toBeVisible();
 
     // Find the support hero chip and click its delete button
     const supportChip = page.getByText(`⭐支援 ${supportHeroCandidate}`).locator('..');
     await supportChip.getByTestId('CancelIcon').click();
 
     // Button should reappear
-    await expect(page.getByRole('button', { name: '推荐自选武将' })).toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('button', { name: '推荐支援武将' })).toBeVisible({ timeout: 3000 });
 
     // Support hero chip should be gone
     await expect(page.getByText(`⭐支援 ${supportHeroCandidate}`)).not.toBeVisible();


### PR DESCRIPTION
## Intent

Add a season selector to initial setup using seasons 1 through the database maximum, defaulting to the latest season when no cookie exists and persisting the choice in a browser cookie. The season limits only support hero and support skill availability; initial setup and round inputs remain unrestricted, including hero-exclusive initial skills, and the selected season stays clearly visible without extra explanatory copy. Audit representative game stages and pages with Playwright on desktop and mobile, move the setup instruction below the season picker, make completed rosters genuinely read-only, use consistent support terminology, add a proper completed-page heading, and expose the round-7 continue action before the long roster on mobile while preserving desktop order. Explicitly do not change /build-a-team. Publish the validated feature branch as a pull request and wait for CI checks to pass.

## What Changed

- Added a season selector to initial setup (seasons 1 through the database maximum), defaulting to the latest season and persisting the choice in a browser cookie via new `storage`, `GameContext` (`SET_SEASON`/season load), `domain`/`game` types, and `api.getDatabaseItems` max-season support; the season limits only support hero and support skill availability while initial setup and round inputs stay unrestricted.
- Polished the game flow UI: moved the setup instruction below the season picker, kept the selected season visible without extra copy, made completed rosters genuinely read-only with a proper completed-page heading, unified support terminology, and surfaced the round-7 continue action before the long roster on mobile while preserving desktop order.
- Added Vitest coverage for the reducer/provider/storage/api changes and Playwright specs (`seasonSelection`, `accessibilityLayout`, updated `supportHeroSkills`) exercising season default/persistence, support-only gating, and responsive layout on desktop and mobile.

## Risk Assessment

✅ Low: The change is well-bounded, feature-flagged behind a season field already present in the data, matches every required acceptance criterion, and is backed by comprehensive unit and e2e tests; the sole finding is cosmetic dead code.

## Testing

Ran the web workspace's scoped tests on Node 22: typecheck clean, 151 Vitest unit tests green, and the season-selection + accessibility-layout + support Playwright specs pass on both desktop and mobile. To demonstrate the user-visible behavior I also captured screenshots of the real rendered surfaces confirming: the season selector defaults to the latest DB season (赛季 16) and sits above the setup instruction, the dropdown lists seasons 1–16, the completed page shows an 对局完成 h1 over a genuinely read-only roster (no edit/remove/recommend controls) with a 赛季 chip and 支援 terminology, and the round-7 continue action renders before the roster on mobile but after it on desktop. /build-a-team was not touched in the diff. Overall result: all tests pass with reviewer-visible visual evidence for every intent facet.

- Evidence: Setup page — season selector above instruction (mobile 390px), defaults to 赛季 16 (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY9V9FB734RHEXH3F09V0VV9/02-setup-season-selector-mobile.png</code>)
- Evidence: Setup page — season selector (desktop), instruction below picker (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY9V9FB734RHEXH3F09V0VV9/01-setup-season-selector-desktop.png</code>)
- Evidence: Season dropdown open — seasons 1 through 16 (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY9V9FB734RHEXH3F09V0VV9/03-season-dropdown-open.png</code>)
- Evidence: Completed page — 对局完成 h1 heading + read-only roster with 赛季 chip and ⭐支援 items, no edit/remove/recommend controls (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY9V9FB734RHEXH3F09V0VV9/04-completed-readonly-roster.png</code>)
- Evidence: Round-7 interstitial (mobile) — continue action above the roster; support wording (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY9V9FB734RHEXH3F09V0VV9/05-round7-interstitial-mobile.png</code>)
- Evidence: Round-7 interstitial (desktop) — continue action below the roster (order preserved) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY9V9FB734RHEXH3F09V0VV9/06-round7-interstitial-desktop.png</code>)
- Evidence: In-round roster — 推荐支援武将 / 推荐支援战法 support terminology (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KY9V9FB734RHEXH3F09V0VV9/07-support-wording-in-round.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `web/src/components/game/CurrentTeam.tsx:57` - `selectedSeason` is typed as non-nullable `number` (types/game.ts) and is always assigned a number by the reducer and initialState, so the null-handling around it is dead code and misleadingly implies the value can be null: `selectedSeason === null` in `isAvailableInSelectedSeason` (CurrentTeam.tsx:57) never short-circuits, `selectedSeason !== null` gating the season chip (CurrentTeam.tsx:184) is always true, and `value={selectedSeason ?? &#39;&#39;}` (SetupForm.tsx:115) never yields `&#39;&#39;`. These can be simplified to plain numeric usage without behavior change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm typecheck` (Go-native tsc) — clean</code>
- <code>`pnpm test` (Vitest) — 151 tests across 14 files pass, covering new gameReducer SET_SEASON/LOAD_DATABASE, GameProvider season load+persist, storage save/load cookie, and api.getDatabaseItems maxSeason</code>
- <code>`pnpm exec playwright test seasonSelection.spec.js accessibilityLayout.spec.js` — season default/persistence, support-only season gating with newer items still enterable in setup/rounds, setup instruction below picker, completed-page single h1 + read-only roster, support wording, mobile round-7 action-before-roster (12 passed)</code>
- <code>`pnpm exec playwright test supportHeroSkills.spec.js` — support hero/skill dialogs and round exclusion (5 passed)</code>
- `Manual visual capture via a temporary Playwright spec (since removed): setup selector desktop+mobile, open season dropdown (赛季 1..16), completed read-only roster with season chip, round-7 interstitial on mobile (continue button above roster) and desktop (below roster)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
