### PR TITLE
fix(web): load canonical database via watched Vite virtual module

### DIFF
--- a/web/src/data.ts
+++ b/web/src/data.ts
@@ -9,7 +9,7 @@
  * `recommendation_data.json` is generated offline by
  * `data/build_recommendation_data.py`; never hand-edit it.
  */
-import databaseRaw from '../public/game-data/database.json';
+import databaseRaw from 'virtual:game-database';
 import recommendationRaw from './recommendation_data.json';
 import type { Database } from './types/domain';
 import type { RecommendationData } from './types/recommendation';

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare module 'virtual:game-database' {
+  const database: unknown;
+  export default database;
+}

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,9 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
+const DATABASE_MODULE_ID = 'virtual:game-database';
+const RESOLVED_DATABASE_MODULE_ID = `\0${DATABASE_MODULE_ID}`;
+const DATABASE_PATH = fileURLToPath(
+  new URL('./public/game-data/database.json', import.meta.url)
+);
+
+const gameDatabase = () => ({
+  name: 'game-database',
+  enforce: 'pre',
+  resolveId(id) {
+    if (id === DATABASE_MODULE_ID) return RESOLVED_DATABASE_MODULE_ID;
+  },
+  load(id) {
+    if (id !== RESOLVED_DATABASE_MODULE_ID) return;
+
+    this.addWatchFile(DATABASE_PATH);
+    return `export default ${readFileSync(DATABASE_PATH, 'utf8')};`;
+  },
+});
+
 // https://vite.dev/config/  (defineConfig from vitest/config also types the `test` block)
 export default defineConfig({
-  plugins: [react()],
+  plugins: [gameDatabase(), react()],
   // The app is served from the domain root on Cloudflare Pages.
   base: '/',
   server: {

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -9,6 +9,11 @@ const DATABASE_PATH = fileURLToPath(
   new URL('./public/game-data/database.json', import.meta.url)
 );
 
+// Vite 8's dev server refuses to let JS import files under `public/`, but
+// `public/game-data/database.json` must stay the single canonical, publicly
+// downloadable database. This virtual module inlines that one file at build
+// time (synchronous in dev, prod build, and Vitest) and watches it in dev, so
+// the app can keep synchronously importing the database without a second copy.
 const gameDatabase = () => ({
   name: 'game-database',
   enforce: 'pre',


### PR DESCRIPTION
## Intent

Fix the Vite 8 development-server error that public assets cannot be imported from JavaScript, while keeping web/public/game-data/database.json as the single canonical and publicly downloadable database. Preserve synchronous database access in the React app across development, production builds, and Vitest, leave the Cloudflare Function runtime import and public URL unchanged, and avoid duplicating or moving the database by loading it through a watched Vite virtual module. Verify the web typecheck, unit tests, Playwright end-to-end tests, and production build, then create a PR.

## What Changed

- Added a `game-database` Vite plugin in `web/vite.config.js` that resolves a `virtual:game-database` module by synchronously inlining `web/public/game-data/database.json` at build time and registering it as a watched file in dev, working around Vite 8's refusal to import assets under `public/` from JavaScript.
- Repointed `web/src/data.ts` to import the database from `virtual:game-database` instead of the direct `../public/game-data/database.json` path, preserving synchronous access across dev, production builds, and Vitest.
- Declared the `virtual:game-database` module type in `web/src/vite-env.d.ts` so the typecheck resolves the new import.
- The `public/game-data/database.json` file stays the single canonical, publicly downloadable copy (unchanged public URL and Cloudflare Function runtime import); no duplicate is created.

## Risk Assessment

✅ Low: A small, well-bounded change that swaps a broken public-asset import for a standard watched Vite virtual module, preserving synchronous DB access, file location, and the unchanged Cloudflare Function import across all consumers.

## Testing

Ran the full intent-required web suite under Node 22 (typecheck, Vitest 267/267, production vite build, Playwright e2e 47/47), then proved the actual fix end-to-end by starting the Vite 8 dev server, loading the app in a browser, and confirming it renders database-backed content (season dropdown, hero/skill autocompletes) with zero console/page errors — the exact scenario the old direct public-asset import broke. Also verified the database remains the single canonical, publicly downloadable file (HTTP 200 at /game-data/database.json, byte-identical in build/, no src duplicate) and the Cloudflare Function import path is unchanged. All checks green; no issues found. Transient build/test artifacts were removed and the working tree is clean.

- Evidence: Vite 8 dev server rendering database-backed app (fix working) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYC0KZJM83R35NY7MM76KGYT/app-home-dev.png</code>)
<details>
<summary>Evidence: Public database still downloadable at canonical URL in dev</summary>

```text
$ curl -s -o /dev/null -w 'http=%{http_code} bytes=%{size_download}' http://localhost:3000/game-data/database.json
http=200 bytes=130636
```
</details>
<details>
<summary>Evidence: Build output contains canonical database verbatim</summary>

```text
$ cmp public/game-data/database.json build/game-data/database.json && echo IDENTICAL
IDENTICAL (single canonical, copied verbatim)
```
</details>
<details>
<summary>Evidence: e2e result</summary>

```text
47 passed (22.0s) — Playwright against Vite 8 dev server
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm typecheck` (tsc --noEmit) — 0 errors</code>
- <code>`pnpm test` (vitest run) — 267 unit tests pass; confirms virtual:game-database resolves under Vitest</code>
- <code>`pnpm build` (vite build v8.1.4) — production build succeeds</code>
- <code>`pnpm test:e2e` (Playwright) — 47 e2e tests pass against the Vite 8 dev server</code>
- <code>Started `pnpm start` (Vite 8 dev server) and confirmed clean startup log with no public-asset import error</code>
- `Loaded http://localhost:3000/ in headless Chromium, captured full-page screenshot, verified database-backed UI (season 赛季 16, hero/skill inputs) and zero pageerror/console errors`
- `curl http://localhost:3000/game-data/database.json -> HTTP 200, 130636 bytes (public URL preserved)`
- `cmp public/game-data/database.json build/game-data/database.json -> identical (single canonical, copied verbatim into build output)`
- `grep confirmed functions/api/battles.js still imports ../../public/game-data/database.json (Function runtime import unchanged) and no duplicate database.json under web/src`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
