### PR TITLE
Fix setup-uv action tag

### DIFF
--- a/.github/workflows/update-web-battles.yml
+++ b/.github/workflows/update-web-battles.yml
@@ -42,7 +42,7 @@ jobs:
           python-version-file: .python-version
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
Pins astral-sh/setup-uv to the published v9.0.0 tag so the Update web battle data workflow can resolve the action. Validation: workflow YAML parses successfully and the staged diff is clean.