### PR TITLE
Add battle upload video guide

### DIFF
--- a/web/src/pages/Contribute.tsx
+++ b/web/src/pages/Contribute.tsx
@@ -15,6 +15,7 @@ import {
   Typography,
 } from '@mui/material';
 import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined';
+import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
 import SendOutlinedIcon from '@mui/icons-material/SendOutlined';
 import { Link as RouterLink } from 'react-router-dom';
 import { database, recommendationData } from '../data';
@@ -212,6 +213,17 @@ const Contribute = () => {
                 选择战报赛季，确认双方全部位置、战法与胜方，再查看当前模型的阵容评分并提交。
               </Typography>
             </Box>
+            <Button
+              component="a"
+              href="https://www.bilibili.com/video/BV1Rt3M6LEdA/"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="outlined"
+              startIcon={<PlayCircleOutlineIcon />}
+              sx={{ mt: 2 }}
+            >
+              观看视频教程（B站）
+            </Button>
           </CardContent>
         </Card>
 

--- a/web/tests/battleContribution.spec.js
+++ b/web/tests/battleContribution.spec.js
@@ -66,6 +66,18 @@ test.describe('Public battle contribution flow', () => {
       ),
     ).toBeVisible();
     await expect(page.getByRole('list').filter({ hasText: '截取一张' })).toBeVisible();
+    const videoTutorial = page.getByRole('link', {
+      name: '观看视频教程（B站）',
+    });
+    await expect(videoTutorial).toHaveAttribute(
+      'href',
+      'https://www.bilibili.com/video/BV1Rt3M6LEdA/',
+    );
+    await expect(videoTutorial).toHaveAttribute('target', '_blank');
+    await expect(videoTutorial).toHaveAttribute(
+      'rel',
+      'noopener noreferrer',
+    );
 
     const nameInput = page.getByRole('textbox', { name: '贡献榜名字（选填）' });
     await expect(nameInput).toHaveValue('旧名字😀');


### PR DESCRIPTION
Adds a compact Bilibili video-tutorial button to the four-step contribution instructions. The link opens safely in a new tab and is covered by the contribution Playwright test. Validation: typecheck, production build, and 4 focused browser tests passed.