### PR TITLE
feat(web): add draft rounds 9 and 10 with cross-session progress persistence

### DIFF
--- a/.github/workflows/update-telemetry-data.yml
+++ b/.github/workflows/update-telemetry-data.yml
@@ -82,7 +82,60 @@ jobs:
             exit 1
           fi
 
+      - name: Capture explicit telemetry reset target
+        if: inputs.reset_checkpoint == true
+        working-directory: web
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
+            --remote \
+            --command="SELECT (SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'round_telemetry') AS table_sql, COUNT(*) AS row_count, MIN(id) AS min_id, MAX(id) AS max_id FROM round_telemetry" \
+            --json > "$RUNNER_TEMP/d1-reset-target.json"
+
+      - name: Validate explicit telemetry reset target
+        if: inputs.reset_checkpoint == true
+        run: |
+          python data/telemetry_retention.py validate-reset-target \
+            "$RUNNER_TEMP/d1-reset-target.json"
+
+      - name: Apply explicit ten-round telemetry beta reset
+        if: inputs.reset_checkpoint == true
+        working-directory: web
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          pnpm dlx wrangler@4.112.0 d1 execute \
+            "$CLOUDFLARE_D1_DATABASE_NAME" \
+            --remote \
+            --file=migrations/0004_round_telemetry_rounds_10_reset.sql \
+            --yes
+
+      - name: Capture post-reset D1 metadata
+        if: inputs.reset_checkpoint == true
+        working-directory: web
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
+            --remote \
+            --command="SELECT (SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'round_telemetry') AS table_sql, COUNT(*) AS row_count, MIN(id) AS min_id, MAX(id) AS max_id, COALESCE((SELECT seq FROM sqlite_sequence WHERE name = 'round_telemetry'), 0) AS sequence_value FROM round_telemetry" \
+            --json > "$RUNNER_TEMP/d1-pre-migration.json"
+
+      - name: Verify explicit telemetry reset result
+        if: inputs.reset_checkpoint == true
+        run: |
+          python data/telemetry_retention.py verify-reset \
+            "$RUNNER_TEMP/d1-pre-migration.json"
+
       - name: Capture pre-migration D1 metadata
+        if: inputs.reset_checkpoint != true
         working-directory: web
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -129,6 +182,7 @@ jobs:
             --yes
 
       - name: Capture post-migration D1 metadata
+        if: inputs.reset_checkpoint != true
         working-directory: web
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -141,12 +195,16 @@ jobs:
             --json > "$RUNNER_TEMP/d1-post-migration.json"
 
       - name: Verify D1 migration and sequence
+        if: inputs.reset_checkpoint != true
         env:
           RESET_CHECKPOINT: ${{ inputs.reset_checkpoint == true && 'true' || 'false' }}
         run: |
           reset_args=()
           case "$RESET_CHECKPOINT" in
-            true) reset_args+=(--reset-checkpoint) ;;
+            true)
+              echo "Reset verification uses the dedicated reset path" >&2
+              exit 1
+              ;;
             false) ;;
             *)
               echo "Invalid reset_checkpoint input" >&2
@@ -205,7 +263,7 @@ jobs:
           trap 'rm -f -- "$RUNNER_TEMP/round_telemetry.sql"' EXIT
           reset_args=()
           case "$RESET_CHECKPOINT" in
-            true) reset_args+=(--reset-state) ;;
+            true) reset_args+=(--reset-and-fold-export) ;;
             false) ;;
             *)
               echo "Invalid reset_checkpoint input" >&2

--- a/GAME_RULE.md
+++ b/GAME_RULE.md
@@ -8,13 +8,22 @@ and project orientation.
 **Initial Setup:**
 - Start with 4 heroes and 8 skills
 
-**Gameplay (8 rounds):**
+**Gameplay (10 rounds):**
 - Round 1: Select 1 hero set from 3 options (each set contains 3 heroes)
 - Round 2: Select 1 skill set from 3 options (each set contains 3 skills)
 - Round 3: Select 1 skill set from 3 options (each set contains 3 skills)
 - Round 4: Select 1 hero set from 3 options (each set contains 3 heroes)
 - Round 5: Select 1 skill set from 3 options (each set contains 3 skills)
 - Round 6: Select 1 skill set from 3 options (each set contains 3 skills)
-- **After Round 6 (end of Cycle 2):** Pick 1 unchosen hero and 2 unchosen skills that are not hero skills — implemented as the "support hero / support skills" pick (add from the current-team panel; recommendations via `recommendSingleHero` / `recommendTwoSkills`)
+- **Optional support pick (unchanged):** After Round 6, the current-team panel
+  may add 1 unchosen hero and 2 unchosen non-hero skills. The support choices
+  use the existing `recommendSingleHero` / `recommendTwoSkills`
+  recommendations and are carried through the later rounds.
+- **Qualification after Round 6:** Confirm the win in one click to unlock Round 7.
 - Round 7: Select 1 hero set from 3 options (each set contains 2 heroes)
 - Round 8: Select 1 skill set from 3 options (each set contains 3 skills)
+- **Qualification after Round 8:** Confirm the win in one click to unlock Round 9.
+- Round 9: Repeat the Round 7 format — select 1 hero set from 3 options
+  (each set contains 2 heroes)
+- Round 10: Repeat the Round 8 format — select 1 skill set from 3 options
+  (each set contains 3 skills)

--- a/README.md
+++ b/README.md
@@ -182,9 +182,10 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
   be verified; individual malformed or impossible events are quarantined and
   exposed only as an aggregate `invalid_event_count`. Valid rows are reduced
   atomically to `web/public/game-data/telemetry_data.json` after UI eligibility
-  and recorded-score verification. The cumulative schema-v4 artifact adds
-  offer/pick, round, position, score-margin, and model-disagreement aggregates
-  plus a deterministic online conditional-choice model. The model remains
+  and recorded-score verification. The cumulative schema-v5 artifact covers
+  all ten rounds and adds offer/pick, round, position, score-margin, and
+  model-disagreement aggregates plus a deterministic online conditional-choice
+  model. The model remains
   unavailable until explicit event/estimated-session/disagreement/evaluation
   evidence gates and a quality gate pass. The raw export remains outside the
   repository. Before
@@ -193,7 +194,7 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
   each incremental build, it validates and advances
   `data/telemetry_state.json`, which contains only cumulative counters, a
   fixed-size anonymous session estimate, resumable model state, and the last
-  processed D1 row ID. Schema v4 is rendered solely from that checkpoint, so
+  processed D1 row ID. Schema v5 is rendered solely from that checkpoint, so
   old raw rows can be deleted without reducing public totals. Optimizer
   features, optimizer deltas, and model-quality statistics are persisted only
   in groups supported by at least ten new events, so a small batch's

--- a/data/build_telemetry_data.py
+++ b/data/build_telemetry_data.py
@@ -5,15 +5,18 @@ The input is the SQL file produced by ``wrangler d1 export --table
 round_telemetry``.  It is loaded into an in-memory SQLite database, validated
 against the schema-v1 browser contract and current game catalog, and reduced to
 counts and, once evidence is sufficient, a regularized conditional-choice
-model that are safe to publish. Without ``--state`` the legacy full-export
-schema-v3 builder remains available for offline compatibility. With ``--state``
-only rows after the checkpoint cursor are folded, and the cumulative schema-v4
-artifact is rendered solely from aggregate state. Raw events are never written
-by this script.
+model that are safe to publish. Without ``--state`` the frozen legacy
+full-export schema-v3 builder remains available for offline compatibility; it
+accepts either known 1–8 or current 1–10 table schemas, but only events from
+rounds 1–8. With ``--state`` the current 1–10 schema is required, only rows after
+the checkpoint cursor are folded, and the cumulative schema-v5 artifact is
+rendered solely from aggregate state. Raw events are never written by this
+script.
 """
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import json
 import math
@@ -34,6 +37,7 @@ from typing import Any, Iterable, Mapping
 # single module identity when this file is launched directly as a script.
 sys.modules.setdefault("build_telemetry_data", sys.modules[__name__])
 
+# Frozen compatibility contract for builds that omit --state.
 ARTIFACT_SCHEMA_VERSION = 3
 EVENT_SCHEMA_VERSION = 1
 MAX_MODEL_VERSIONS = 32
@@ -63,7 +67,17 @@ ROUND_TYPES = {
     6: "skill",
     7: "hero",
     8: "skill",
+    9: "hero",
+    10: "skill",
 }
+# Schema v3 is permanently limited to these original eight rounds. Current
+# publication uses ROUND_TYPES through the stateful schema-v5 path.
+LEGACY_ROUND_TYPES = {
+    number: round_type
+    for number, round_type in ROUND_TYPES.items()
+    if number <= 8
+}
+TWO_ITEM_HERO_ROUNDS = frozenset({7, 9})
 EXPECTED_COLUMNS = (
     "id",
     "event_id",
@@ -370,7 +384,12 @@ def _load_sql_connection(sql: str, description: str) -> sqlite3.Connection:
     return connection
 
 
-def _load_export(export_path: Path, migration_path: Path) -> sqlite3.Connection:
+def _load_export(
+    export_path: Path,
+    migration_path: Path,
+    *,
+    allow_legacy_schema: bool = False,
+) -> sqlite3.Connection:
     try:
         sql = export_path.read_text(encoding="utf-8")
     except OSError as exc:
@@ -407,10 +426,31 @@ def _load_export(export_path: Path, migration_path: Path) -> sqlite3.Connection:
     canonical = _load_sql_connection(migration_sql, "canonical D1 migration")
     try:
         actual_contract = _schema_contract(connection)
-        expected_contract = _schema_contract(canonical)
+        accepted_contracts = {_schema_contract(canonical)}
     finally:
         canonical.close()
-    if actual_contract != expected_contract:
+    if allow_legacy_schema:
+        current_constraint = '"round_number" BETWEEN 1 AND 10'
+        legacy_constraint = '"round_number" BETWEEN 1 AND 8'
+        if migration_sql.count(current_constraint) != 1:
+            connection.close()
+            raise InvalidTelemetryError(
+                "canonical D1 migration does not contain the known "
+                "ten-round constraint"
+            )
+        legacy = _load_sql_connection(
+            migration_sql.replace(
+                current_constraint,
+                legacy_constraint,
+                1,
+            ),
+            "legacy D1 migration",
+        )
+        try:
+            accepted_contracts.add(_schema_contract(legacy))
+        finally:
+            legacy.close()
+    if actual_contract not in accepted_contracts:
         connection.close()
         raise InvalidTelemetryError(
             "round_telemetry schema mismatch with canonical migration"
@@ -563,7 +603,7 @@ def _validate_event_fields(
 
     round_number = row["round_number"]
     if not _is_int(round_number) or round_number not in ROUND_TYPES:
-        raise InvalidTelemetryError("round_number must be between 1 and 8")
+        raise InvalidTelemetryError("round_number must be between 1 and 10")
     round_type = row["round_type"]
     if round_type != ROUND_TYPES[round_number]:
         raise InvalidTelemetryError("round_type does not match round_number")
@@ -625,7 +665,7 @@ def _validate_event_fields(
             )
 
     offered_sets = _load_json_field(row["offered_sets_json"], "offered_sets_json")
-    items_per_set = 2 if round_number == 7 else 3
+    items_per_set = 2 if round_number in TWO_ITEM_HERO_ROUNDS else 3
     known_offers = (
         set(contract.hero_names)
         if round_type == "hero"
@@ -770,10 +810,15 @@ def load_event_batch(
     contract: TelemetryContract,
     *,
     after_id: int = 0,
+    allow_legacy_schema: bool = False,
 ) -> tuple[list[dict[str, Any]], int, int]:
     if not _is_int(after_id) or after_id < 0:
         raise InvalidTelemetryError("after_id must be a non-negative integer")
-    connection = _load_export(export_path, migration_path)
+    connection = _load_export(
+        export_path,
+        migration_path,
+        allow_legacy_schema=allow_legacy_schema,
+    )
     try:
         rows = connection.execute(
             f"SELECT {', '.join(EXPECTED_COLUMNS)} FROM round_telemetry "
@@ -822,6 +867,7 @@ def load_events(
         export_path,
         migration_path,
         contract,
+        allow_legacy_schema=True,
     )
     return events, invalid_event_count
 
@@ -1300,7 +1346,16 @@ def build_artifact(
     catalog_version: str,
     invalid_event_count: int = 0,
 ) -> dict[str, Any]:
+    """Build the frozen eight-round schema-v3 full-export artifact."""
     event_rows = list(events)
+    if any(
+        event.get("round_number") not in LEGACY_ROUND_TYPES
+        for event in event_rows
+    ):
+        raise InvalidTelemetryError(
+            "legacy schema-v3 full-export builds support rounds 1-8 only; "
+            "use --state for rounds 9-10"
+        )
     preference_model, preference_predictions = _build_preference_model(event_rows)
     preference_ready = preference_model["status"] == "ready"
     round_rows = {
@@ -1319,7 +1374,7 @@ def build_artifact(
             "player_preference_agreement_count": 0 if preference_ready else None,
             "average_meaningful_preference_disagreement_margin": None,
         }
-        for number, round_type in ROUND_TYPES.items()
+        for number, round_type in LEGACY_ROUND_TYPES.items()
     }
     meaningful_disagreement_margin_totals: dict[int, float] = defaultdict(float)
     item_counts: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
@@ -1472,7 +1527,11 @@ def build_artifact(
     return artifact
 
 
-def _preference_feature_parts(feature_id: Any) -> list[Any] | None:
+def _preference_feature_parts(
+    feature_id: Any,
+    *,
+    maximum_round_number: int = max(ROUND_TYPES),
+) -> list[Any] | None:
     if not _is_short_string(feature_id, 512):
         return None
     try:
@@ -1491,6 +1550,7 @@ def _preference_feature_parts(feature_id: Any) -> list[Any] | None:
         and len(parts) == 2
         and _is_int(parts[1])
         and parts[1] in ROUND_TYPES
+        and parts[1] <= maximum_round_number
     ):
         return parts
     if (
@@ -1523,10 +1583,73 @@ def _minimum_preference_feature_support(parts: list[Any]) -> int:
     return MIN_RATE_SUPPORT * 3 if parts[0] == "round_score" else MIN_FEATURE_SUPPORT
 
 
+def _validate_frozen_v4_artifact(artifact: Mapping[str, Any]) -> None:
+    """Validate an eight-round v4 artifact through the current v5 contract."""
+    if (
+        not isinstance(artifact, dict)
+        or artifact.get("schema")
+        != {
+            "version": 4,
+            "source_event_schema_version": EVENT_SCHEMA_VERSION,
+        }
+        or not isinstance(artifact.get("rounds"), list)
+        or len(artifact["rounds"]) != len(LEGACY_ROUND_TYPES)
+    ):
+        raise InvalidTelemetryError("telemetry artifact schema is invalid")
+
+    preference_model = artifact.get("preference_model")
+    if isinstance(preference_model, dict):
+        weights = preference_model.get("weights")
+        support = preference_model.get("support")
+        if isinstance(weights, dict) and isinstance(support, dict):
+            for feature_id in {*weights, *support}:
+                if (
+                    _preference_feature_parts(
+                        feature_id,
+                        maximum_round_number=max(LEGACY_ROUND_TYPES),
+                    )
+                    is None
+                ):
+                    raise InvalidTelemetryError(
+                        "frozen schema-v4 preference features are invalid"
+                    )
+
+    current = copy.deepcopy(artifact)
+    current["schema"]["version"] = 5
+    preference_ready = (
+        isinstance(preference_model, dict)
+        and preference_model.get("status") == "ready"
+    )
+    for number in (9, 10):
+        preference_count = 0 if preference_ready else None
+        current["rounds"].append(
+            {
+                "round_number": number,
+                "round_type": ROUND_TYPES[number],
+                "event_count": 0,
+                "recommendation_accepted_count": 0,
+                "chosen_position_counts": [0, 0, 0],
+                "recommended_position_counts": [0, 0, 0],
+                "rate_suppressed": True,
+                "preference_top_disagreement_count": preference_count,
+                "meaningful_preference_disagreement_count": preference_count,
+                "player_preference_agreement_count": preference_count,
+                "average_meaningful_preference_disagreement_margin": None,
+            }
+        )
+
+    from telemetry_incremental_state import validate_public_artifact
+
+    validate_public_artifact(current)
+
+
 def validate_artifact(artifact: Mapping[str, Any]) -> None:
     """Fail closed if aggregation or preference-model wiring emits bad output."""
     schema = artifact.get("schema") if isinstance(artifact, dict) else None
     if isinstance(schema, dict) and schema.get("version") == 4:
+        _validate_frozen_v4_artifact(artifact)
+        return
+    if isinstance(schema, dict) and schema.get("version") == 5:
         from telemetry_incremental_state import validate_public_artifact
 
         validate_public_artifact(artifact)
@@ -1579,9 +1702,17 @@ def validate_artifact(artifact: Mapping[str, Any]) -> None:
 
     summary = artifact["summary"]
     rounds = artifact["rounds"]
-    if not isinstance(summary, dict) or not isinstance(rounds, list) or len(rounds) != 8:
+    if (
+        not isinstance(summary, dict)
+        or not isinstance(rounds, list)
+        or len(rounds) != len(LEGACY_ROUND_TYPES)
+    ):
         raise InvalidTelemetryError("telemetry artifact summary or rounds are invalid")
-    if [row.get("round_number") for row in rounds if isinstance(row, dict)] != list(range(1, 9)):
+    if [
+        row.get("round_number")
+        for row in rounds
+        if isinstance(row, dict)
+    ] != list(LEGACY_ROUND_TYPES):
         raise InvalidTelemetryError("telemetry artifact rounds are not ordered 1-8")
 
     total_events = 0
@@ -1599,7 +1730,7 @@ def validate_artifact(artifact: Mapping[str, Any]) -> None:
             "meaningful_preference_disagreement_count",
             "player_preference_agreement_count",
             "average_meaningful_preference_disagreement_margin",
-        } or row["round_type"] != ROUND_TYPES[number]:
+        } or row["round_type"] != LEGACY_ROUND_TYPES[number]:
             raise InvalidTelemetryError(f"telemetry artifact round {number} is invalid")
         event_count = row["event_count"]
         chosen_counts = row["chosen_position_counts"]
@@ -1791,14 +1922,24 @@ def validate_artifact(artifact: Mapping[str, Any]) -> None:
             or len(weights) > MAX_PREFERENCE_FEATURES
             or set(weights) != set(support)
             or any(
-                _preference_feature_parts(feature_id) is None
+                _preference_feature_parts(
+                    feature_id,
+                    maximum_round_number=max(LEGACY_ROUND_TYPES),
+                )
+                is None
                 or isinstance(value, bool)
                 or not isinstance(value, (int, float))
                 or not math.isfinite(value)
                 for feature_id, value in weights.items()
             )
             or any(
-                (parts := _preference_feature_parts(feature_id)) is None
+                (
+                    parts := _preference_feature_parts(
+                        feature_id,
+                        maximum_round_number=max(LEGACY_ROUND_TYPES),
+                    )
+                )
+                is None
                 or not _is_int(value)
                 or value < _minimum_preference_feature_support(parts)
                 for feature_id, value in support.items()
@@ -2008,6 +2149,7 @@ def build(
     *,
     initialize_state: bool = False,
     reset_state: bool = False,
+    reset_and_fold_export: bool = False,
 ) -> dict[str, Any]:
     historical_recommendation_paths = tuple(historical_recommendation_paths)
     if migration_path is None:
@@ -2015,13 +2157,20 @@ def build(
             Path(__file__).resolve().parent.parent
             / "web/migrations/0001_round_telemetry.sql"
         )
-    if initialize_state and reset_state:
-        raise InvalidTelemetryError(
-            "incremental state cannot be initialized and reset together"
+    explicit_state_actions = sum(
+        (
+            initialize_state,
+            reset_state,
+            reset_and_fold_export,
         )
-    if (initialize_state or reset_state) and state_path is None:
+    )
+    if explicit_state_actions > 1:
         raise InvalidTelemetryError(
-            "--initialize-state and --reset-state require an incremental state path"
+            "incremental state actions are mutually exclusive"
+        )
+    if explicit_state_actions and state_path is None:
+        raise InvalidTelemetryError(
+            "incremental state actions require an incremental state path"
         )
     if state_path is not None:
         state_resolved = state_path.resolve()
@@ -2073,6 +2222,22 @@ def build(
                 (),
                 catalog_version=contract.catalog_version,
                 last_processed_id=last_processed_id,
+            )
+        elif reset_and_fold_export:
+            new_events, new_invalid_event_count, last_processed_id = (
+                load_event_batch(
+                    export_path,
+                    migration_path,
+                    contract,
+                    after_id=0,
+                )
+            )
+            state = fold_events(
+                None,
+                new_events,
+                catalog_version=contract.catalog_version,
+                last_processed_id=last_processed_id,
+                invalid_event_count=new_invalid_event_count,
             )
         else:
             previous_state: dict[str, Any] | None = None
@@ -2161,7 +2326,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         help=(
             "aggregate-only incremental checkpoint; omitted to run the "
-            "legacy full-export build without updating checkpoint state"
+            "frozen eight-round schema-v3 full-export build, which rejects "
+            "rounds 9-10, without updating checkpoint state"
         ),
     )
     parser.add_argument(
@@ -2178,6 +2344,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=(
             "explicitly discard cumulative telemetry and advance a new empty "
             "checkpoint past every row in the current export"
+        ),
+    )
+    parser.add_argument(
+        "--reset-and-fold-export",
+        action="store_true",
+        help=(
+            "explicitly discard cumulative telemetry and fold every row in "
+            "the current export into a fresh checkpoint"
         ),
     )
     return parser.parse_args(argv)
@@ -2201,6 +2375,7 @@ def main(argv: list[str] | None = None) -> int:
             args.state,
             initialize_state=args.initialize_state,
             reset_state=args.reset_state,
+            reset_and_fold_export=args.reset_and_fold_export,
         )
     except InvalidTelemetryError as exc:
         print(f"Telemetry build failed: {exc}", file=sys.stderr)

--- a/data/telemetry_incremental_state.py
+++ b/data/telemetry_incremental_state.py
@@ -32,6 +32,7 @@ from build_telemetry_data import (
     PREFERENCE_QUALITY_DECIMAL_PLACES,
     PREFERENCE_VERSION_OTHER_BUCKET,
     ROUND_TYPES,
+    TWO_ITEM_HERO_ROUNDS,
     InvalidTelemetryError,
     _MODEL_VERSION_RE,
     _PREFERENCE_MODEL_VERSION_RE,
@@ -61,7 +62,7 @@ SESSION_HLL_PRECISION = 10
 SESSION_HLL_REGISTER_COUNT = 1 << SESSION_HLL_PRECISION
 CALIBRATION_BIN_COUNT = 10
 MAX_STATE_FEATURES = 100_000
-INCREMENTAL_ARTIFACT_SCHEMA_VERSION = 4
+INCREMENTAL_ARTIFACT_SCHEMA_VERSION = 5
 INCREMENTAL_PREFERENCE_MODEL_VERSION_PREFIX = "preference-v2:"
 MODEL_VERSION_OTHER_BUCKET = "other"
 
@@ -385,7 +386,7 @@ def validate_state(
         round_event_total += count
         round_accepted_total += accepted
         round_type = ROUND_TYPES[number]
-        items_per_option = 2 if number == 7 else 3
+        items_per_option = 2 if number in TWO_ITEM_HERO_ROUNDS else 3
         expected_item_totals[round_type]["opportunities"] += count
         expected_item_totals[round_type]["offers"] += (
             count * items_per_option * 3
@@ -1320,7 +1321,7 @@ def _incremental_preference_artifact(
 
 
 def build_public_artifact(state: Mapping[str, Any]) -> dict[str, Any]:
-    """Render the cumulative schema-v4 artifact solely from checkpoint state."""
+    """Render the cumulative schema-v5 artifact solely from checkpoint state."""
     validate_state(state)
     aggregate = state_aggregate_snapshot(state)
     preference_model = _incremental_preference_artifact(state, aggregate)
@@ -1746,7 +1747,7 @@ def _validate_public_preference_model(
 
 
 def validate_public_artifact(artifact: Mapping[str, Any]) -> None:
-    """Validate the cumulative schema-v4 public checkpoint projection."""
+    """Validate the cumulative schema-v5 public checkpoint projection."""
     if (
         not isinstance(artifact, dict)
         or set(artifact)
@@ -1984,7 +1985,9 @@ def validate_public_artifact(artifact: Mapping[str, Any]) -> None:
             else "skills"
         )
         items_per_option = (
-            2 if round_row["round_number"] == 7 else 3
+            2
+            if round_row["round_number"] in TWO_ITEM_HERO_ROUNDS
+            else 3
         )
         expected_item_totals[family]["offers"] += (
             round_row["event_count"] * items_per_option * 3

--- a/data/telemetry_retention.py
+++ b/data/telemetry_retention.py
@@ -60,6 +60,8 @@ _ID_PRIMARY_KEY_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _QUOTED_IDENTIFIER_RE = re.compile(r'"([A-Za-z_][A-Za-z0-9_]*)"')
+_CURRENT_ROUND_CONSTRAINT = '"round_number" BETWEEN 1 AND 10'
+_LEGACY_ROUND_CONSTRAINT = '"round_number" BETWEEN 1 AND 8'
 
 
 class TelemetryRetentionError(ValueError):
@@ -333,6 +335,56 @@ def _validate_schema_compatibility(
     ):
         raise TelemetryRetentionError(
             "round_telemetry schema is incompatible with the migration"
+        )
+
+
+def _legacy_table_sql(canonical_table_sql: str) -> str:
+    if canonical_table_sql.count(_CURRENT_ROUND_CONSTRAINT) != 1:
+        raise TelemetryRetentionError(
+            "canonical telemetry schema does not contain the known "
+            "ten-round constraint"
+        )
+    return canonical_table_sql.replace(
+        _CURRENT_ROUND_CONSTRAINT,
+        _LEGACY_ROUND_CONSTRAINT,
+        1,
+    )
+
+
+def validate_reset_target(
+    snapshot: TableSnapshot,
+    canonical_table_sql: str,
+) -> str:
+    """Allow reset only for an exact known eight- or ten-round table."""
+    actual = _schema_comparison_key(snapshot.table_sql)
+    if actual == _schema_comparison_key(canonical_table_sql):
+        return "current-ten-round"
+    if actual == _schema_comparison_key(
+        _legacy_table_sql(canonical_table_sql)
+    ):
+        return "legacy-eight-round"
+    raise TelemetryRetentionError(
+        "round_telemetry reset target is not a known eight- or ten-round schema"
+    )
+
+
+def verify_reset_result(
+    snapshot: TableSnapshot,
+    canonical_table_sql: str,
+) -> None:
+    """Verify the reset installed the current schema and a safe sequence."""
+    _validate_schema_compatibility(snapshot.table_sql, canonical_table_sql)
+    if not schema_has_autoincrement(snapshot.table_sql):
+        raise TelemetryRetentionError(
+            "round_telemetry reset did not enable AUTOINCREMENT"
+        )
+    if snapshot.sequence_value is None:
+        raise TelemetryRetentionError(
+            "round_telemetry sqlite_sequence value is missing"
+        )
+    if snapshot.sequence_value < (snapshot.max_id or 0):
+        raise TelemetryRetentionError(
+            "round_telemetry sqlite_sequence is behind post-reset rows"
         )
 
 
@@ -634,6 +686,20 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     _add_canonical_argument(preflight)
 
+    reset_target = commands.add_parser(
+        "validate-reset-target",
+        help="validate a known eight- or ten-round table before reset",
+    )
+    reset_target.add_argument("metadata", type=Path)
+    _add_canonical_argument(reset_target)
+
+    reset_verify = commands.add_parser(
+        "verify-reset",
+        help="verify the current schema and sequence after an explicit reset",
+    )
+    reset_verify.add_argument("metadata", type=Path)
+    _add_canonical_argument(reset_verify)
+
     verify = commands.add_parser(
         "verify",
         help="verify AUTOINCREMENT, row preservation, and sqlite_sequence",
@@ -703,6 +769,30 @@ def main(argv: list[str] | None = None) -> int:
                 "Telemetry retention preflight passed; "
                 f"AUTOINCREMENT migration status: {decision.status}."
             )
+        elif args.command == "validate-reset-target":
+            snapshot = parse_table_snapshot(
+                load_json_document(
+                    args.metadata,
+                    "Wrangler reset-target metadata",
+                )
+            )
+            canonical = load_canonical_table_sql(args.canonical)
+            target_status = validate_reset_target(snapshot, canonical)
+            print(
+                "Telemetry reset target validation passed; "
+                f"schema status: {target_status}."
+            )
+        elif args.command == "verify-reset":
+            snapshot = parse_table_snapshot(
+                load_json_document(
+                    args.metadata,
+                    "Wrangler post-reset metadata",
+                ),
+                require_sequence=True,
+            )
+            canonical = load_canonical_table_sql(args.canonical)
+            verify_reset_result(snapshot, canonical)
+            print("Telemetry reset verification passed.")
         elif args.command == "verify":
             before = parse_table_snapshot(
                 load_json_document(

--- a/data/telemetry_state.json
+++ b/data/telemetry_state.json
@@ -1,736 +1,42 @@
 {
   "analytics": {
     "items": {
-      "hero": {
-        "乐进": {
-          "offer_count": 7,
-          "picked_count": 3
-        },
-        "于吉": {
-          "offer_count": 6,
-          "picked_count": 1
-        },
-        "于禁": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "关平": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "关羽": {
-          "offer_count": 12,
-          "picked_count": 6
-        },
-        "关银屏": {
-          "offer_count": 2,
-          "picked_count": 2
-        },
-        "凌统": {
-          "offer_count": 1,
-          "picked_count": 1
-        },
-        "刘备": {
-          "offer_count": 4,
-          "picked_count": 2
-        },
-        "刘禅": {
-          "offer_count": 3,
-          "picked_count": 1
-        },
-        "司马懿": {
-          "offer_count": 3,
-          "picked_count": 3
-        },
-        "吕布": {
-          "offer_count": 6,
-          "picked_count": 1
-        },
-        "吴国太": {
-          "offer_count": 5,
-          "picked_count": 1
-        },
-        "周仓": {
-          "offer_count": 1,
-          "picked_count": 1
-        },
-        "周泰": {
-          "offer_count": 6,
-          "picked_count": 2
-        },
-        "周瑜": {
-          "offer_count": 6,
-          "picked_count": 2
-        },
-        "夏侯惇": {
-          "offer_count": 12,
-          "picked_count": 3
-        },
-        "夏侯渊": {
-          "offer_count": 10,
-          "picked_count": 0
-        },
-        "大乔": {
-          "offer_count": 7,
-          "picked_count": 3
-        },
-        "姜维": {
-          "offer_count": 5,
-          "picked_count": 2
-        },
-        "孙权": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "孙策": {
-          "offer_count": 1,
-          "picked_count": 1
-        },
-        "孟获": {
-          "offer_count": 2,
-          "picked_count": 1
-        },
-        "小乔": {
-          "offer_count": 8,
-          "picked_count": 1
-        },
-        "左慈": {
-          "offer_count": 2,
-          "picked_count": 1
-        },
-        "庞德": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "庞统": {
-          "offer_count": 10,
-          "picked_count": 4
-        },
-        "张宁": {
-          "offer_count": 6,
-          "picked_count": 0
-        },
-        "张宝": {
-          "offer_count": 13,
-          "picked_count": 6
-        },
-        "张春华": {
-          "offer_count": 8,
-          "picked_count": 6
-        },
-        "张昭": {
-          "offer_count": 7,
-          "picked_count": 0
-        },
-        "张梁": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "张辽": {
-          "offer_count": 11,
-          "picked_count": 4
-        },
-        "张郃": {
-          "offer_count": 2,
-          "picked_count": 0
-        },
-        "张飞": {
-          "offer_count": 8,
-          "picked_count": 3
-        },
-        "徐盛": {
-          "offer_count": 7,
-          "picked_count": 2
-        },
-        "曹丕": {
-          "offer_count": 3,
-          "picked_count": 2
-        },
-        "曹仁": {
-          "offer_count": 9,
-          "picked_count": 2
-        },
-        "曹操": {
-          "offer_count": 4,
-          "picked_count": 2
-        },
-        "曹纯": {
-          "offer_count": 6,
-          "picked_count": 1
-        },
-        "木鹿大王": {
-          "offer_count": 3,
-          "picked_count": 2
-        },
-        "朱儁": {
-          "offer_count": 6,
-          "picked_count": 2
-        },
-        "李儒": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "步练师": {
-          "offer_count": 5,
-          "picked_count": 1
-        },
-        "法正": {
-          "offer_count": 9,
-          "picked_count": 6
-        },
-        "王双": {
-          "offer_count": 3,
-          "picked_count": 0
-        },
-        "王异": {
-          "offer_count": 5,
-          "picked_count": 1
-        },
-        "甄洛": {
-          "offer_count": 10,
-          "picked_count": 4
-        },
-        "甘夫人": {
-          "offer_count": 7,
-          "picked_count": 2
-        },
-        "田丰": {
-          "offer_count": 9,
-          "picked_count": 2
-        },
-        "皇甫嵩2": {
-          "offer_count": 4,
-          "picked_count": 3
-        },
-        "程昱": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "程普": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "荀彧": {
-          "offer_count": 9,
-          "picked_count": 3
-        },
-        "荀攸": {
-          "offer_count": 2,
-          "picked_count": 0
-        },
-        "董卓": {
-          "offer_count": 4,
-          "picked_count": 0
-        },
-        "蔡文姬": {
-          "offer_count": 15,
-          "picked_count": 1
-        },
-        "袁术": {
-          "offer_count": 9,
-          "picked_count": 4
-        },
-        "袁绍": {
-          "offer_count": 12,
-          "picked_count": 4
-        },
-        "诸葛亮": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "诸葛亮2": {
-          "offer_count": 1,
-          "picked_count": 1
-        },
-        "貂蝉": {
-          "offer_count": 7,
-          "picked_count": 2
-        },
-        "贾诩": {
-          "offer_count": 9,
-          "picked_count": 2
-        },
-        "赵云": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "邓艾": {
-          "offer_count": 6,
-          "picked_count": 3
-        },
-        "邹氏": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "郝昭": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "郭嘉": {
-          "offer_count": 4,
-          "picked_count": 0
-        },
-        "陆抗": {
-          "offer_count": 1,
-          "picked_count": 1
-        },
-        "陆逊": {
-          "offer_count": 3,
-          "picked_count": 3
-        },
-        "颜良": {
-          "offer_count": 1,
-          "picked_count": 1
-        },
-        "马云禄": {
-          "offer_count": 8,
-          "picked_count": 3
-        },
-        "马腾": {
-          "offer_count": 6,
-          "picked_count": 2
-        },
-        "马超": {
-          "offer_count": 6,
-          "picked_count": 3
-        },
-        "高顺": {
-          "offer_count": 7,
-          "picked_count": 2
-        },
-        "魏延": {
-          "offer_count": 2,
-          "picked_count": 1
-        },
-        "鲁肃": {
-          "offer_count": 8,
-          "picked_count": 2
-        },
-        "麋夫人": {
-          "offer_count": 2,
-          "picked_count": 0
-        },
-        "黄月英": {
-          "offer_count": 5,
-          "picked_count": 3
-        },
-        "黄盖": {
-          "offer_count": 8,
-          "picked_count": 3
-        }
-      },
-      "skill": {
-        "万军辟易": {
-          "offer_count": 3,
-          "picked_count": 0
-        },
-        "万夫莫当": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "三军夺气": {
-          "offer_count": 10,
-          "picked_count": 2
-        },
-        "上智为间": {
-          "offer_count": 8,
-          "picked_count": 3
-        },
-        "乘虚而入": {
-          "offer_count": 10,
-          "picked_count": 5
-        },
-        "乘间投隙": {
-          "offer_count": 1,
-          "picked_count": 1
-        },
-        "五雷轰顶": {
-          "offer_count": 11,
-          "picked_count": 3
-        },
-        "以静制动": {
-          "offer_count": 12,
-          "picked_count": 3
-        },
-        "任人择势": {
-          "offer_count": 2,
-          "picked_count": 1
-        },
-        "伏兵四起": {
-          "offer_count": 7,
-          "picked_count": 3
-        },
-        "兵贵神速": {
-          "offer_count": 6,
-          "picked_count": 1
-        },
-        "冲锐巧变": {
-          "offer_count": 12,
-          "picked_count": 4
-        },
-        "出其不意": {
-          "offer_count": 12,
-          "picked_count": 2
-        },
-        "势如破竹": {
-          "offer_count": 12,
-          "picked_count": 1
-        },
-        "勇冠三军": {
-          "offer_count": 2,
-          "picked_count": 0
-        },
-        "十面埋伏": {
-          "offer_count": 4,
-          "picked_count": 0
-        },
-        "千里突袭": {
-          "offer_count": 12,
-          "picked_count": 2
-        },
-        "及锋而试": {
-          "offer_count": 6,
-          "picked_count": 2
-        },
-        "同舟共济": {
-          "offer_count": 5,
-          "picked_count": 2
-        },
-        "固若金汤": {
-          "offer_count": 5,
-          "picked_count": 3
-        },
-        "坚如磐石": {
-          "offer_count": 7,
-          "picked_count": 2
-        },
-        "奇正相生": {
-          "offer_count": 10,
-          "picked_count": 4
-        },
-        "奇门遁甲": {
-          "offer_count": 7,
-          "picked_count": 1
-        },
-        "威名显赫": {
-          "offer_count": 11,
-          "picked_count": 2
-        },
-        "岿然不动": {
-          "offer_count": 7,
-          "picked_count": 3
-        },
-        "巧利天灾": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "御敌临前": {
-          "offer_count": 6,
-          "picked_count": 4
-        },
-        "忘私相助": {
-          "offer_count": 8,
-          "picked_count": 5
-        },
-        "恩威并行": {
-          "offer_count": 5,
-          "picked_count": 1
-        },
-        "惩前毖后": {
-          "offer_count": 14,
-          "picked_count": 6
-        },
-        "战八方": {
-          "offer_count": 11,
-          "picked_count": 3
-        },
-        "折冲御侮": {
-          "offer_count": 5,
-          "picked_count": 5
-        },
-        "披坚执锐": {
-          "offer_count": 6,
-          "picked_count": 4
-        },
-        "拔刀相向": {
-          "offer_count": 5,
-          "picked_count": 1
-        },
-        "指点乾坤": {
-          "offer_count": 14,
-          "picked_count": 7
-        },
-        "挫锐折锋": {
-          "offer_count": 12,
-          "picked_count": 5
-        },
-        "掠阵破军": {
-          "offer_count": 2,
-          "picked_count": 0
-        },
-        "摧坚克难": {
-          "offer_count": 9,
-          "picked_count": 5
-        },
-        "攻其不备": {
-          "offer_count": 9,
-          "picked_count": 2
-        },
-        "文武双全": {
-          "offer_count": 16,
-          "picked_count": 5
-        },
-        "文韬武略": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "料事如神": {
-          "offer_count": 9,
-          "picked_count": 4
-        },
-        "斩将夺旗": {
-          "offer_count": 11,
-          "picked_count": 2
-        },
-        "断戈夺锋": {
-          "offer_count": 8,
-          "picked_count": 1
-        },
-        "断敌粮道": {
-          "offer_count": 12,
-          "picked_count": 8
-        },
-        "无难之志": {
-          "offer_count": 19,
-          "picked_count": 2
-        },
-        "明其虚实": {
-          "offer_count": 8,
-          "picked_count": 5
-        },
-        "智破千军": {
-          "offer_count": 7,
-          "picked_count": 1
-        },
-        "未雨绸缪": {
-          "offer_count": 9,
-          "picked_count": 2
-        },
-        "机变无穷": {
-          "offer_count": 5,
-          "picked_count": 2
-        },
-        "横征暴敛": {
-          "offer_count": 15,
-          "picked_count": 7
-        },
-        "横扫千军": {
-          "offer_count": 10,
-          "picked_count": 3
-        },
-        "步步为营": {
-          "offer_count": 13,
-          "picked_count": 6
-        },
-        "水淹七军": {
-          "offer_count": 14,
-          "picked_count": 3
-        },
-        "洗筋伐髓": {
-          "offer_count": 12,
-          "picked_count": 2
-        },
-        "洞若观火": {
-          "offer_count": 3,
-          "picked_count": 0
-        },
-        "清风驱疾": {
-          "offer_count": 6,
-          "picked_count": 4
-        },
-        "潜师袭远": {
-          "offer_count": 4,
-          "picked_count": 1
-        },
-        "潜龙在渊": {
-          "offer_count": 5,
-          "picked_count": 1
-        },
-        "烈火张天": {
-          "offer_count": 6,
-          "picked_count": 0
-        },
-        "烈火焚营": {
-          "offer_count": 8,
-          "picked_count": 1
-        },
-        "狂风大作": {
-          "offer_count": 10,
-          "picked_count": 0
-        },
-        "王佐之才": {
-          "offer_count": 10,
-          "picked_count": 2
-        },
-        "百战不殆": {
-          "offer_count": 9,
-          "picked_count": 4
-        },
-        "睿虑合图": {
-          "offer_count": 2,
-          "picked_count": 0
-        },
-        "瞋目横矛": {
-          "offer_count": 5,
-          "picked_count": 1
-        },
-        "知人善任": {
-          "offer_count": 14,
-          "picked_count": 6
-        },
-        "破军袭敌": {
-          "offer_count": 14,
-          "picked_count": 4
-        },
-        "破阵驰围": {
-          "offer_count": 5,
-          "picked_count": 1
-        },
-        "神略制变": {
-          "offer_count": 9,
-          "picked_count": 3
-        },
-        "空城计": {
-          "offer_count": 6,
-          "picked_count": 4
-        },
-        "经天纬地": {
-          "offer_count": 8,
-          "picked_count": 2
-        },
-        "胜敌益强": {
-          "offer_count": 11,
-          "picked_count": 5
-        },
-        "舍生取义": {
-          "offer_count": 10,
-          "picked_count": 2
-        },
-        "蓄势待发": {
-          "offer_count": 10,
-          "picked_count": 6
-        },
-        "虎步连环": {
-          "offer_count": 3,
-          "picked_count": 0
-        },
-        "计袭粮仓": {
-          "offer_count": 2,
-          "picked_count": 0
-        },
-        "诱敌深入": {
-          "offer_count": 5,
-          "picked_count": 0
-        },
-        "调和阴阳": {
-          "offer_count": 3,
-          "picked_count": 2
-        },
-        "谋而后动": {
-          "offer_count": 10,
-          "picked_count": 6
-        },
-        "趁火打劫": {
-          "offer_count": 3,
-          "picked_count": 0
-        },
-        "践墨随敌": {
-          "offer_count": 4,
-          "picked_count": 2
-        },
-        "蹈锋饮血": {
-          "offer_count": 9,
-          "picked_count": 6
-        },
-        "轻装驰援": {
-          "offer_count": 11,
-          "picked_count": 3
-        },
-        "运智铺谋": {
-          "offer_count": 8,
-          "picked_count": 4
-        },
-        "运筹帷幄": {
-          "offer_count": 7,
-          "picked_count": 4
-        },
-        "金城汤池": {
-          "offer_count": 7,
-          "picked_count": 2
-        },
-        "铁骑横冲": {
-          "offer_count": 8,
-          "picked_count": 1
-        },
-        "锐不可当": {
-          "offer_count": 8,
-          "picked_count": 5
-        },
-        "青囊急救": {
-          "offer_count": 8,
-          "picked_count": 3
-        },
-        "韬光养晦": {
-          "offer_count": 10,
-          "picked_count": 3
-        },
-        "风助火势": {
-          "offer_count": 7,
-          "picked_count": 1
-        },
-        "风卷残云": {
-          "offer_count": 1,
-          "picked_count": 0
-        },
-        "黄天惑心": {
-          "offer_count": 10,
-          "picked_count": 6
-        }
-      }
+      "hero": {},
+      "skill": {}
     },
     "opportunity_counts": {
-      "hero": 47,
-      "skill": 82
+      "hero": 0,
+      "skill": 0
     },
     "score_margins": {
       "0_to_1": {
-        "event_count": 15,
-        "recommendation_accepted_count": 11
+        "event_count": 0,
+        "recommendation_accepted_count": 0
       },
       "1_to_3": {
-        "event_count": 19,
-        "recommendation_accepted_count": 16
+        "event_count": 0,
+        "recommendation_accepted_count": 0
       },
       "over_3": {
-        "event_count": 94,
-        "recommendation_accepted_count": 88
+        "event_count": 0,
+        "recommendation_accepted_count": 0
       },
       "tie": {
-        "event_count": 1,
+        "event_count": 0,
         "recommendation_accepted_count": 0
       }
     }
   },
   "catalog_version": "975e9b7727fc",
   "cursor": {
-    "last_processed_id": 130
+    "last_processed_id": 0
   },
   "preference_model": {
     "algorithm": "ftrl-proximal",
     "alpha": 0.1,
     "beta": 1.0,
     "evaluation": {
-      "brier_sum": 17.703000090663494,
+      "brier_sum": 0.0,
       "calibration_bins": [
         {
           "confidence_sum": 0.0,
@@ -748,24 +54,24 @@
           "outcome_sum": 0.0
         },
         {
-          "confidence_sum": 12.311487693661576,
-          "count": 34,
-          "outcome_sum": 24.0
+          "confidence_sum": 0.0,
+          "count": 0,
+          "outcome_sum": 0.0
         },
         {
-          "confidence_sum": 16.15363273529434,
-          "count": 36,
-          "outcome_sum": 27.0
+          "confidence_sum": 0.0,
+          "count": 0,
+          "outcome_sum": 0.0
         },
         {
-          "confidence_sum": 11.876821938744726,
-          "count": 22,
-          "outcome_sum": 21.0
+          "confidence_sum": 0.0,
+          "count": 0,
+          "outcome_sum": 0.0
         },
         {
-          "confidence_sum": 12.202333880445725,
-          "count": 19,
-          "outcome_sum": 19.0
+          "confidence_sum": 0.0,
+          "count": 0,
+          "outcome_sum": 0.0
         },
         {
           "confidence_sum": 0.0,
@@ -783,331 +89,199 @@
           "outcome_sum": 0.0
         }
       ],
-      "correct_count": 99,
-      "event_count": 120,
-      "log_loss_sum": 94.31862987512108,
-      "paired_correct_count": 106
+      "correct_count": 0,
+      "event_count": 0,
+      "log_loss_sum": 0.0,
+      "paired_correct_count": 0
     },
     "l1": 0.0,
     "l2": 0.05,
     "minimum_persisted_event_support": 10,
-    "n": {
-      "[\"item\",\"hero\",\"关羽\"]": 2.4046799711310554,
-      "[\"item\",\"hero\",\"夏侯惇\"]": 1.7439355735695992,
-      "[\"item\",\"hero\",\"庞统\"]": 1.3192005411356509,
-      "[\"item\",\"hero\",\"张宝\"]": 2.733015643046142,
-      "[\"item\",\"hero\",\"张辽\"]": 1.8847894586874117,
-      "[\"item\",\"hero\",\"甄洛\"]": 1.5199971534551706,
-      "[\"item\",\"hero\",\"蔡文姬\"]": 0.910447658817404,
-      "[\"item\",\"hero\",\"袁绍\"]": 1.2711611364679918,
-      "[\"item\",\"skill\",\"乘虚而入\"]": 1.6207360073622836,
-      "[\"item\",\"skill\",\"五雷轰顶\"]": 1.2513356564980869,
-      "[\"item\",\"skill\",\"以静制动\"]": 1.787444233869051,
-      "[\"item\",\"skill\",\"冲锐巧变\"]": 1.8610127651479005,
-      "[\"item\",\"skill\",\"出其不意\"]": 1.4312732890222,
-      "[\"item\",\"skill\",\"势如破竹\"]": 1.4855068774848654,
-      "[\"item\",\"skill\",\"千里突袭\"]": 1.2834360056317105,
-      "[\"item\",\"skill\",\"奇正相生\"]": 1.8427758038459456,
-      "[\"item\",\"skill\",\"威名显赫\"]": 0.801585525241072,
-      "[\"item\",\"skill\",\"惩前毖后\"]": 2.081777205778533,
-      "[\"item\",\"skill\",\"战八方\"]": 1.0218405920692328,
-      "[\"item\",\"skill\",\"指点乾坤\"]": 2.511093050337291,
-      "[\"item\",\"skill\",\"挫锐折锋\"]": 1.5355197335555621,
-      "[\"item\",\"skill\",\"文武双全\"]": 2.0268197986013208,
-      "[\"item\",\"skill\",\"斩将夺旗\"]": 1.1469823795868155,
-      "[\"item\",\"skill\",\"断敌粮道\"]": 2.979794743994634,
-      "[\"item\",\"skill\",\"无难之志\"]": 1.565622500202128,
-      "[\"item\",\"skill\",\"横征暴敛\"]": 2.4906669250021363,
-      "[\"item\",\"skill\",\"横扫千军\"]": 1.460017998288361,
-      "[\"item\",\"skill\",\"步步为营\"]": 2.4035348860057395,
-      "[\"item\",\"skill\",\"水淹七军\"]": 1.7126043284179273,
-      "[\"item\",\"skill\",\"洗筋伐髓\"]": 1.1624305522213039,
-      "[\"item\",\"skill\",\"王佐之才\"]": 1.1679222358934576,
-      "[\"item\",\"skill\",\"知人善任\"]": 2.4076704739167076,
-      "[\"item\",\"skill\",\"破军袭敌\"]": 2.0150524746403295,
-      "[\"item\",\"skill\",\"胜敌益强\"]": 1.568940421866296,
-      "[\"item\",\"skill\",\"舍生取义\"]": 1.1436935496020055,
-      "[\"item\",\"skill\",\"蓄势待发\"]": 2.5300896508297654,
-      "[\"item\",\"skill\",\"谋而后动\"]": 1.5150825159303096,
-      "[\"item\",\"skill\",\"轻装驰援\"]": 1.268982216626782,
-      "[\"item\",\"skill\",\"韬光养晦\"]": 1.2241698207647744,
-      "[\"item\",\"skill\",\"黄天惑心\"]": 2.2568909726992885,
-      "[\"pool_item\",\"skill\",\"上兵伐谋\",\"skill\",\"无难之志\"]": 0.9367464650821932,
-      "[\"pool_item\",\"skill\",\"穷追不舍\",\"skill\",\"惩前毖后\"]": 1.3450281648470583,
-      "[\"pool_item\",\"skill\",\"穷追不舍\",\"skill\",\"破军袭敌\"]": 0.9960918776536455,
-      "[\"pool_item\",\"skill\",\"避其锐气\",\"skill\",\"无难之志\"]": 0.7702648177192093,
-      "[\"pool_item\",\"skill\",\"铸甲销戈\",\"skill\",\"势如破竹\"]": 0.9370770785436621,
-      "[\"position\",0]": 19.299964934734877,
-      "[\"position\",1]": 16.865072533604856,
-      "[\"position\",2]": 16.943962803650727,
-      "[\"round_score\",1]": 10.801484512271088,
-      "[\"round_score\",2]": 4.522390857555802,
-      "[\"round_score\",3]": 2.9785281910734227,
-      "[\"round_score\",4]": 7.235012983970815,
-      "[\"round_score\",5]": 2.6964203633243913,
-      "[\"round_score\",6]": 3.3364636433344494,
-      "[\"score\"]": 31.90139636285307
-    },
+    "n": {},
     "score_feature_limit": 10.0,
-    "support": {
-      "[\"item\",\"hero\",\"关羽\"]": 11,
-      "[\"item\",\"hero\",\"夏侯惇\"]": 11,
-      "[\"item\",\"hero\",\"庞统\"]": 10,
-      "[\"item\",\"hero\",\"张宝\"]": 12,
-      "[\"item\",\"hero\",\"张辽\"]": 11,
-      "[\"item\",\"hero\",\"甄洛\"]": 10,
-      "[\"item\",\"hero\",\"蔡文姬\"]": 12,
-      "[\"item\",\"hero\",\"袁绍\"]": 11,
-      "[\"item\",\"skill\",\"乘虚而入\"]": 10,
-      "[\"item\",\"skill\",\"五雷轰顶\"]": 10,
-      "[\"item\",\"skill\",\"以静制动\"]": 12,
-      "[\"item\",\"skill\",\"冲锐巧变\"]": 11,
-      "[\"item\",\"skill\",\"出其不意\"]": 12,
-      "[\"item\",\"skill\",\"势如破竹\"]": 12,
-      "[\"item\",\"skill\",\"千里突袭\"]": 12,
-      "[\"item\",\"skill\",\"奇正相生\"]": 10,
-      "[\"item\",\"skill\",\"威名显赫\"]": 11,
-      "[\"item\",\"skill\",\"惩前毖后\"]": 14,
-      "[\"item\",\"skill\",\"战八方\"]": 10,
-      "[\"item\",\"skill\",\"指点乾坤\"]": 14,
-      "[\"item\",\"skill\",\"挫锐折锋\"]": 12,
-      "[\"item\",\"skill\",\"文武双全\"]": 16,
-      "[\"item\",\"skill\",\"斩将夺旗\"]": 11,
-      "[\"item\",\"skill\",\"断敌粮道\"]": 12,
-      "[\"item\",\"skill\",\"无难之志\"]": 17,
-      "[\"item\",\"skill\",\"横征暴敛\"]": 14,
-      "[\"item\",\"skill\",\"横扫千军\"]": 10,
-      "[\"item\",\"skill\",\"步步为营\"]": 13,
-      "[\"item\",\"skill\",\"水淹七军\"]": 14,
-      "[\"item\",\"skill\",\"洗筋伐髓\"]": 11,
-      "[\"item\",\"skill\",\"王佐之才\"]": 10,
-      "[\"item\",\"skill\",\"知人善任\"]": 13,
-      "[\"item\",\"skill\",\"破军袭敌\"]": 14,
-      "[\"item\",\"skill\",\"胜敌益强\"]": 11,
-      "[\"item\",\"skill\",\"舍生取义\"]": 10,
-      "[\"item\",\"skill\",\"蓄势待发\"]": 10,
-      "[\"item\",\"skill\",\"谋而后动\"]": 10,
-      "[\"item\",\"skill\",\"轻装驰援\"]": 11,
-      "[\"item\",\"skill\",\"韬光养晦\"]": 10,
-      "[\"item\",\"skill\",\"黄天惑心\"]": 10,
-      "[\"pool_item\",\"skill\",\"上兵伐谋\",\"skill\",\"无难之志\"]": 10,
-      "[\"pool_item\",\"skill\",\"穷追不舍\",\"skill\",\"惩前毖后\"]": 10,
-      "[\"pool_item\",\"skill\",\"穷追不舍\",\"skill\",\"破军袭敌\"]": 10,
-      "[\"pool_item\",\"skill\",\"避其锐气\",\"skill\",\"无难之志\"]": 10,
-      "[\"pool_item\",\"skill\",\"铸甲销戈\",\"skill\",\"势如破竹\"]": 10,
-      "[\"position\",0]": 120,
-      "[\"position\",1]": 120,
-      "[\"position\",2]": 120,
-      "[\"round_score\",1]": 63,
-      "[\"round_score\",2]": 63,
-      "[\"round_score\",3]": 57,
-      "[\"round_score\",4]": 57,
-      "[\"round_score\",5]": 57,
-      "[\"round_score\",6]": 57,
-      "[\"score\"]": 360
-    },
-    "update_count": 129,
-    "z": {
-      "[\"item\",\"hero\",\"关羽\"]": -2.3337798725007306,
-      "[\"item\",\"hero\",\"夏侯惇\"]": 1.0999256698375475,
-      "[\"item\",\"hero\",\"庞统\"]": 0.4565091057214302,
-      "[\"item\",\"hero\",\"张宝\"]": -0.17360161522529127,
-      "[\"item\",\"hero\",\"张辽\"]": 0.1944245159222074,
-      "[\"item\",\"hero\",\"甄洛\"]": -0.9080972315096372,
-      "[\"item\",\"hero\",\"蔡文姬\"]": 2.141612348419595,
-      "[\"item\",\"hero\",\"袁绍\"]": 0.6365960237337724,
-      "[\"item\",\"skill\",\"乘虚而入\"]": -1.250324114472811,
-      "[\"item\",\"skill\",\"五雷轰顶\"]": 2.0051135628557404,
-      "[\"item\",\"skill\",\"以静制动\"]": 0.9142914307220893,
-      "[\"item\",\"skill\",\"冲锐巧变\"]": 0.01728423364909081,
-      "[\"item\",\"skill\",\"出其不意\"]": 1.4262280278606947,
-      "[\"item\",\"skill\",\"势如破竹\"]": 3.1801616533484336,
-      "[\"item\",\"skill\",\"千里突袭\"]": 1.456718372141151,
-      "[\"item\",\"skill\",\"奇正相生\"]": -1.0849246075827483,
-      "[\"item\",\"skill\",\"威名显赫\"]": 2.058512678150004,
-      "[\"item\",\"skill\",\"惩前毖后\"]": -0.9112954293958817,
-      "[\"item\",\"skill\",\"战八方\"]": 1.9229822533259309,
-      "[\"item\",\"skill\",\"指点乾坤\"]": -2.5110101608398416,
-      "[\"item\",\"skill\",\"挫锐折锋\"]": 0.08197327042063338,
-      "[\"item\",\"skill\",\"文武双全\"]": 1.0200728980581757,
-      "[\"item\",\"skill\",\"斩将夺旗\"]": 1.2308272686455484,
-      "[\"item\",\"skill\",\"断敌粮道\"]": -4.452188947497857,
-      "[\"item\",\"skill\",\"无难之志\"]": 4.794385640448437,
-      "[\"item\",\"skill\",\"横征暴敛\"]": -1.5077147261416937,
-      "[\"item\",\"skill\",\"横扫千军\"]": 0.330641678661655,
-      "[\"item\",\"skill\",\"步步为营\"]": -1.414635449896474,
-      "[\"item\",\"skill\",\"水淹七军\"]": 1.8825300758117423,
-      "[\"item\",\"skill\",\"洗筋伐髓\"]": 2.129566752540859,
-      "[\"item\",\"skill\",\"王佐之才\"]": 0.5780036237008881,
-      "[\"item\",\"skill\",\"知人善任\"]": -1.2838757084623036,
-      "[\"item\",\"skill\",\"破军袭敌\"]": 0.834796376066118,
-      "[\"item\",\"skill\",\"胜敌益强\"]": -0.14366878930321014,
-      "[\"item\",\"skill\",\"舍生取义\"]": 1.166369797026882,
-      "[\"item\",\"skill\",\"蓄势待发\"]": -2.7459570974938172,
-      "[\"item\",\"skill\",\"谋而后动\"]": -2.286753785770771,
-      "[\"item\",\"skill\",\"轻装驰援\"]": 0.6377205523157017,
-      "[\"item\",\"skill\",\"韬光养晦\"]": 1.1538261996103791,
-      "[\"item\",\"skill\",\"黄天惑心\"]": -2.9559742134269156,
-      "[\"pool_item\",\"skill\",\"上兵伐谋\",\"skill\",\"无难之志\"]": 2.124583228638429,
-      "[\"pool_item\",\"skill\",\"穷追不舍\",\"skill\",\"惩前毖后\"]": 0.2109411922403545,
-      "[\"pool_item\",\"skill\",\"穷追不舍\",\"skill\",\"破军袭敌\"]": 1.4662119999550705,
-      "[\"pool_item\",\"skill\",\"避其锐气\",\"skill\",\"无难之志\"]": 3.029943549482597,
-      "[\"pool_item\",\"skill\",\"铸甲销戈\",\"skill\",\"势如破竹\"]": 3.4431155696871203,
-      "[\"position\",0]": -4.542252577485055,
-      "[\"position\",1]": 1.2867908763131337,
-      "[\"position\",2]": 4.8892197217225375,
-      "[\"round_score\",1]": -9.341503914525711,
-      "[\"round_score\",2]": -8.733714582461182,
-      "[\"round_score\",3]": -8.371310975966903,
-      "[\"round_score\",4]": -10.667070731577528,
-      "[\"round_score\",5]": -7.733949621455181,
-      "[\"round_score\",6]": -8.847488378508135,
-      "[\"score\"]": -62.89558111798708
-    }
+    "support": {},
+    "update_count": 0,
+    "z": {}
   },
   "rounds": {
     "1": {
       "chosen_position_counts": [
-        7,
-        9,
-        8
+        0,
+        0,
+        0
       ],
-      "event_count": 24,
-      "meaningful_preference_disagreement_count": 0,
-      "meaningful_preference_disagreement_margin_total": 0.0,
-      "player_preference_agreement_count": 13,
-      "preference_top_disagreement_count": 4,
-      "recommendation_accepted_count": 19,
-      "recommended_position_counts": [
-        8,
-        8,
-        8
-      ]
-    },
-    "2": {
-      "chosen_position_counts": [
-        11,
-        6,
-        5
-      ],
-      "event_count": 22,
-      "meaningful_preference_disagreement_count": 0,
-      "meaningful_preference_disagreement_margin_total": 0.0,
-      "player_preference_agreement_count": 16,
-      "preference_top_disagreement_count": 3,
-      "recommendation_accepted_count": 19,
-      "recommended_position_counts": [
-        11,
-        5,
-        6
-      ]
-    },
-    "3": {
-      "chosen_position_counts": [
-        8,
-        5,
-        6
-      ],
-      "event_count": 19,
-      "meaningful_preference_disagreement_count": 0,
-      "meaningful_preference_disagreement_margin_total": 0.0,
-      "player_preference_agreement_count": 15,
-      "preference_top_disagreement_count": 1,
-      "recommendation_accepted_count": 16,
-      "recommended_position_counts": [
-        8,
-        6,
-        5
-      ]
-    },
-    "4": {
-      "chosen_position_counts": [
-        9,
-        6,
-        4
-      ],
-      "event_count": 19,
-      "meaningful_preference_disagreement_count": 0,
-      "meaningful_preference_disagreement_margin_total": 0.0,
-      "player_preference_agreement_count": 18,
-      "preference_top_disagreement_count": 0,
-      "recommendation_accepted_count": 18,
-      "recommended_position_counts": [
-        8,
-        7,
-        4
-      ]
-    },
-    "5": {
-      "chosen_position_counts": [
-        8,
-        7,
-        4
-      ],
-      "event_count": 19,
-      "meaningful_preference_disagreement_count": 1,
-      "meaningful_preference_disagreement_margin_total": 0.14500000000000002,
-      "player_preference_agreement_count": 17,
-      "preference_top_disagreement_count": 2,
-      "recommendation_accepted_count": 17,
-      "recommended_position_counts": [
-        7,
-        6,
-        6
-      ]
-    },
-    "6": {
-      "chosen_position_counts": [
-        6,
-        6,
-        7
-      ],
-      "event_count": 19,
-      "meaningful_preference_disagreement_count": 0,
-      "meaningful_preference_disagreement_margin_total": 0.0,
-      "player_preference_agreement_count": 17,
-      "preference_top_disagreement_count": 2,
-      "recommendation_accepted_count": 19,
-      "recommended_position_counts": [
-        6,
-        6,
-        7
-      ]
-    },
-    "7": {
-      "chosen_position_counts": [
-        2,
-        1,
-        1
-      ],
-      "event_count": 4,
+      "event_count": 0,
       "meaningful_preference_disagreement_count": 0,
       "meaningful_preference_disagreement_margin_total": 0.0,
       "player_preference_agreement_count": 0,
       "preference_top_disagreement_count": 0,
-      "recommendation_accepted_count": 4,
+      "recommendation_accepted_count": 0,
       "recommended_position_counts": [
-        2,
-        1,
-        1
+        0,
+        0,
+        0
+      ]
+    },
+    "10": {
+      "chosen_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "event_count": 0,
+      "meaningful_preference_disagreement_count": 0,
+      "meaningful_preference_disagreement_margin_total": 0.0,
+      "player_preference_agreement_count": 0,
+      "preference_top_disagreement_count": 0,
+      "recommendation_accepted_count": 0,
+      "recommended_position_counts": [
+        0,
+        0,
+        0
+      ]
+    },
+    "2": {
+      "chosen_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "event_count": 0,
+      "meaningful_preference_disagreement_count": 0,
+      "meaningful_preference_disagreement_margin_total": 0.0,
+      "player_preference_agreement_count": 0,
+      "preference_top_disagreement_count": 0,
+      "recommendation_accepted_count": 0,
+      "recommended_position_counts": [
+        0,
+        0,
+        0
+      ]
+    },
+    "3": {
+      "chosen_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "event_count": 0,
+      "meaningful_preference_disagreement_count": 0,
+      "meaningful_preference_disagreement_margin_total": 0.0,
+      "player_preference_agreement_count": 0,
+      "preference_top_disagreement_count": 0,
+      "recommendation_accepted_count": 0,
+      "recommended_position_counts": [
+        0,
+        0,
+        0
+      ]
+    },
+    "4": {
+      "chosen_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "event_count": 0,
+      "meaningful_preference_disagreement_count": 0,
+      "meaningful_preference_disagreement_margin_total": 0.0,
+      "player_preference_agreement_count": 0,
+      "preference_top_disagreement_count": 0,
+      "recommendation_accepted_count": 0,
+      "recommended_position_counts": [
+        0,
+        0,
+        0
+      ]
+    },
+    "5": {
+      "chosen_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "event_count": 0,
+      "meaningful_preference_disagreement_count": 0,
+      "meaningful_preference_disagreement_margin_total": 0.0,
+      "player_preference_agreement_count": 0,
+      "preference_top_disagreement_count": 0,
+      "recommendation_accepted_count": 0,
+      "recommended_position_counts": [
+        0,
+        0,
+        0
+      ]
+    },
+    "6": {
+      "chosen_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "event_count": 0,
+      "meaningful_preference_disagreement_count": 0,
+      "meaningful_preference_disagreement_margin_total": 0.0,
+      "player_preference_agreement_count": 0,
+      "preference_top_disagreement_count": 0,
+      "recommendation_accepted_count": 0,
+      "recommended_position_counts": [
+        0,
+        0,
+        0
+      ]
+    },
+    "7": {
+      "chosen_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "event_count": 0,
+      "meaningful_preference_disagreement_count": 0,
+      "meaningful_preference_disagreement_margin_total": 0.0,
+      "player_preference_agreement_count": 0,
+      "preference_top_disagreement_count": 0,
+      "recommendation_accepted_count": 0,
+      "recommended_position_counts": [
+        0,
+        0,
+        0
       ]
     },
     "8": {
       "chosen_position_counts": [
         0,
-        2,
-        1
+        0,
+        0
       ],
-      "event_count": 3,
+      "event_count": 0,
       "meaningful_preference_disagreement_count": 0,
       "meaningful_preference_disagreement_margin_total": 0.0,
       "player_preference_agreement_count": 0,
       "preference_top_disagreement_count": 0,
-      "recommendation_accepted_count": 3,
+      "recommendation_accepted_count": 0,
       "recommended_position_counts": [
         0,
-        2,
-        1
+        0,
+        0
+      ]
+    },
+    "9": {
+      "chosen_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "event_count": 0,
+      "meaningful_preference_disagreement_count": 0,
+      "meaningful_preference_disagreement_margin_total": 0.0,
+      "player_preference_agreement_count": 0,
+      "preference_top_disagreement_count": 0,
+      "recommendation_accepted_count": 0,
+      "recommended_position_counts": [
+        0,
+        0,
+        0
       ]
     }
   },
@@ -1119,18 +293,15 @@
     "version": 1
   },
   "summary": {
-    "event_count": 129,
-    "invalid_event_count": 1,
-    "model_version_counts": {
-      "2:5595010354864ec9": 129
-    },
+    "event_count": 0,
+    "invalid_event_count": 0,
+    "model_version_counts": {},
     "preference_event_count": 0,
     "preference_model_version_counts": {},
-    "recommendation_accepted_count": 115,
+    "recommendation_accepted_count": 0,
     "session_hll": {
       "precision": 10,
       "registers": [
-        2,
         0,
         0,
         0,
@@ -1144,7 +315,6 @@
         0,
         0,
         0,
-        4,
         0,
         0,
         0,
@@ -1154,7 +324,6 @@
         0,
         0,
         0,
-        1,
         0,
         0,
         0,
@@ -1219,11 +388,9 @@
         0,
         0,
         0,
-        1,
         0,
         0,
         0,
-        1,
         0,
         0,
         0,
@@ -1267,7 +434,6 @@
         0,
         0,
         0,
-        2,
         0,
         0,
         0,
@@ -1300,7 +466,6 @@
         0,
         0,
         0,
-        4,
         0,
         0,
         0,
@@ -1413,7 +578,6 @@
         0,
         0,
         0,
-        2,
         0,
         0,
         0,
@@ -1485,8 +649,6 @@
         0,
         0,
         0,
-        2,
-        2,
         0,
         0,
         0,
@@ -1512,7 +674,6 @@
         0,
         0,
         0,
-        2,
         0,
         0,
         0,
@@ -1532,7 +693,6 @@
         0,
         0,
         0,
-        2,
         0,
         0,
         0,
@@ -1577,7 +737,6 @@
         0,
         0,
         0,
-        6,
         0,
         0,
         0,
@@ -1592,7 +751,6 @@
         0,
         0,
         0,
-        4,
         0,
         0,
         0,
@@ -1600,19 +758,16 @@
         0,
         0,
         0,
-        1,
         0,
         0,
         0,
         0,
         0,
         0,
-        4,
         0,
         0,
         0,
         0,
-        2,
         0,
         0,
         0,
@@ -1634,7 +789,6 @@
         0,
         0,
         0,
-        1,
         0,
         0,
         0,
@@ -1664,7 +818,6 @@
         0,
         0,
         0,
-        2,
         0,
         0,
         0,
@@ -1723,9 +876,7 @@
         0,
         0,
         0,
-        1,
         0,
-        1,
         0,
         0,
         0,
@@ -1789,7 +940,6 @@
         0,
         0,
         0,
-        1,
         0,
         0,
         0,
@@ -1826,7 +976,6 @@
         0,
         0,
         0,
-        1,
         0,
         0,
         0,
@@ -1850,7 +999,6 @@
         0,
         0,
         0,
-        6,
         0,
         0,
         0,
@@ -2063,12 +1211,10 @@
         0,
         0,
         0,
-        2,
         0,
         0,
         0,
         0,
-        2,
         0,
         0,
         0,
@@ -2098,7 +1244,6 @@
         0,
         0,
         0,
-        3,
         0,
         0,
         0,
@@ -2116,7 +1261,6 @@
         0,
         0,
         0,
-        1,
         0,
         0,
         0,
@@ -2129,7 +1273,35 @@
         0,
         0,
         0,
-        2,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
         0,
         0,
         0,

--- a/data/test_build_telemetry_data.py
+++ b/data/test_build_telemetry_data.py
@@ -19,6 +19,8 @@ from build_telemetry_data import (  # noqa: E402
     MAX_PREFERENCE_FEATURES,
     PREFERENCE_QUALITY_DECIMAL_PLACES,
     PREFERENCE_VERSION_OTHER_BUCKET,
+    ROUND_TYPES,
+    TWO_ITEM_HERO_ROUNDS,
     _build_preference_model,
     _published_preference_version_counts,
     _quantize_preference_probabilities,
@@ -143,10 +145,10 @@ def _event(
     chosen_index: int = 0,
     model_version: str = MODEL_VERSION,
 ) -> tuple:
-    round_type = "hero" if round_number in (1, 4, 7) else "skill"
+    round_type = ROUND_TYPES.get(round_number, "skill")
     offered_sets = (
         [["A", "B"], ["C", "D"], ["E", "F"]]
-        if round_number == 7
+        if round_number in TWO_ITEM_HERO_ROUNDS
         else [["A", "B", "C"], ["D", "E", "F"], ["G", "H", "I"]]
         if round_type == "hero"
         else [["a", "b", "c"], ["d", "e", "f"], ["g", "h", "i"]]
@@ -163,7 +165,11 @@ def _event(
         catalog_version,
         json.dumps({"heroes": ["J"], "skills": ["j"]}),
         json.dumps(offered_sets),
-        json.dumps([3.0, 2.0, 0.0] if round_number == 7 else [3.0, 2.0, 1.0]),
+        json.dumps(
+            [3.0, 2.0, 0.0]
+            if round_number in TWO_ITEM_HERO_ROUNDS
+            else [3.0, 2.0, 1.0]
+        ),
         0,
         chosen_index,
         None,
@@ -296,7 +302,44 @@ class TelemetryBuilderTests(unittest.TestCase):
         _write_export(self.export_path, [])
         artifact = self._build()
         self.assertEqual(artifact["summary"]["event_count"], 0)
-        self.assertEqual([row["round_number"] for row in artifact["rounds"]], list(range(1, 9)))
+        self.assertEqual(
+            [row["round_number"] for row in artifact["rounds"]],
+            list(range(1, 9)),
+        )
+
+    def test_legacy_full_export_rejects_rounds_nine_and_ten(self) -> None:
+        _write_export(
+            self.export_path,
+            [
+                _event(self.catalog_version, suffix=9, round_number=9),
+                _event(self.catalog_version, suffix=10, round_number=10),
+            ],
+        )
+
+        with self.assertRaisesRegex(
+            InvalidTelemetryError,
+            "schema-v3 full-export builds support rounds 1-8 only",
+        ):
+            self._build()
+        self.assertFalse(self.output_path.exists())
+
+    def test_legacy_full_export_accepts_known_eight_round_schema(self) -> None:
+        legacy_schema = MIGRATION.read_text(encoding="utf-8").replace(
+            '"round_number" BETWEEN 1 AND 10',
+            '"round_number" BETWEEN 1 AND 8',
+            1,
+        )
+        _write_export(
+            self.export_path,
+            [_event(self.catalog_version, suffix=8, round_number=8)],
+            legacy_schema,
+        )
+
+        artifact = self._build()
+
+        self.assertEqual(artifact["schema"]["version"], 3)
+        self.assertEqual(artifact["summary"]["event_count"], 1)
+        self.assertEqual(artifact["rounds"][7]["event_count"], 1)
 
     def test_schema_metadata_and_constraints_must_match_migration(self) -> None:
         canonical = MIGRATION.read_text(encoding="utf-8")
@@ -315,8 +358,8 @@ class TelemetryBuilderTests(unittest.TestCase):
             ),
             "default": ("DEFAULT CURRENT_TIMESTAMP", "DEFAULT 'not-current'"),
             "check": (
-                '"round_number" BETWEEN 1 AND 8',
-                '"round_number" BETWEEN 1 AND 7',
+                '"round_number" BETWEEN 1 AND 10',
+                '"round_number" BETWEEN 1 AND 9',
             ),
             "unique": (
                 '"event_id"                 TEXT NOT NULL UNIQUE',
@@ -757,6 +800,25 @@ class TelemetryBuilderTests(unittest.TestCase):
         low_support["preference_model"]["support"]['["round_score",8]'] = 3
         with self.assertRaisesRegex(InvalidTelemetryError, "preference model"):
             validate_artifact(low_support)
+
+        frozen_round_eight = json.loads(json.dumps(artifact))
+        frozen_round_eight["preference_model"]["weights"] = {
+            '["round_score",8]': 0.5
+        }
+        frozen_round_eight["preference_model"]["support"] = {
+            '["round_score",8]': 30
+        }
+        validate_artifact(frozen_round_eight)
+
+        frozen_round_nine = json.loads(json.dumps(frozen_round_eight))
+        frozen_round_nine["preference_model"]["weights"] = {
+            '["round_score",9]': 0.5
+        }
+        frozen_round_nine["preference_model"]["support"] = {
+            '["round_score",9]': 30
+        }
+        with self.assertRaisesRegex(InvalidTelemetryError, "preference model"):
+            validate_artifact(frozen_round_nine)
 
         unhashed_version = json.loads(json.dumps(artifact))
         unhashed_version["preference_model"]["version"] = "preference-v1"

--- a/data/test_telemetry_incremental_state.py
+++ b/data/test_telemetry_incremental_state.py
@@ -14,6 +14,7 @@ from build_telemetry_data import (  # noqa: E402
     build,
     load_catalog,
     load_event_batch,
+    validate_artifact,
 )
 from telemetry_incremental_state import (  # noqa: E402
     INCREMENTAL_ARTIFACT_SCHEMA_VERSION,
@@ -84,6 +85,10 @@ class IncrementalTelemetryStateTests(unittest.TestCase):
         self.assertEqual(state["cursor"]["last_processed_id"], 2)
         self.assertEqual(state["summary"]["event_count"], 2)
         self.assertEqual(
+            sorted(state["rounds"], key=int),
+            [str(number) for number in range(1, 11)],
+        )
+        self.assertEqual(
             artifact["schema"]["version"],
             INCREMENTAL_ARTIFACT_SCHEMA_VERSION,
         )
@@ -110,6 +115,33 @@ class IncrementalTelemetryStateTests(unittest.TestCase):
         self.assertEqual(self.state_path.read_bytes(), state_bytes)
         self.assertEqual(self.output_path.read_bytes(), artifact_bytes)
 
+    def test_rounds_nine_and_ten_fold_into_ten_round_public_artifact(self) -> None:
+        _write_export(
+            self.export_path,
+            [
+                _event(self.catalog_version, suffix=9, round_number=9),
+                _event(self.catalog_version, suffix=10, round_number=10),
+            ],
+        )
+
+        artifact = self._build()
+        state = self._load_state()
+
+        self.assertEqual(artifact["schema"]["version"], 5)
+        self.assertEqual(len(artifact["rounds"]), 10)
+        self.assertEqual(
+            (artifact["rounds"][8]["round_type"], artifact["rounds"][8]["event_count"]),
+            ("hero", 1),
+        )
+        self.assertEqual(
+            (artifact["rounds"][9]["round_type"], artifact["rounds"][9]["event_count"]),
+            ("skill", 1),
+        )
+        self.assertEqual(state["rounds"]["9"]["event_count"], 1)
+        self.assertEqual(state["rounds"]["10"]["event_count"], 1)
+        validate_state(state, self.catalog_version)
+        validate_public_artifact(artifact)
+
     def test_missing_state_fails_closed_without_explicit_action(self) -> None:
         _write_export(
             self.export_path,
@@ -126,6 +158,30 @@ class IncrementalTelemetryStateTests(unittest.TestCase):
                 self.recommendation_path,
                 self.output_path,
                 state_path=self.state_path,
+            )
+
+    def test_stateful_build_rejects_frozen_eight_round_export_schema(
+        self,
+    ) -> None:
+        legacy_schema = MIGRATION.read_text(encoding="utf-8").replace(
+            '"round_number" BETWEEN 1 AND 10',
+            '"round_number" BETWEEN 1 AND 8',
+            1,
+        )
+        _write_export(
+            self.export_path,
+            [_event(self.catalog_version, suffix=1, round_number=1)],
+            legacy_schema,
+        )
+
+        with self.assertRaisesRegex(InvalidTelemetryError, "schema mismatch"):
+            build(
+                self.export_path,
+                self.database_path,
+                self.recommendation_path,
+                self.output_path,
+                state_path=self.state_path,
+                initialize_state=True,
             )
 
     def test_split_batches_preserve_cumulative_public_aggregates(self) -> None:
@@ -532,6 +588,36 @@ class IncrementalTelemetryStateTests(unittest.TestCase):
         )
         validate_public_artifact(artifact)
 
+        current_round_ten = json.loads(json.dumps(artifact))
+        current_round_ten["preference_model"]["weights"] = {
+            '["round_score",10]': 0.5
+        }
+        current_round_ten["preference_model"]["support"] = {
+            '["round_score",10]': 30
+        }
+        validate_artifact(current_round_ten)
+
+        frozen_round_eight = json.loads(json.dumps(artifact))
+        frozen_round_eight["schema"]["version"] = 4
+        frozen_round_eight["rounds"] = frozen_round_eight["rounds"][:8]
+        frozen_round_eight["preference_model"]["weights"] = {
+            '["round_score",8]': 0.5
+        }
+        frozen_round_eight["preference_model"]["support"] = {
+            '["round_score",8]': 30
+        }
+        validate_artifact(frozen_round_eight)
+
+        frozen_round_nine = json.loads(json.dumps(frozen_round_eight))
+        frozen_round_nine["preference_model"]["weights"] = {
+            '["round_score",9]': 0.5
+        }
+        frozen_round_nine["preference_model"]["support"] = {
+            '["round_score",9]': 30
+        }
+        with self.assertRaisesRegex(InvalidTelemetryError, "schema-v4"):
+            validate_artifact(frozen_round_nine)
+
     def test_checkpoint_survives_purge_gaps_and_delete_all(self) -> None:
         initial_rows = [
             _event(self.catalog_version, suffix=1, round_number=1),
@@ -615,6 +701,32 @@ class IncrementalTelemetryStateTests(unittest.TestCase):
         after_reset = self._build()
         self.assertEqual(after_reset["summary"]["event_count"], 1)
         self.assertEqual(self._load_state()["cursor"]["last_processed_id"], 12)
+
+    def test_reset_and_fold_export_keeps_rows_from_recreated_table(self) -> None:
+        _write_export(
+            self.export_path,
+            [_event(self.catalog_version, suffix=10, round_number=1)],
+            row_ids=[10],
+        )
+        self._build()
+
+        _write_export(
+            self.export_path,
+            [_event(self.catalog_version, suffix=1, round_number=9)],
+            row_ids=[1],
+        )
+        reset_artifact = build(
+            self.export_path,
+            self.database_path,
+            self.recommendation_path,
+            self.output_path,
+            state_path=self.state_path,
+            reset_and_fold_export=True,
+        )
+
+        self.assertEqual(reset_artifact["summary"]["event_count"], 1)
+        self.assertEqual(reset_artifact["rounds"][8]["event_count"], 1)
+        self.assertEqual(self._load_state()["cursor"]["last_processed_id"], 1)
 
     def test_state_projection_is_independent_of_raw_export(self) -> None:
         _write_export(

--- a/data/test_telemetry_retention.py
+++ b/data/test_telemetry_retention.py
@@ -32,7 +32,9 @@ from telemetry_retention import (  # noqa: E402
     parse_table_snapshot,
     render_bounded_purge_sql,
     schema_has_autoincrement,
+    validate_reset_target,
     verify_migration,
+    verify_reset_result,
     write_bounded_purge_sql,
 )
 
@@ -41,6 +43,12 @@ ROOT = Path(__file__).resolve().parent.parent
 CANONICAL_MIGRATION = ROOT / "web/migrations/0001_round_telemetry.sql"
 UPGRADE_MIGRATION = (
     ROOT / "web/migrations/0002_round_telemetry_autoincrement.sql"
+)
+RESET_MIGRATION = (
+    ROOT / "web/migrations/0004_round_telemetry_rounds_10_reset.sql"
+)
+WEB_BATTLE_MIGRATION = (
+    ROOT / "web/migrations/0003_web_battle_submissions.sql"
 )
 UPDATE_WORKFLOW = ROOT / ".github/workflows/update-telemetry-data.yml"
 INSERT_SQL = """
@@ -74,7 +82,7 @@ def _row(identifier: int, *, round_number: int = 1) -> tuple[object, ...]:
         "2026-07-01T00:00:00.000Z",
         "2026-07-01 00:00:01",
         round_number,
-        "hero" if round_number in {1, 4, 7} else "skill",
+        "hero" if round_number in {1, 4, 7, 9} else "skill",
         1,
         "1:0123456789abcdef",
         "fedcba9876543210",
@@ -173,20 +181,81 @@ class TelemetryMigrationTests(unittest.TestCase):
         with self.assertRaises(sqlite3.IntegrityError):
             connection.execute(INSERT_SQL, duplicate_session_round)
 
-        invalid_round = list(_row(12))
-        invalid_round[5] = 9
+        connection.execute(INSERT_SQL, _row(12, round_number=9))
+        connection.execute(INSERT_SQL, _row(13, round_number=10))
+
+        invalid_round = list(_row(14))
+        invalid_round[5] = 11
         with self.assertRaises(sqlite3.IntegrityError):
             connection.execute(INSERT_SQL, invalid_round)
 
-        invalid_type = list(_row(13))
+        invalid_type = list(_row(15))
         invalid_type[6] = "other"
         with self.assertRaises(sqlite3.IntegrityError):
             connection.execute(INSERT_SQL, invalid_type)
 
-        invalid_position = list(_row(14))
+        invalid_position = list(_row(16))
         invalid_position[13] = 3
         with self.assertRaises(sqlite3.IntegrityError):
             connection.execute(INSERT_SQL, invalid_position)
+        connection.close()
+
+    def test_ten_round_reset_discards_only_round_telemetry(self) -> None:
+        old_round_sql = CANONICAL_MIGRATION.read_text(encoding="utf-8").replace(
+            "BETWEEN 1 AND 10",
+            "BETWEEN 1 AND 8",
+            1,
+        )
+        connection = sqlite3.connect(":memory:")
+        connection.executescript(old_round_sql)
+        connection.executescript(
+            WEB_BATTLE_MIGRATION.read_text(encoding="utf-8")
+        )
+        connection.execute(INSERT_SQL, _row(8, round_number=8))
+        connection.execute(
+            """
+            INSERT INTO "web_battle_submissions" (
+                "submission_id",
+                "uploader_name",
+                "catalog_version",
+                "canonical_hash",
+                "battle_json"
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "20000000-0000-4000-8000-000000000001",
+                "tester",
+                "0123456789ab",
+                "0" * 64,
+                "{}",
+            ),
+        )
+
+        connection.executescript(RESET_MIGRATION.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            connection.execute(
+                'SELECT COUNT(*) FROM "round_telemetry"'
+            ).fetchone()[0],
+            0,
+        )
+        self.assertEqual(
+            connection.execute(
+                'SELECT COUNT(*) FROM "web_battle_submissions"'
+            ).fetchone()[0],
+            1,
+        )
+        table_sql = connection.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'round_telemetry'"
+        ).fetchone()[0]
+        self.assertIn("BETWEEN 1 AND 10", table_sql)
+        connection.execute(INSERT_SQL, _row(9, round_number=9))
+        connection.execute(INSERT_SQL, _row(10, round_number=10))
+        invalid_round = list(_row(11))
+        invalid_round[5] = 11
+        with self.assertRaises(sqlite3.IntegrityError):
+            connection.execute(INSERT_SQL, invalid_round)
         connection.close()
 
     def test_delete_all_then_reinsert_never_reuses_an_id(self) -> None:
@@ -242,6 +311,7 @@ class TelemetryMigrationTests(unittest.TestCase):
         source = CANONICAL_MIGRATION.read_text(encoding="utf-8")
         self.assertIn('CREATE TABLE IF NOT EXISTS "round_telemetry"', source)
         self.assertIn('"id"                       INTEGER PRIMARY KEY AUTOINCREMENT', source)
+        self.assertIn('"round_number" BETWEEN 1 AND 10', source)
         self.assertTrue(
             schema_has_autoincrement(
                 load_canonical_table_sql(CANONICAL_MIGRATION)
@@ -259,7 +329,48 @@ class TelemetryMigrationTests(unittest.TestCase):
             "--file=migrations/0002_round_telemetry_autoincrement.sql",
             source,
         )
+        self.assertIn(
+            "if: inputs.reset_checkpoint == true",
+            source,
+        )
+        self.assertIn(
+            "--file=migrations/0004_round_telemetry_rounds_10_reset.sql",
+            source,
+        )
         self.assertNotIn("d1 migrations apply", source)
+
+    def test_workflow_validates_reset_before_and_after_destructive_step(
+        self,
+    ) -> None:
+        source = UPDATE_WORKFLOW.read_text(encoding="utf-8")
+        capture_position = source.index(
+            "name: Capture explicit telemetry reset target"
+        )
+        validate_position = source.index(
+            "name: Validate explicit telemetry reset target"
+        )
+        reset_position = source.index(
+            "name: Apply explicit ten-round telemetry beta reset"
+        )
+        verify_position = source.index(
+            "name: Verify explicit telemetry reset result"
+        )
+        export_position = source.index("name: Export round telemetry from D1")
+
+        self.assertLess(capture_position, validate_position)
+        self.assertLess(validate_position, reset_position)
+        self.assertLess(reset_position, verify_position)
+        self.assertLess(verify_position, export_position)
+        self.assertIn(
+            "python data/telemetry_retention.py validate-reset-target",
+            source,
+        )
+        self.assertIn(
+            "python data/telemetry_retention.py verify-reset",
+            source,
+        )
+        self.assertIn("true) reset_args+=(--reset-and-fold-export)", source)
+        self.assertNotIn("true) reset_args+=(--reset-state)", source)
 
     def test_workflow_uses_node24_pnpm_and_reports_published_events(self) -> None:
         source = UPDATE_WORKFLOW.read_text(encoding="utf-8")
@@ -356,6 +467,129 @@ class TelemetryRetentionMetadataTests(unittest.TestCase):
                     "unsafe",
                 ):
                     evaluate_preflight(snapshot, 6, self.canonical)
+
+    def test_preflight_rejects_eight_round_schema_until_explicit_reset(
+        self,
+    ) -> None:
+        eight_round_schema = self.canonical.replace(
+            "BETWEEN 1 AND 10",
+            "BETWEEN 1 AND 8",
+            1,
+        )
+        snapshot = parse_table_snapshot(
+            _metadata(
+                eight_round_schema,
+                row_count=0,
+                min_id=None,
+                max_id=None,
+            )
+        )
+
+        with self.assertRaisesRegex(
+            TelemetryRetentionError,
+            "incompatible",
+        ):
+            evaluate_preflight(snapshot, 0, self.canonical)
+
+    def test_reset_target_accepts_only_known_eight_or_ten_round_schema(
+        self,
+    ) -> None:
+        legacy_schema = self.canonical.replace(
+            "BETWEEN 1 AND 10",
+            "BETWEEN 1 AND 8",
+            1,
+        )
+        for expected, schema in (
+            ("current-ten-round", self.canonical),
+            ("legacy-eight-round", legacy_schema),
+            (
+                "legacy-eight-round",
+                legacy_schema.replace(" AUTOINCREMENT", "", 1),
+            ),
+        ):
+            with self.subTest(expected=expected):
+                snapshot = parse_table_snapshot(
+                    _metadata(
+                        schema,
+                        row_count=1,
+                        min_id=1,
+                        max_id=1,
+                    )
+                )
+                self.assertEqual(
+                    validate_reset_target(snapshot, self.canonical),
+                    expected,
+                )
+
+        unknown_schema = self.canonical.replace(
+            "BETWEEN 1 AND 10",
+            "BETWEEN 1 AND 9",
+            1,
+        )
+        with self.assertRaisesRegex(
+            TelemetryRetentionError,
+            "not a known",
+        ):
+            validate_reset_target(
+                parse_table_snapshot(
+                    _metadata(
+                        unknown_schema,
+                        row_count=0,
+                        min_id=None,
+                        max_id=None,
+                    )
+                ),
+                self.canonical,
+            )
+
+    def test_reset_verification_allows_new_rows_but_requires_current_schema(
+        self,
+    ) -> None:
+        post_reset = parse_table_snapshot(
+            _metadata(
+                self.canonical,
+                row_count=2,
+                min_id=1,
+                max_id=2,
+                sequence_value=2,
+                include_sequence=True,
+            ),
+            require_sequence=True,
+        )
+        verify_reset_result(post_reset, self.canonical)
+
+        behind = parse_table_snapshot(
+            _metadata(
+                self.canonical,
+                row_count=2,
+                min_id=1,
+                max_id=2,
+                sequence_value=1,
+                include_sequence=True,
+            ),
+            require_sequence=True,
+        )
+        with self.assertRaisesRegex(TelemetryRetentionError, "post-reset"):
+            verify_reset_result(behind, self.canonical)
+
+        legacy_schema = self.canonical.replace(
+            "BETWEEN 1 AND 10",
+            "BETWEEN 1 AND 8",
+            1,
+        )
+        legacy = parse_table_snapshot(
+            _metadata(
+                legacy_schema,
+                row_count=0,
+                min_id=None,
+                max_id=None,
+                sequence_value=0,
+                include_sequence=True,
+            ),
+            require_sequence=True,
+        )
+        with self.assertRaisesRegex(TelemetryRetentionError, "incompatible"):
+            verify_reset_result(legacy, self.canonical)
 
     def test_verify_requires_preserved_stats_autoincrement_and_safe_sequence(
         self,
@@ -641,6 +875,48 @@ class TelemetryRetentionMetadataTests(unittest.TestCase):
                 ),
                 1,
             )
+
+    def test_reset_validation_cli_checks_target_and_post_reset_metadata(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory_name:
+            directory = Path(directory_name)
+            target_path = directory / "target.json"
+            result_path = directory / "result.json"
+            target_path.write_text(
+                json.dumps(
+                    _metadata(
+                        self.canonical.replace(
+                            "BETWEEN 1 AND 10",
+                            "BETWEEN 1 AND 8",
+                            1,
+                        ),
+                        row_count=1,
+                        min_id=7,
+                        max_id=7,
+                    )
+                ),
+                encoding="utf-8",
+            )
+            result_path.write_text(
+                json.dumps(
+                    _metadata(
+                        self.canonical,
+                        row_count=1,
+                        min_id=1,
+                        max_id=1,
+                        sequence_value=1,
+                        include_sequence=True,
+                    )
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                main(["validate-reset-target", str(target_path)]),
+                0,
+            )
+            self.assertEqual(main(["verify-reset", str(result_path)]), 0)
 
 
 class TelemetryPublicationReportTests(unittest.TestCase):

--- a/web/README.md
+++ b/web/README.md
@@ -365,13 +365,16 @@ Manual workflow dispatch exposes an explicit checkpoint-reset option for a
 deliberate catalog/algorithm reset. Normal runs fail if the checkpoint is
 missing or incompatible; they never silently discard cumulative history.
 
-If the D1 database is deliberately replaced, first initialize the empty
-replacement database with `migrations/0001_round_telemetry.sql`, then manually
-dispatch `Update telemetry data` once with `reset_checkpoint` enabled. That
-explicit run validates the existing checkpoint, treats its cursor as zero for
-replacement-database sequence checks, discards its prior aggregates, and
-advances the new checkpoint past any rows already present in the replacement
-database. Do not enable the reset option for routine weekly retention.
+A `reset_checkpoint` dispatch runs the dedicated reset path (see [Ten-round
+telemetry reset rollout](#ten-round-telemetry-reset-rollout)): it validates the
+live `round_telemetry` is a known eight- or ten-round schema, applies
+`migrations/0004_round_telemetry_rounds_10_reset.sql` to drop and recreate the
+Rounds 1–10 table, verifies AUTOINCREMENT and the `sqlite_sequence` value,
+discards the prior aggregates, and folds every row in the fresh export from
+scratch. If the D1 database is instead deliberately replaced, initialize the
+empty replacement database with `migrations/0001_round_telemetry.sql` first,
+then dispatch the same reset. Do not enable the reset option for routine weekly
+retention.
 
 The builder recomputes event scores and tie-breaks from the recorded paired
 model version. Before deploying a new `src/recommendation_data.json`, retain the

--- a/web/README.md
+++ b/web/README.md
@@ -12,10 +12,14 @@ the model data is generated and community reports are imported.
 ## Features
 
 - **Setup Phase**: Select starting heroes and skills with pinyin search support, and pick the current season (defaults to the latest available; the season only limits support hero/skill availability, not initial setup or round inputs)
-- **Game Flow**: Round-by-round draft with recommendations for optimal team building (see [GAME_RULE.md](../GAME_RULE.md))
+- **Game Flow**: Ten-round draft with one-click win qualification after Rounds
+  6 and 8; Round 9 repeats the Round 7 hero format and Round 10 repeats the
+  Round 8 skill format (see [GAME_RULE.md](../GAME_RULE.md))
 - **Manual Editing**: Edit team composition manually at any time
 - **Analytics Dashboard**: Player-friendly, question-led analytics — hero/skill rankings by 胜率参考 (smoothed win rate, with 参考场次 as supporting context), 组合分 synergy tables, usage, and optional (collapsed) model diagnostics
-- **Auto-save**: Progress automatically saved to cookies
+- **Auto-save**: Game progress automatically saved in a versioned,
+  non-expiring `localStorage` record; season and team-builder data remain in
+  separate cookies
 - **Anonymous round telemetry**: Always-on, non-blocking offer/score/choice
   logging through a Cloudflare Pages Function with an offline local retry queue
 - **Community battle uploads**: Best-effort DeepSeek JSON prefill with manual
@@ -34,7 +38,7 @@ the model data is generated and community reports are imported.
 - **Material-UI (MUI)** - Component library and styling
 - **React Router** - Client-side routing
 - **pinyin-pro** - Chinese pinyin search support
-- **js-cookie** - Cookie-based persistence
+- **js-cookie** - Selected-season and team-builder cookie persistence
 - **Cloudflare Pages Functions + D1** - Write-only telemetry and battle-report
   collection; all recommendation and leaderboard reads remain static
 
@@ -129,6 +133,15 @@ web/
 - **TagList**: Display and manage selected items
 
 ### Game Phase
+
+The draft has ten rounds. A one-click win gate controls progression from Round
+6 to 7 and Round 8 to 9. The existing support pick remains optional after Round
+6, and any support selections carry through the later rounds. A completed
+supported draft can therefore contain up to 15 heroes and 28 skills. Team
+recommendations consider that full pool, using a bounded top-two-team-first
+search before constructing the third team and globally assigning its 18
+selected skills.
+
 - **GameBoard**: Main game container managing the draft rounds
 - **RoundInfo**: Display current round information with stepper
 - **CurrentTeam**: Show current team (with its roster 评分/score) and manual edit capability
@@ -142,7 +155,7 @@ web/
 ### Analytics
 - **Analytics**: Player-friendly dashboard driven by the generated paired-model artifact
 - A separate **匿名选项统计** section is shown when
-  `public/game-data/telemetry_data.json` contains schema-v4 item analytics. Its 武将/战法
+  `public/game-data/telemetry_data.json` contains schema-v5 item analytics. Its 武将/战法
   toggle switches two responsive, height-capped tables showing every aggregated item:
   **游戏最常提供** ranks by offer count and shows offer rate, while **玩家最常选择**
   ranks by pick count and shows the conditional picked-when-offered rate. Offer counts
@@ -155,7 +168,7 @@ web/
 - The telemetry artifact still retains diagnostic round, position, score-margin,
   recommendation-agreement, preference-model status/evidence, and evaluation aggregates,
   but Analytics does not show them in this player-facing ranking section.
-  Backward-compatible schema-v2/v3 readers remain for stale deployed assets;
+  Backward-compatible schema-v2/v3/v4 readers remain for stale deployed assets;
   schema-v2 artifacts have no item analytics, so the section is omitted entirely.
 - Question-led layout with a plain-language guide to the three player-facing measures:
   胜率参考 (smoothed win rate), 组合分 (combo score — the model's extra pairing/hero-skill
@@ -199,14 +212,21 @@ Uses React Context API with `useReducer` for global state:
 - Game state (current round, heroes, skills)
 - Round inputs (3 option sets)
 - Recommendations and selections
-- Auto-save to cookies on every state change
+- Auto-save to versioned `localStorage` on every state change
 
 ## Persistence
 
-Game progress is automatically saved to cookies with a 1-year expiry:
+Game progress is automatically saved in a versioned `gameProgress`
+`localStorage` envelope with no application-defined expiry:
+
 - Current game state
 - Round inputs
 - Automatically restored on page load
+
+Malformed records and records with an unsupported version are ignored. The
+legacy `gameProgress` cookie is intentionally not migrated or restored. The
+separate `/build-a-team` arrangement continues to use its one-year
+`teamBuilder` cookie.
 
 The selected season is persisted in its own `selectedSeason` cookie, kept
 separate from game progress so it survives a game reset; when the cookie is
@@ -225,6 +245,13 @@ browser continues to use only the paired battle model for recommendations; the
 preference model supplies a separately labelled player-choice probability and
 is omitted from the option cards unless both its evidence and prequential quality
 gates pass.
+
+The stateful production builder publishes aggregate schema v5 with exactly
+Rounds 1–10: Round 9 is a two-item hero round and Round 10 is a three-item skill
+round. The browser-to-Function source-event wire contract remains schema v1.
+The no-`--state` full-export builder stays frozen at aggregate schema v3 and
+Rounds 1–8 for offline compatibility; it rejects exports containing Round 9 or
+10 events.
 
 The repository-root `data/telemetry_state.json` is a separate generated,
 aggregate-only checkpoint used by the weekly builder. It is not served to the
@@ -258,6 +285,21 @@ source of truth; no Wrangler configuration file is required.
    `/api/telemetry/rounds` plus `/api/battles` are then served by Pages
    Functions. Static recommendation pages and `/contributors` never query D1.
 
+### Ten-round telemetry reset rollout
+
+The checked-in aggregate checkpoint and public schema-v5 artifact intentionally
+start the ten-round beta contract with zero history. Updating the repository
+does not change the remote D1 database.
+
+An existing D1 database with the earlier Rounds 1–8 constraint requires one
+manual **Update telemetry data** workflow dispatch with
+`reset_checkpoint=true`. That explicit run applies
+`migrations/0004_round_telemetry_rounds_10_reset.sql`, dropping and recreating
+only `round_telemetry` with the Rounds 1–10 constraint; it preserves
+`web_battle_submissions`. Until this one-time reset succeeds, the old D1 schema
+fails retention preflight closed. Subsequent scheduled runs leave the reset
+option disabled.
+
 ### Weekly aggregate workflow
 
 The `Update telemetry data` GitHub Actions workflow uses the schedule declared
@@ -279,7 +321,7 @@ the currently retained `round_telemetry` rows to `$RUNNER_TEMP`. This direct
 execution keeps the dashboard-managed Pages project free of a committed
 Wrangler configuration. The builder folds only IDs newer than the committed
 cursor into `../data/telemetry_state.json` and renders the cumulative public
-schema-v4 artifact solely from that checkpoint. It then runs the web type-check,
+schema-v5 artifact solely from that checkpoint. It then runs the web type-check,
 unit tests, and production build. Exactly the checkpoint and
 `public/game-data/telemetry_data.json` are eligible for staging, and they are
 committed together when either changes.
@@ -373,7 +415,7 @@ serif headings, layered over MUI's component library.
 
 ### Build Issues
 - Delete `node_modules`, then run `pnpm install --frozen-lockfile`
-- Clear browser cache and cookies
+- Clear browser site data (`localStorage` and cookies)
 - Run `pnpm typecheck` and `pnpm build` to surface type/build errors
 
 ## Contributing

--- a/web/functions/api/telemetry/rounds.js
+++ b/web/functions/api/telemetry/rounds.js
@@ -14,6 +14,8 @@ const ROUND_TYPES = Object.freeze({
   6: 'skill',
   7: 'hero',
   8: 'skill',
+  9: 'hero',
+  10: 'skill',
 });
 const EVENT_KEYS = new Set([
   'event_id',
@@ -33,7 +35,7 @@ const EVENT_KEYS = new Set([
   'preference_probabilities',
 ]);
 const INSERT_SQL = `
-  INSERT OR IGNORE INTO round_telemetry (
+  INSERT INTO round_telemetry (
     event_id,
     session_id,
     client_ts,
@@ -50,6 +52,7 @@ const INSERT_SQL = `
     preference_model_version,
     preference_probs_json
   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT DO NOTHING
 `;
 
 const responseJson = (body, status = 200) =>
@@ -127,8 +130,8 @@ export function validateRoundEvent(event, nowMs = Date.now()) {
   if (clientTimestampMs > nowMs + MAX_FUTURE_SKEW_MS) {
     return 'client_ts is too far in the future';
   }
-  if (!Number.isInteger(event.round_number) || event.round_number < 1 || event.round_number > 8) {
-    return 'round_number must be between 1 and 8';
+  if (!Number.isInteger(event.round_number) || event.round_number < 1 || event.round_number > 10) {
+    return 'round_number must be between 1 and 10';
   }
   if (event.round_type !== ROUND_TYPES[event.round_number]) {
     return 'round_type does not match round_number';
@@ -173,7 +176,7 @@ export function validateRoundEvent(event, nowMs = Date.now()) {
     return 'pool_before contains duplicate or overlapping items';
   }
 
-  const itemsPerSet = event.round_number === 7 ? 2 : 3;
+  const itemsPerSet = event.round_number === 7 || event.round_number === 9 ? 2 : 3;
   if (
     !Array.isArray(event.offered_sets) ||
     event.offered_sets.length !== 3 ||

--- a/web/functions/api/telemetry/rounds.test.js
+++ b/web/functions/api/telemetry/rounds.test.js
@@ -43,9 +43,11 @@ const cloneEvent = (overrides = {}) => ({
 class FakeD1 {
   constructor() {
     this.eventIds = new Set();
+    this.preparedSql = null;
   }
 
-  prepare() {
+  prepare(sql) {
+    this.preparedSql = sql;
     return {
       bind: (...values) => ({ values }),
     };
@@ -71,6 +73,79 @@ const requestFor = (body) =>
 describe('round telemetry validation', () => {
   test('accepts a complete schema-v1 round event', () => {
     expect(validateRoundEvent(cloneEvent())).toBeNull();
+  });
+
+  test('accepts round 9 as a two-hero-set round', () => {
+    expect(
+      validateRoundEvent(
+        cloneEvent({
+          round_number: 9,
+          round_type: 'hero',
+          offered_sets: [
+            ['曹操', '夏侯惇'],
+            ['孙权', '周瑜'],
+            ['袁绍', '颜良'],
+          ],
+        })
+      )
+    ).toBeNull();
+  });
+
+  test('accepts round 10 as a three-skill-set round', () => {
+    expect(
+      validateRoundEvent(
+        cloneEvent({
+          round_number: 10,
+          round_type: 'skill',
+          offered_sets: [
+            ['战法五', '战法六', '战法七'],
+            ['战法八', '战法九', '战法十'],
+            ['战法十一', '战法十二', '战法十三'],
+          ],
+        })
+      )
+    ).toBeNull();
+  });
+
+  test('rejects rounds above the ten-round contract', () => {
+    expect(
+      validateRoundEvent(
+        cloneEvent({
+          round_number: 11,
+          round_type: 'skill',
+        })
+      )
+    ).toBe('round_number must be between 1 and 10');
+  });
+
+  test('requires two heroes per set in round 9', () => {
+    expect(
+      validateRoundEvent(
+        cloneEvent({
+          round_number: 9,
+          round_type: 'hero',
+        })
+      )
+    ).toBe('offered_sets must contain three sets of 2');
+  });
+
+  test('requires the configured type for rounds 9 and 10', () => {
+    expect(
+      validateRoundEvent(
+        cloneEvent({
+          round_number: 9,
+          round_type: 'skill',
+        })
+      )
+    ).toBe('round_type does not match round_number');
+    expect(
+      validateRoundEvent(
+        cloneEvent({
+          round_number: 10,
+          round_type: 'hero',
+        })
+      )
+    ).toBe('round_type does not match round_number');
   });
 
   test('allows support context to be omitted', () => {
@@ -207,6 +282,8 @@ describe('POST /api/telemetry/rounds', () => {
     const first = await onRequestPost(context);
     expect(first.status).toBe(200);
     await expect(first.json()).resolves.toEqual({ ok: true, accepted: 1, duplicates: 0 });
+    expect(database.preparedSql).toContain('ON CONFLICT DO NOTHING');
+    expect(database.preparedSql).not.toContain('INSERT OR IGNORE');
 
     const retry = await onRequestPost({
       ...context,
@@ -214,6 +291,39 @@ describe('POST /api/telemetry/rounds', () => {
     });
     expect(retry.status).toBe(200);
     await expect(retry.json()).resolves.toEqual({ ok: true, accepted: 0, duplicates: 1 });
+  });
+
+  test('surfaces non-uniqueness storage constraints for retry', async () => {
+    const database = new FakeD1();
+    database.batch = vi
+      .fn()
+      .mockRejectedValue(
+        new Error('CHECK constraint failed: round_number BETWEEN 1 AND 8')
+      );
+
+    const response = await onRequestPost({
+      request: requestFor({
+        events: [
+          cloneEvent({
+            round_number: 9,
+            round_type: 'hero',
+            offered_sets: [
+              ['曹操', '夏侯惇'],
+              ['孙权', '周瑜'],
+              ['袁绍', '颜良'],
+            ],
+          }),
+        ],
+      }),
+      env: { TELEMETRY_DB: database },
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'telemetry storage unavailable',
+    });
+    expect(database.preparedSql).toContain('ON CONFLICT DO NOTHING');
   });
 
   test('rejects an invalid event without writing the batch', async () => {

--- a/web/migrations/0002_round_telemetry_autoincrement.sql
+++ b/web/migrations/0002_round_telemetry_autoincrement.sql
@@ -4,7 +4,7 @@ CREATE TABLE "round_telemetry_autoincrement" (
     "session_id"               TEXT NOT NULL,
     "client_ts"                TEXT NOT NULL,
     "received_at"              TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "round_number"             INTEGER NOT NULL CHECK ("round_number" BETWEEN 1 AND 8),
+    "round_number"             INTEGER NOT NULL CHECK ("round_number" BETWEEN 1 AND 10),
     "round_type"               TEXT NOT NULL CHECK ("round_type" IN ('hero', 'skill')),
     "schema_version"           INTEGER NOT NULL,
     "model_version"            TEXT NOT NULL,

--- a/web/migrations/0004_round_telemetry_rounds_10_reset.sql
+++ b/web/migrations/0004_round_telemetry_rounds_10_reset.sql
@@ -1,4 +1,11 @@
-CREATE TABLE IF NOT EXISTS "round_telemetry" (
+-- Explicit beta-history reset for the ten-round draft contract.
+--
+-- This migration intentionally discards only anonymous round telemetry. The
+-- separate web_battle_submissions table and its accepted-report pipeline are
+-- not touched.
+DROP TABLE IF EXISTS "round_telemetry";
+
+CREATE TABLE "round_telemetry" (
     "id"                       INTEGER PRIMARY KEY AUTOINCREMENT,
     "event_id"                 TEXT NOT NULL UNIQUE,
     "session_id"               TEXT NOT NULL,

--- a/web/public/game-data/telemetry_data.json
+++ b/web/public/game-data/telemetry_data.json
@@ -1,1251 +1,38 @@
 {
   "analytics": {
     "items": {
-      "heroes": [
-        {
-          "name": "乐进",
-          "offer_count": 7,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "于吉",
-          "offer_count": 6,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "于禁",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "关平",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "关羽",
-          "offer_count": 12,
-          "opportunity_count": 47,
-          "picked_count": 6,
-          "rate_suppressed": false
-        },
-        {
-          "name": "关银屏",
-          "offer_count": 2,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "凌统",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "刘备",
-          "offer_count": 4,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "刘禅",
-          "offer_count": 3,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "司马懿",
-          "offer_count": 3,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "吕布",
-          "offer_count": 6,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "吴国太",
-          "offer_count": 5,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "周仓",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "周泰",
-          "offer_count": 6,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "周瑜",
-          "offer_count": 6,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "夏侯惇",
-          "offer_count": 12,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": false
-        },
-        {
-          "name": "夏侯渊",
-          "offer_count": 10,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": false
-        },
-        {
-          "name": "大乔",
-          "offer_count": 7,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "姜维",
-          "offer_count": 5,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "孙权",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "孙策",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "孟获",
-          "offer_count": 2,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "小乔",
-          "offer_count": 8,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "左慈",
-          "offer_count": 2,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "庞德",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "庞统",
-          "offer_count": 10,
-          "opportunity_count": 47,
-          "picked_count": 4,
-          "rate_suppressed": false
-        },
-        {
-          "name": "张宁",
-          "offer_count": 6,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "张宝",
-          "offer_count": 13,
-          "opportunity_count": 47,
-          "picked_count": 6,
-          "rate_suppressed": false
-        },
-        {
-          "name": "张春华",
-          "offer_count": 8,
-          "opportunity_count": 47,
-          "picked_count": 6,
-          "rate_suppressed": true
-        },
-        {
-          "name": "张昭",
-          "offer_count": 7,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "张梁",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "张辽",
-          "offer_count": 11,
-          "opportunity_count": 47,
-          "picked_count": 4,
-          "rate_suppressed": false
-        },
-        {
-          "name": "张郃",
-          "offer_count": 2,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "张飞",
-          "offer_count": 8,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "徐盛",
-          "offer_count": 7,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "曹丕",
-          "offer_count": 3,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "曹仁",
-          "offer_count": 9,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "曹操",
-          "offer_count": 4,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "曹纯",
-          "offer_count": 6,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "木鹿大王",
-          "offer_count": 3,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "朱儁",
-          "offer_count": 6,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "李儒",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "步练师",
-          "offer_count": 5,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "法正",
-          "offer_count": 9,
-          "opportunity_count": 47,
-          "picked_count": 6,
-          "rate_suppressed": true
-        },
-        {
-          "name": "王双",
-          "offer_count": 3,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "王异",
-          "offer_count": 5,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "甄洛",
-          "offer_count": 10,
-          "opportunity_count": 47,
-          "picked_count": 4,
-          "rate_suppressed": false
-        },
-        {
-          "name": "甘夫人",
-          "offer_count": 7,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "田丰",
-          "offer_count": 9,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "皇甫嵩2",
-          "offer_count": 4,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "程昱",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "程普",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "荀彧",
-          "offer_count": 9,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "荀攸",
-          "offer_count": 2,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "董卓",
-          "offer_count": 4,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "蔡文姬",
-          "offer_count": 15,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": false
-        },
-        {
-          "name": "袁术",
-          "offer_count": 9,
-          "opportunity_count": 47,
-          "picked_count": 4,
-          "rate_suppressed": true
-        },
-        {
-          "name": "袁绍",
-          "offer_count": 12,
-          "opportunity_count": 47,
-          "picked_count": 4,
-          "rate_suppressed": false
-        },
-        {
-          "name": "诸葛亮",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "诸葛亮2",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "貂蝉",
-          "offer_count": 7,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "贾诩",
-          "offer_count": 9,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "赵云",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "邓艾",
-          "offer_count": 6,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "邹氏",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "郝昭",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "郭嘉",
-          "offer_count": 4,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "陆抗",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "陆逊",
-          "offer_count": 3,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "颜良",
-          "offer_count": 1,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "马云禄",
-          "offer_count": 8,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "马腾",
-          "offer_count": 6,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "马超",
-          "offer_count": 6,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "高顺",
-          "offer_count": 7,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "魏延",
-          "offer_count": 2,
-          "opportunity_count": 47,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "鲁肃",
-          "offer_count": 8,
-          "opportunity_count": 47,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "麋夫人",
-          "offer_count": 2,
-          "opportunity_count": 47,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "黄月英",
-          "offer_count": 5,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "黄盖",
-          "offer_count": 8,
-          "opportunity_count": 47,
-          "picked_count": 3,
-          "rate_suppressed": true
-        }
-      ],
-      "skills": [
-        {
-          "name": "万军辟易",
-          "offer_count": 3,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "万夫莫当",
-          "offer_count": 1,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "三军夺气",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": false
-        },
-        {
-          "name": "上智为间",
-          "offer_count": 8,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "乘虚而入",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 5,
-          "rate_suppressed": false
-        },
-        {
-          "name": "乘间投隙",
-          "offer_count": 1,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "五雷轰顶",
-          "offer_count": 11,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": false
-        },
-        {
-          "name": "以静制动",
-          "offer_count": 12,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": false
-        },
-        {
-          "name": "任人择势",
-          "offer_count": 2,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "伏兵四起",
-          "offer_count": 7,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "兵贵神速",
-          "offer_count": 6,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "冲锐巧变",
-          "offer_count": 12,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": false
-        },
-        {
-          "name": "出其不意",
-          "offer_count": 12,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": false
-        },
-        {
-          "name": "势如破竹",
-          "offer_count": 12,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": false
-        },
-        {
-          "name": "勇冠三军",
-          "offer_count": 2,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "十面埋伏",
-          "offer_count": 4,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "千里突袭",
-          "offer_count": 12,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": false
-        },
-        {
-          "name": "及锋而试",
-          "offer_count": 6,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "同舟共济",
-          "offer_count": 5,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "固若金汤",
-          "offer_count": 5,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "坚如磐石",
-          "offer_count": 7,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "奇正相生",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": false
-        },
-        {
-          "name": "奇门遁甲",
-          "offer_count": 7,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "威名显赫",
-          "offer_count": 11,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": false
-        },
-        {
-          "name": "岿然不动",
-          "offer_count": 7,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "巧利天灾",
-          "offer_count": 1,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "御敌临前",
-          "offer_count": 6,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": true
-        },
-        {
-          "name": "忘私相助",
-          "offer_count": 8,
-          "opportunity_count": 82,
-          "picked_count": 5,
-          "rate_suppressed": true
-        },
-        {
-          "name": "恩威并行",
-          "offer_count": 5,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "惩前毖后",
-          "offer_count": 14,
-          "opportunity_count": 82,
-          "picked_count": 6,
-          "rate_suppressed": false
-        },
-        {
-          "name": "战八方",
-          "offer_count": 11,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": false
-        },
-        {
-          "name": "折冲御侮",
-          "offer_count": 5,
-          "opportunity_count": 82,
-          "picked_count": 5,
-          "rate_suppressed": true
-        },
-        {
-          "name": "披坚执锐",
-          "offer_count": 6,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": true
-        },
-        {
-          "name": "拔刀相向",
-          "offer_count": 5,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "指点乾坤",
-          "offer_count": 14,
-          "opportunity_count": 82,
-          "picked_count": 7,
-          "rate_suppressed": false
-        },
-        {
-          "name": "挫锐折锋",
-          "offer_count": 12,
-          "opportunity_count": 82,
-          "picked_count": 5,
-          "rate_suppressed": false
-        },
-        {
-          "name": "掠阵破军",
-          "offer_count": 2,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "摧坚克难",
-          "offer_count": 9,
-          "opportunity_count": 82,
-          "picked_count": 5,
-          "rate_suppressed": true
-        },
-        {
-          "name": "攻其不备",
-          "offer_count": 9,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "文武双全",
-          "offer_count": 16,
-          "opportunity_count": 82,
-          "picked_count": 5,
-          "rate_suppressed": false
-        },
-        {
-          "name": "文韬武略",
-          "offer_count": 1,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "料事如神",
-          "offer_count": 9,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": true
-        },
-        {
-          "name": "斩将夺旗",
-          "offer_count": 11,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": false
-        },
-        {
-          "name": "断戈夺锋",
-          "offer_count": 8,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "断敌粮道",
-          "offer_count": 12,
-          "opportunity_count": 82,
-          "picked_count": 8,
-          "rate_suppressed": false
-        },
-        {
-          "name": "无难之志",
-          "offer_count": 19,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": false
-        },
-        {
-          "name": "明其虚实",
-          "offer_count": 8,
-          "opportunity_count": 82,
-          "picked_count": 5,
-          "rate_suppressed": true
-        },
-        {
-          "name": "智破千军",
-          "offer_count": 7,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "未雨绸缪",
-          "offer_count": 9,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "机变无穷",
-          "offer_count": 5,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "横征暴敛",
-          "offer_count": 15,
-          "opportunity_count": 82,
-          "picked_count": 7,
-          "rate_suppressed": false
-        },
-        {
-          "name": "横扫千军",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": false
-        },
-        {
-          "name": "步步为营",
-          "offer_count": 13,
-          "opportunity_count": 82,
-          "picked_count": 6,
-          "rate_suppressed": false
-        },
-        {
-          "name": "水淹七军",
-          "offer_count": 14,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": false
-        },
-        {
-          "name": "洗筋伐髓",
-          "offer_count": 12,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": false
-        },
-        {
-          "name": "洞若观火",
-          "offer_count": 3,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "清风驱疾",
-          "offer_count": 6,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": true
-        },
-        {
-          "name": "潜师袭远",
-          "offer_count": 4,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "潜龙在渊",
-          "offer_count": 5,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "烈火张天",
-          "offer_count": 6,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "烈火焚营",
-          "offer_count": 8,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "狂风大作",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": false
-        },
-        {
-          "name": "王佐之才",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": false
-        },
-        {
-          "name": "百战不殆",
-          "offer_count": 9,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": true
-        },
-        {
-          "name": "睿虑合图",
-          "offer_count": 2,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "瞋目横矛",
-          "offer_count": 5,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "知人善任",
-          "offer_count": 14,
-          "opportunity_count": 82,
-          "picked_count": 6,
-          "rate_suppressed": false
-        },
-        {
-          "name": "破军袭敌",
-          "offer_count": 14,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": false
-        },
-        {
-          "name": "破阵驰围",
-          "offer_count": 5,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "神略制变",
-          "offer_count": 9,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "空城计",
-          "offer_count": 6,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": true
-        },
-        {
-          "name": "经天纬地",
-          "offer_count": 8,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "胜敌益强",
-          "offer_count": 11,
-          "opportunity_count": 82,
-          "picked_count": 5,
-          "rate_suppressed": false
-        },
-        {
-          "name": "舍生取义",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": false
-        },
-        {
-          "name": "蓄势待发",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 6,
-          "rate_suppressed": false
-        },
-        {
-          "name": "虎步连环",
-          "offer_count": 3,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "计袭粮仓",
-          "offer_count": 2,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "诱敌深入",
-          "offer_count": 5,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "调和阴阳",
-          "offer_count": 3,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "谋而后动",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 6,
-          "rate_suppressed": false
-        },
-        {
-          "name": "趁火打劫",
-          "offer_count": 3,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "践墨随敌",
-          "offer_count": 4,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "蹈锋饮血",
-          "offer_count": 9,
-          "opportunity_count": 82,
-          "picked_count": 6,
-          "rate_suppressed": true
-        },
-        {
-          "name": "轻装驰援",
-          "offer_count": 11,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": false
-        },
-        {
-          "name": "运智铺谋",
-          "offer_count": 8,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": true
-        },
-        {
-          "name": "运筹帷幄",
-          "offer_count": 7,
-          "opportunity_count": 82,
-          "picked_count": 4,
-          "rate_suppressed": true
-        },
-        {
-          "name": "金城汤池",
-          "offer_count": 7,
-          "opportunity_count": 82,
-          "picked_count": 2,
-          "rate_suppressed": true
-        },
-        {
-          "name": "铁骑横冲",
-          "offer_count": 8,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "锐不可当",
-          "offer_count": 8,
-          "opportunity_count": 82,
-          "picked_count": 5,
-          "rate_suppressed": true
-        },
-        {
-          "name": "青囊急救",
-          "offer_count": 8,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": true
-        },
-        {
-          "name": "韬光养晦",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 3,
-          "rate_suppressed": false
-        },
-        {
-          "name": "风助火势",
-          "offer_count": 7,
-          "opportunity_count": 82,
-          "picked_count": 1,
-          "rate_suppressed": true
-        },
-        {
-          "name": "风卷残云",
-          "offer_count": 1,
-          "opportunity_count": 82,
-          "picked_count": 0,
-          "rate_suppressed": true
-        },
-        {
-          "name": "黄天惑心",
-          "offer_count": 10,
-          "opportunity_count": 82,
-          "picked_count": 6,
-          "rate_suppressed": false
-        }
-      ]
+      "heroes": [],
+      "skills": []
     },
     "minimum_rate_support": 10,
     "score_margins": [
       {
-        "event_count": 1,
+        "event_count": 0,
         "key": "tie",
         "label": "并列",
         "rate_suppressed": true,
         "recommendation_accepted_count": 0
       },
       {
-        "event_count": 15,
+        "event_count": 0,
         "key": "0_to_1",
         "label": "0–1 分",
-        "rate_suppressed": false,
-        "recommendation_accepted_count": 11
+        "rate_suppressed": true,
+        "recommendation_accepted_count": 0
       },
       {
-        "event_count": 19,
+        "event_count": 0,
         "key": "1_to_3",
         "label": "1–3 分",
-        "rate_suppressed": false,
-        "recommendation_accepted_count": 16
+        "rate_suppressed": true,
+        "recommendation_accepted_count": 0
       },
       {
-        "event_count": 94,
+        "event_count": 0,
         "key": "over_3",
         "label": "超过 3 分",
-        "rate_suppressed": false,
-        "recommendation_accepted_count": 88
+        "rate_suppressed": true,
+        "recommendation_accepted_count": 0
       }
     ]
   },
@@ -1253,25 +40,25 @@
   "preference_model": {
     "algorithm": "ftrl-proximal",
     "evaluation": {
-      "accuracy": 0.825,
-      "brier": 0.147525,
-      "calibration_error": 0.346448,
-      "calibration_event_count": 111,
-      "event_count": 120,
-      "log_loss": 0.785988582293,
+      "accuracy": null,
+      "brier": null,
+      "calibration_error": null,
+      "calibration_event_count": 0,
+      "event_count": 0,
+      "log_loss": null,
       "method": "prequential",
-      "paired_accuracy": 0.883333,
+      "paired_accuracy": null,
       "uniform_log_loss": 1.098612288668
     },
     "evidence": {
-      "estimated_session_count": 29,
-      "evaluation_event_count": 120,
-      "event_count": 129,
+      "estimated_session_count": 0,
+      "evaluation_event_count": 0,
+      "event_count": 0,
       "minimum_estimated_session_count": 40,
       "minimum_evaluation_event_count": 36,
       "minimum_event_count": 240,
       "minimum_recommendation_disagreement_count": 30,
-      "recommendation_disagreement_count": 14
+      "recommendation_disagreement_count": 0
     },
     "feature_schema_version": 2,
     "l2": 0.05,
@@ -1288,20 +75,20 @@
     {
       "average_meaningful_preference_disagreement_margin": null,
       "chosen_position_counts": [
-        7,
-        9,
-        8
+        0,
+        0,
+        0
       ],
-      "event_count": 24,
+      "event_count": 0,
       "meaningful_preference_disagreement_count": null,
       "player_preference_agreement_count": null,
       "preference_top_disagreement_count": null,
-      "rate_suppressed": false,
-      "recommendation_accepted_count": 19,
+      "rate_suppressed": true,
+      "recommendation_accepted_count": 0,
       "recommended_position_counts": [
-        8,
-        8,
-        8
+        0,
+        0,
+        0
       ],
       "round_number": 1,
       "round_type": "hero"
@@ -1309,20 +96,20 @@
     {
       "average_meaningful_preference_disagreement_margin": null,
       "chosen_position_counts": [
-        11,
-        6,
-        5
+        0,
+        0,
+        0
       ],
-      "event_count": 22,
+      "event_count": 0,
       "meaningful_preference_disagreement_count": null,
       "player_preference_agreement_count": null,
       "preference_top_disagreement_count": null,
-      "rate_suppressed": false,
-      "recommendation_accepted_count": 19,
+      "rate_suppressed": true,
+      "recommendation_accepted_count": 0,
       "recommended_position_counts": [
-        11,
-        5,
-        6
+        0,
+        0,
+        0
       ],
       "round_number": 2,
       "round_type": "skill"
@@ -1330,20 +117,20 @@
     {
       "average_meaningful_preference_disagreement_margin": null,
       "chosen_position_counts": [
-        8,
-        5,
-        6
+        0,
+        0,
+        0
       ],
-      "event_count": 19,
+      "event_count": 0,
       "meaningful_preference_disagreement_count": null,
       "player_preference_agreement_count": null,
       "preference_top_disagreement_count": null,
-      "rate_suppressed": false,
-      "recommendation_accepted_count": 16,
+      "rate_suppressed": true,
+      "recommendation_accepted_count": 0,
       "recommended_position_counts": [
-        8,
-        6,
-        5
+        0,
+        0,
+        0
       ],
       "round_number": 3,
       "round_type": "skill"
@@ -1351,20 +138,20 @@
     {
       "average_meaningful_preference_disagreement_margin": null,
       "chosen_position_counts": [
-        9,
-        6,
-        4
+        0,
+        0,
+        0
       ],
-      "event_count": 19,
+      "event_count": 0,
       "meaningful_preference_disagreement_count": null,
       "player_preference_agreement_count": null,
       "preference_top_disagreement_count": null,
-      "rate_suppressed": false,
-      "recommendation_accepted_count": 18,
+      "rate_suppressed": true,
+      "recommendation_accepted_count": 0,
       "recommended_position_counts": [
-        8,
-        7,
-        4
+        0,
+        0,
+        0
       ],
       "round_number": 4,
       "round_type": "hero"
@@ -1372,20 +159,20 @@
     {
       "average_meaningful_preference_disagreement_margin": null,
       "chosen_position_counts": [
-        8,
-        7,
-        4
+        0,
+        0,
+        0
       ],
-      "event_count": 19,
+      "event_count": 0,
       "meaningful_preference_disagreement_count": null,
       "player_preference_agreement_count": null,
       "preference_top_disagreement_count": null,
-      "rate_suppressed": false,
-      "recommendation_accepted_count": 17,
+      "rate_suppressed": true,
+      "recommendation_accepted_count": 0,
       "recommended_position_counts": [
-        7,
-        6,
-        6
+        0,
+        0,
+        0
       ],
       "round_number": 5,
       "round_type": "skill"
@@ -1393,20 +180,20 @@
     {
       "average_meaningful_preference_disagreement_margin": null,
       "chosen_position_counts": [
-        6,
-        6,
-        7
+        0,
+        0,
+        0
       ],
-      "event_count": 19,
+      "event_count": 0,
       "meaningful_preference_disagreement_count": null,
       "player_preference_agreement_count": null,
       "preference_top_disagreement_count": null,
-      "rate_suppressed": false,
-      "recommendation_accepted_count": 19,
+      "rate_suppressed": true,
+      "recommendation_accepted_count": 0,
       "recommended_position_counts": [
-        6,
-        6,
-        7
+        0,
+        0,
+        0
       ],
       "round_number": 6,
       "round_type": "skill"
@@ -1414,20 +201,20 @@
     {
       "average_meaningful_preference_disagreement_margin": null,
       "chosen_position_counts": [
-        2,
-        1,
-        1
+        0,
+        0,
+        0
       ],
-      "event_count": 4,
+      "event_count": 0,
       "meaningful_preference_disagreement_count": null,
       "player_preference_agreement_count": null,
       "preference_top_disagreement_count": null,
       "rate_suppressed": true,
-      "recommendation_accepted_count": 4,
+      "recommendation_accepted_count": 0,
       "recommended_position_counts": [
-        2,
-        1,
-        1
+        0,
+        0,
+        0
       ],
       "round_number": 7,
       "round_type": "hero"
@@ -1436,40 +223,77 @@
       "average_meaningful_preference_disagreement_margin": null,
       "chosen_position_counts": [
         0,
-        2,
-        1
+        0,
+        0
       ],
-      "event_count": 3,
+      "event_count": 0,
       "meaningful_preference_disagreement_count": null,
       "player_preference_agreement_count": null,
       "preference_top_disagreement_count": null,
       "rate_suppressed": true,
-      "recommendation_accepted_count": 3,
+      "recommendation_accepted_count": 0,
       "recommended_position_counts": [
         0,
-        2,
-        1
+        0,
+        0
       ],
       "round_number": 8,
+      "round_type": "skill"
+    },
+    {
+      "average_meaningful_preference_disagreement_margin": null,
+      "chosen_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "event_count": 0,
+      "meaningful_preference_disagreement_count": null,
+      "player_preference_agreement_count": null,
+      "preference_top_disagreement_count": null,
+      "rate_suppressed": true,
+      "recommendation_accepted_count": 0,
+      "recommended_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "round_number": 9,
+      "round_type": "hero"
+    },
+    {
+      "average_meaningful_preference_disagreement_margin": null,
+      "chosen_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "event_count": 0,
+      "meaningful_preference_disagreement_count": null,
+      "player_preference_agreement_count": null,
+      "preference_top_disagreement_count": null,
+      "rate_suppressed": true,
+      "recommendation_accepted_count": 0,
+      "recommended_position_counts": [
+        0,
+        0,
+        0
+      ],
+      "round_number": 10,
       "round_type": "skill"
     }
   ],
   "schema": {
     "source_event_schema_version": 1,
-    "version": 4
+    "version": 5
   },
   "summary": {
-    "estimated_session_count": 29,
-    "event_count": 129,
-    "invalid_event_count": 1,
-    "model_versions": [
-      {
-        "event_count": 129,
-        "version": "2:5595010354864ec9"
-      }
-    ],
+    "estimated_session_count": 0,
+    "event_count": 0,
+    "invalid_event_count": 0,
+    "model_versions": [],
     "preference_event_count": 0,
     "preference_model_versions": [],
-    "recommendation_accepted_count": 115
+    "recommendation_accepted_count": 0
   }
 }

--- a/web/src/components/game/CurrentTeam.tsx
+++ b/web/src/components/game/CurrentTeam.tsx
@@ -53,6 +53,9 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
 
   const hasSupportHero = !!supportHero;
   const hasSupportSkills = (supportSkills || []).length >= 2;
+  const showSupportSelectionHint =
+    (state.gameState?.round_number ?? 1) < 7 &&
+    (!hasSupportHero || !hasSupportSkills);
   const isAvailableInSelectedSeason = (season: number | undefined) =>
     selectedSeason === null || season === undefined || season <= selectedSeason;
   const supportAvailableHeroes = (availableHeroes || []).filter((hero) =>
@@ -254,7 +257,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
           </Box>
         )}
 
-        {editable && (!hasSupportHero || !hasSupportSkills) && (
+        {editable && showSupportSelectionHint && (
           <Alert
             severity="info"
             variant="outlined"

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { Container, Box, Button, Alert, CircularProgress, Typography, Paper, Snackbar } from "@mui/material";
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useGame } from "../../context/GameContext";
 import { api } from "../../services/api";
-import { getRoundType, getItemsPerSet } from "../../services/gameLogic";
+import { getRoundType, getItemsPerSet, TOTAL_ROUNDS } from "../../services/gameLogic";
 import { generateLLMPrompt } from "../../services/promptGenerator";
 import RoundInfo from "./RoundInfo";
 import CurrentTeam from "./CurrentTeam";
@@ -16,6 +16,62 @@ import type { SetName } from "../../types/game";
 import type { OptionAnalysis } from "../../services/recommendationEngine";
 import type { PreferencePrediction } from "../../types/telemetryData";
 import { recordRoundTelemetry } from "../../services/telemetry";
+
+interface QualificationInterstitialProps {
+  roundNumber: 7 | 9;
+  onContinue: () => void;
+  children: ReactNode;
+}
+
+const QualificationInterstitial = ({
+  roundNumber,
+  onContinue,
+  children,
+}: QualificationInterstitialProps) => (
+  <Container maxWidth="xl" disableGutters>
+    <Box>
+      <RoundInfo roundNumber={roundNumber} />
+      <Paper sx={{ p: 3, mb: 3, textAlign: "center" }}>
+        <Typography variant="overline" color="error.main">州内小组赛</Typography>
+        <Typography component="h2" variant="h4" gutterBottom sx={{ mb: { xs: 0, md: 3 } }}>
+          整军再战
+        </Typography>
+        <Button
+          variant="contained"
+          color="primary"
+          size="large"
+          fullWidth
+          sx={{
+            display: { xs: "flex", md: "none" },
+            mt: 2,
+            mb: 3,
+            maxWidth: 360,
+            mx: "auto",
+          }}
+          onClick={onContinue}
+        >
+          我赢了，进入下一轮
+        </Button>
+        {children}
+        <Button
+          variant="contained"
+          color="primary"
+          size="large"
+          fullWidth
+          sx={{
+            display: { xs: "none", md: "flex" },
+            mt: 3,
+            maxWidth: 360,
+            mx: "auto",
+          }}
+          onClick={onContinue}
+        >
+          我赢了，进入下一轮
+        </Button>
+      </Paper>
+    </Box>
+  </Container>
+);
 
 /**
  * Main game board component - manages game flow
@@ -43,90 +99,49 @@ const GameBoard = () => {
   }
 
   const roundNumber = gameState.round_number;
-  const roundType = getRoundType(roundNumber);
-  const itemsPerSet = getItemsPerSet(roundNumber);
-
-  // Filter out already-selected heroes/skills (including support) from the available items
   const supportHero = gameState.support_hero || null;
   const supportSkillsList = gameState.support_skills || [];
-  const selectedHeroes = new Set([...(gameState.current_heroes || []), ...(supportHero ? [supportHero] : [])]);
-  const selectedSkills = new Set([...(gameState.current_skills || []), ...supportSkillsList]);
-
-  let availableItems: string[];
-  if (roundType === "hero") {
-    // Only show heroes not already selected
-    availableItems = availableHeroes.filter(h => !selectedHeroes.has(h));
-  } else {
-    // During rounds, only show orange regular skills (no hero skills, no purple), exclude already-selected
-    availableItems = orangeRegularSkills.filter(s => !selectedSkills.has(s));
-  }
 
   const handleUpdateTeam = (heroes: string[], skills: string[]) => {
     dispatch({ type: "UPDATE_TEAM", heroes, skills });
   };
 
-  // Interstitial page between round 6 and 7 (州内小组赛)
-  if (roundNumber === 7 && !gameState.round7_interstitial_dismissed) {
+  const qualificationRound =
+    roundNumber === 7 && !gameState.round7_interstitial_dismissed
+      ? 7
+      : roundNumber === 9 && !gameState.round9_interstitial_dismissed
+        ? 9
+        : null;
+
+  if (qualificationRound) {
     return (
-      <Container maxWidth="xl" disableGutters>
-        <Box>
-          <RoundInfo roundNumber={7} />
-          <Paper sx={{ p: 3, mb: 3, textAlign: "center" }}>
-            <Typography variant="overline" color="error.main">州内小组赛</Typography>
-            <Typography component="h2" variant="h4" gutterBottom sx={{ mb: { xs: 0, md: 3 } }}>
-              整军再战
-            </Typography>
-            <Button
-              variant="contained"
-              color="primary"
-              size="large"
-              fullWidth
-              sx={{
-                display: { xs: "flex", md: "none" },
-                mt: 2,
-                mb: 3,
-                maxWidth: 360,
-                mx: "auto",
-              }}
-              onClick={() => dispatch({ type: "DISMISS_ROUND7_INTERSTITIAL" })}
-            >
-              我赢了，进入下一轮
-            </Button>
-            <CurrentTeam
-              heroes={gameState.current_heroes}
-              skills={gameState.current_skills}
-              availableHeroes={availableHeroes}
-              heroMetadata={heroMetadata}
-              skillMetadata={skillMetadata}
-              availableSkills={regularSkills}
-              onUpdateTeam={handleUpdateTeam}
-              editable={true}
-              supportHero={supportHero}
-              supportSkills={supportSkillsList}
-            />
-            <Button
-              variant="contained"
-              color="primary"
-              size="large"
-              fullWidth
-              sx={{
-                display: { xs: "none", md: "flex" },
-                mt: 3,
-                maxWidth: 360,
-                mx: "auto",
-              }}
-              onClick={() => dispatch({ type: "DISMISS_ROUND7_INTERSTITIAL" })}
-            >
-              我赢了，进入下一轮
-            </Button>
-          </Paper>
-        </Box>
-      </Container>
+      <QualificationInterstitial
+        roundNumber={qualificationRound}
+        onContinue={() =>
+          dispatch({
+            type: "DISMISS_ROUND_INTERSTITIAL",
+            roundNumber: qualificationRound,
+          })
+        }
+      >
+        <CurrentTeam
+          heroes={gameState.current_heroes}
+          skills={gameState.current_skills}
+          availableHeroes={availableHeroes}
+          heroMetadata={heroMetadata}
+          skillMetadata={skillMetadata}
+          availableSkills={regularSkills}
+          onUpdateTeam={handleUpdateTeam}
+          editable={true}
+          supportHero={supportHero}
+          supportSkills={supportSkillsList}
+        />
+      </QualificationInterstitial>
     );
   }
 
   // Check if game is complete
-  if (roundNumber > 8) {
+  if (roundNumber > TOTAL_ROUNDS) {
     return (
       <Container maxWidth="xl" disableGutters>
         <Box>
@@ -134,7 +149,7 @@ const GameBoard = () => {
             <Typography component="h1" variant="h4" gutterBottom>
               对局完成
             </Typography>
-            你已完成全部 8 轮。可查看最终队伍配置。
+            你已完成全部 {TOTAL_ROUNDS} 轮。可查看最终队伍配置。
           </Alert>
 
           <CurrentTeam
@@ -155,6 +170,22 @@ const GameBoard = () => {
         </Box>
       </Container>
     );
+  }
+
+  const roundType = getRoundType(roundNumber);
+  const itemsPerSet = getItemsPerSet(roundNumber);
+
+  // Filter out already-selected heroes/skills (including support) from the available items
+  const selectedHeroes = new Set([...(gameState.current_heroes || []), ...(supportHero ? [supportHero] : [])]);
+  const selectedSkills = new Set([...(gameState.current_skills || []), ...supportSkillsList]);
+
+  let availableItems: string[];
+  if (roundType === "hero") {
+    // Only show heroes not already selected
+    availableItems = availableHeroes.filter(h => !selectedHeroes.has(h));
+  } else {
+    // During rounds, only show orange regular skills (no hero skills, no purple), exclude already-selected
+    availableItems = orangeRegularSkills.filter(s => !selectedSkills.has(s));
   }
 
   const handleUpdateSet = (setName: SetName, items: string[]) => {

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -149,7 +149,16 @@ const GameBoard = () => {
             <Typography component="h1" variant="h4" gutterBottom>
               对局完成
             </Typography>
-            你已完成全部 {TOTAL_ROUNDS} 轮。可查看最终队伍配置。
+            <Typography variant="body1">
+              你已完成全部 {TOTAL_ROUNDS} 轮。可查看最终队伍配置。
+            </Typography>
+            <Typography
+              component="p"
+              variant="h6"
+              sx={{ mt: 1.25, mb: 0, fontWeight: 800, color: "success.dark" }}
+            >
+              祝你夺冠 🏆
+            </Typography>
           </Alert>
 
           <CurrentTeam

--- a/web/src/components/game/RoundInfo.tsx
+++ b/web/src/components/game/RoundInfo.tsx
@@ -1,7 +1,12 @@
 import { Typography, Stepper, Step, StepLabel, Paper, Box, Button, Chip } from '@mui/material';
 import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
 import { useNavigate } from 'react-router-dom';
-import { getRoundInfo } from '../../services/gameLogic';
+import {
+  getRoundInfo,
+  getRoundType,
+  ROUND_NUMBERS,
+  TOTAL_ROUNDS,
+} from '../../services/gameLogic';
 
 interface RoundInfoProps {
   roundNumber: number;
@@ -13,7 +18,6 @@ interface RoundInfoProps {
 const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
   const navigate = useNavigate();
   const info = getRoundInfo(roundNumber);
-  const rounds = [1, 2, 3, 4, 5, 6, 7, 8];
   
   return (
     <Paper sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, position: 'relative', borderTop: '3px solid', borderTopColor: 'text.primary' }}>
@@ -28,7 +32,7 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
         }}
       >
         <Box sx={{ flex: 1 }}>
-          <Chip size="small" color="error" variant="outlined" label={`第 ${roundNumber} / 8 轮`} sx={{ mb: 1.5 }} />
+          <Chip size="small" color="error" variant="outlined" label={`第 ${roundNumber} / ${TOTAL_ROUNDS} 轮`} sx={{ mb: 1.5 }} />
           <Typography component="h1" variant="h4" gutterBottom>
             {info.title}
           </Typography>
@@ -52,16 +56,16 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
       
       <Box
         role="list"
-        aria-label="8 轮进度"
+        aria-label={`${TOTAL_ROUNDS} 轮进度`}
         sx={{
           display: { xs: 'grid', sm: 'none' },
-          gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+          gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
           gap: 0.75,
           pt: 1,
         }}
       >
-        {rounds.map((round) => {
-          const isHero = round === 1 || round === 4 || round === 7;
+        {ROUND_NUMBERS.map((round) => {
+          const isHero = getRoundType(round) === 'hero';
           const isActive = round === roundNumber;
           const isComplete = round < roundNumber;
           const status = isActive ? '当前' : isComplete ? '已完成' : '未开始';
@@ -97,7 +101,7 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
 
       <Box
         role="region"
-        aria-label="8 轮进度，可横向滚动"
+        aria-label={`${TOTAL_ROUNDS} 轮进度，可横向滚动`}
         tabIndex={0}
         sx={{
           display: { xs: 'none', sm: 'block' },
@@ -109,9 +113,9 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
           },
         }}
       >
-      <Stepper activeStep={roundNumber - 1} alternativeLabel sx={{ mt: 2, minWidth: 660 }}>
-        {rounds.map((round) => {
-          const isHero = round === 1 || round === 4 || round === 7;
+      <Stepper activeStep={roundNumber - 1} alternativeLabel sx={{ mt: 2, minWidth: 820 }}>
+        {ROUND_NUMBERS.map((round) => {
+          const isHero = getRoundType(round) === 'hero';
           return (
             <Step key={round}>
               <StepLabel>

--- a/web/src/components/game/__tests__/RoundInfo.test.tsx
+++ b/web/src/components/game/__tests__/RoundInfo.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RoundInfo from '../RoundInfo';
+
+describe('RoundInfo', () => {
+  test('shows all ten rounds and marks round 9 as the active hero round', () => {
+    render(
+      <MemoryRouter>
+        <RoundInfo roundNumber={9} />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: '第 9 轮：选择武将' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('第 9 / 10 轮')).toBeInTheDocument();
+
+    const progress = screen.getByRole('list', { name: '10 轮进度' });
+    expect(within(progress).getAllByRole('listitem')).toHaveLength(10);
+    expect(
+      within(progress).getByRole('listitem', {
+        name: '第 9 轮，武将，当前',
+      })
+    ).toHaveAttribute('aria-current', 'step');
+  });
+});

--- a/web/src/context/GameContext.tsx
+++ b/web/src/context/GameContext.tsx
@@ -157,14 +157,19 @@ export const gameReducer = (state: ReducerState, action: GameAction): ReducerSta
       };
     }
 
-    case 'DISMISS_ROUND7_INTERSTITIAL':
+    case 'DISMISS_ROUND_INTERSTITIAL': {
+      const dismissedField =
+        action.roundNumber === 7
+          ? 'round7_interstitial_dismissed'
+          : 'round9_interstitial_dismissed';
       return {
         ...state,
         gameState: {
           ...state.gameState!,
-          round7_interstitial_dismissed: true,
+          [dismissedField]: true,
         },
       };
+    }
 
     case 'UPDATE_TEAM':
       return {
@@ -282,7 +287,7 @@ export const GameProvider = ({ children, databaseItems }: GameProviderProps) => 
     }
   }, [state.databaseLoaded, state.selectedSeason]);
 
-  // Auto-save game progress to cookies whenever it changes
+  // Auto-save game progress to versioned local storage whenever it changes.
   useEffect(() => {
     if (state.gameState) {
       storage.saveGameProgress(state.gameState, state.currentRoundInputs);

--- a/web/src/context/__tests__/GameProvider.test.tsx
+++ b/web/src/context/__tests__/GameProvider.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Cookies from 'js-cookie';
 import type { DatabaseItems } from '../../types/game';
-import { storage } from '../../utils/storage';
+import {
+  GAME_PROGRESS_STORAGE_KEY,
+  GAME_PROGRESS_STORAGE_VERSION,
+  storage,
+} from '../../utils/storage';
 import { GameProvider, useGame } from '../GameContext';
 
 vi.mock('../../services/telemetry', () => ({
@@ -38,6 +42,13 @@ const StateProbe = () => {
           ? `${state.maxSeason}:${state.selectedSeason}`
           : 'loading'}
       </output>
+      <output data-testid="game-state">
+        {state.gameState
+          ? `${state.gameState.round_number}:${String(
+            state.gameState.round9_interstitial_dismissed
+          )}`
+          : 'none'}
+      </output>
       <button type="button" onClick={() => dispatch({ type: 'SET_SEASON', season: 7 })}>
         select seven
       </button>
@@ -55,15 +66,53 @@ const renderProvider = (databaseItems: DatabaseItems) =>
     </GameProvider>
   );
 
-describe('GameProvider season persistence', () => {
+describe('GameProvider persistence', () => {
   beforeEach(() => {
+    localStorage.clear();
     Cookies.remove('gameProgress', { path: '/' });
     Cookies.remove('selectedSeason', { path: '/' });
   });
 
   afterEach(() => {
+    localStorage.clear();
     Cookies.remove('gameProgress', { path: '/' });
     Cookies.remove('selectedSeason', { path: '/' });
+  });
+
+  test('restores a versioned round-9 save while leaving its new gate undismissed', async () => {
+    localStorage.setItem(
+      GAME_PROGRESS_STORAGE_KEY,
+      JSON.stringify({
+        version: GAME_PROGRESS_STORAGE_VERSION,
+        gameState: {
+          current_heroes: ['旧武将'],
+          current_skills: ['旧战法'],
+          support_hero: null,
+          support_skills: [],
+          round_number: 9,
+          round_history: [],
+          round7_interstitial_dismissed: true,
+        },
+        currentRoundInputs: {
+          set1: ['新武将'],
+          set2: [],
+          set3: [],
+        },
+      })
+    );
+
+    renderProvider(makeDatabaseItems(16));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('game-state')).toHaveTextContent('9:undefined');
+    });
+    await waitFor(() => {
+      const stored = JSON.parse(
+        localStorage.getItem(GAME_PROGRESS_STORAGE_KEY)!
+      );
+      expect(stored.version).toBe(GAME_PROGRESS_STORAGE_VERSION);
+      expect(stored.gameState.round9_interstitial_dismissed).toBeUndefined();
+    });
   });
 
   test.each([

--- a/web/src/context/__tests__/gameReducer.test.ts
+++ b/web/src/context/__tests__/gameReducer.test.ts
@@ -96,6 +96,38 @@ describe('gameReducer', () => {
     expect(next.isLoading).toBe(false);
   });
 
+  test.each([
+    [7, 'round7_interstitial_dismissed'],
+    [9, 'round9_interstitial_dismissed'],
+  ] as const)(
+    'dismisses the qualification interstitial for round %i',
+    (roundNumber, dismissedField) => {
+      const next = gameReducer({
+        ...initialState,
+        gameState: {
+          current_heroes: [],
+          current_skills: [],
+          support_hero: null,
+          support_skills: [],
+          round_number: roundNumber,
+          round_history: [],
+        },
+      }, {
+        type: 'DISMISS_ROUND_INTERSTITIAL',
+        roundNumber,
+      });
+
+      expect(next.gameState?.[dismissedField]).toBe(true);
+      expect(
+        next.gameState?.[
+          roundNumber === 7
+            ? 'round9_interstitial_dismissed'
+            : 'round7_interstitial_dismissed'
+        ]
+      ).toBeUndefined();
+    }
+  );
+
   test('LOAD_DATABASE marks the database as loaded', () => {
     const next = gameReducer(initialState, {
       type: 'LOAD_DATABASE',

--- a/web/src/pages/BuildATeam.tsx
+++ b/web/src/pages/BuildATeam.tsx
@@ -117,7 +117,7 @@ const BuildATeam = () => {
     [supportHero, supportSkills]
   );
 
-  // Full pool from the current gameState (restored from the cookie on mount),
+  // Full pool from the current gameState (restored from localStorage on mount),
   // including the support hero and support skills.
   const allPoolHeroes = useMemo(
     () => [
@@ -463,7 +463,7 @@ const BuildATeam = () => {
 
       {noPool && (
         <Alert severity="info" sx={{ mb: 2 }}>
-          当前卡池为空。请先在首页（推荐器）设置并进行选秀，卡池会保存在 Cookie 中后再回到本页。
+          当前卡池为空。请先在首页（推荐器）设置并进行选秀；进度保存后再回到本页。
         </Alert>
       )}
 

--- a/web/src/services/__tests__/fixtures/tenRoundFormationFixture.ts
+++ b/web/src/services/__tests__/fixtures/tenRoundFormationFixture.ts
@@ -1,0 +1,55 @@
+/**
+ * Representative completed round-10 pool: 14 normal heroes plus the optional
+ * support hero, and 26 normal skills plus the two optional support skills.
+ *
+ * These are real catalog names so the benchmark exercises the generated model,
+ * signature-skill exclusions, and soft camp/role metadata used in production.
+ */
+export const TEN_ROUND_HERO_POOL = [
+  '刘备',
+  '关羽',
+  '张飞',
+  '诸葛亮',
+  '赵云',
+  '马超',
+  '曹操',
+  '司马懿',
+  '夏侯惇',
+  '孙权',
+  '周瑜',
+  '陆逊',
+  '吕布',
+  '张辽',
+  '貂蝉',
+] as const;
+
+export const TEN_ROUND_SKILL_POOL = [
+  '乐不思蜀',
+  '暗渡阴平',
+  '恩威并行',
+  '未雨绸缪',
+  '诱敌深入',
+  '风助火势',
+  '瞋目横矛',
+  '掠阵破军',
+  '及锋而试',
+  '调和阴阳',
+  '蹈锋饮血',
+  '践墨随敌',
+  '机变无穷',
+  '潜龙在渊',
+  '御敌临前',
+  '虎步连环',
+  '神略制变',
+  '惩前毖后',
+  '万军辟易',
+  '谋而后动',
+  '黄天惑心',
+  '断戈夺锋',
+  '空城计',
+  '步步为营',
+  '智破千军',
+  '挫锐折锋',
+  '运智铺谋',
+  '十面埋伏',
+] as const;

--- a/web/src/services/__tests__/gameLogic.test.ts
+++ b/web/src/services/__tests__/gameLogic.test.ts
@@ -1,0 +1,86 @@
+import type { GameState, RoundType } from '../../types/game';
+import {
+  getItemsPerSet,
+  getRoundInfo,
+  getRoundType,
+  ROUND_NUMBERS,
+  TOTAL_ROUNDS,
+  updateGameState,
+} from '../gameLogic';
+
+const makeGameState = (roundNumber: number): GameState => ({
+  current_heroes: [],
+  current_skills: [],
+  support_hero: null,
+  support_skills: [],
+  round_number: roundNumber,
+  round_history: [],
+});
+
+describe('ten-round game flow', () => {
+  test('defines the canonical type and offer size for every round', () => {
+    const expectedTypes: RoundType[] = [
+      'hero',
+      'skill',
+      'skill',
+      'hero',
+      'skill',
+      'skill',
+      'hero',
+      'skill',
+      'hero',
+      'skill',
+    ];
+
+    expect(TOTAL_ROUNDS).toBe(10);
+    expect(ROUND_NUMBERS.map(getRoundType)).toEqual(expectedTypes);
+    expect(ROUND_NUMBERS.map(getItemsPerSet)).toEqual([
+      3, 3, 3, 3, 3, 3, 2, 3, 2, 3,
+    ]);
+  });
+
+  test('repeats the late-game hero and skill round shapes', () => {
+    expect(getRoundInfo(7)).toMatchObject({
+      roundType: 'hero',
+      itemsPerSet: 2,
+      cycleNumber: 3,
+      roundInCycle: 1,
+    });
+    expect(getRoundInfo(9)).toMatchObject({
+      roundType: 'hero',
+      itemsPerSet: 2,
+      cycleNumber: 4,
+      roundInCycle: 1,
+    });
+    expect(getRoundInfo(10)).toMatchObject({
+      roundType: 'skill',
+      itemsPerSet: 3,
+      cycleNumber: 4,
+      roundInCycle: 2,
+    });
+  });
+
+  test('only marks the game complete after recording round 10', () => {
+    const roundNine = updateGameState(
+      makeGameState(9),
+      'hero',
+      ['武将甲', '武将乙'],
+      0
+    );
+    expect(roundNine.gameComplete).toBe(false);
+    expect(roundNine.gameState.round_number).toBe(10);
+
+    const roundTen = updateGameState(
+      makeGameState(10),
+      'skill',
+      ['战法甲', '战法乙', '战法丙'],
+      1
+    );
+    expect(roundTen.gameComplete).toBe(true);
+    expect(roundTen.gameState.round_number).toBe(11);
+  });
+
+  test('rejects round numbers outside the supported flow', () => {
+    expect(() => getRoundType(11)).toThrow(RangeError);
+  });
+});

--- a/web/src/services/__tests__/promptGenerator.test.ts
+++ b/web/src/services/__tests__/promptGenerator.test.ts
@@ -196,6 +196,26 @@ describe('generateLLMPrompt - model context', () => {
 });
 
 describe('generateLLMPrompt - round planning', () => {
+  test('round 7 prompt accounts for the final hero choice in round 9', async () => {
+    const prompt = await generateLLMPrompt({
+      gameState: {
+        round_number: 7,
+        current_heroes: ['木鹿大王', '诸葛亮2'],
+        current_skills: ['七进七出'],
+        support_hero: null,
+        support_skills: [],
+      } as unknown as GameState,
+      currentRoundInputs: {
+        set1: ['祝融', '孟获'],
+        set2: ['孙权', '陆抗'],
+        set3: ['张宁', '左慈'],
+      },
+      roundType: 'hero',
+    });
+
+    expect(prompt).toContain('第9轮还有一次选将机会');
+  });
+
   test('round 4+ asks for tentative three-team planning; round 3 does not', async () => {
     const mk = (round: number) =>
       generateLLMPrompt({

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -12,6 +12,10 @@ import {
 } from '../recommendationEngine';
 import { recommendationData, database } from '../../data';
 import type { RecommendationData } from '../../types/recommendation';
+import {
+  TEN_ROUND_HERO_POOL,
+  TEN_ROUND_SKILL_POOL,
+} from './fixtures/tenRoundFormationFixture';
 
 /** A small synthetic artifact so pure scoring/optimization is deterministic. */
 function makeData(overrides: Partial<RecommendationData['model']> = {}): RecommendationData {
@@ -339,6 +343,31 @@ describe('recommendTeams — global formation optimization', () => {
     expect(new Set(h0.skills)).toEqual(new Set(['s0', 's1']));
   });
 
+  test('positive SP potential keeps an individually weak decisive pair in the 28→18 shortlist', () => {
+    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 28 }, (_, i) => `s${i}`);
+    const weights: Record<string, number> = {};
+    // A standalone-only shortlist would take exactly s0..s17 and discard both
+    // weak pair members. Their joint value on h0 is decisive, so both must
+    // survive candidate pruning and be assigned together.
+    for (let i = 0; i < 18; i += 1) weights[`S|s${i}`] = 1;
+    weights['S|s26'] = -0.5;
+    weights['S|s27'] = -0.5;
+    weights['SP|h0|s26|s27'] = 4;
+    const data = makeData({
+      weights,
+      support: {},
+      n_features: Object.keys(weights).length,
+    });
+
+    const r = recommendTeams(heroes, skills, data, data.catalog);
+    const h0 = r.options[0].teams
+      .flatMap((team) => team.heroes)
+      .find((hero) => hero.name === 'h0')!;
+
+    expect(new Set(h0.skills)).toEqual(new Set(['s26', 's27']));
+  });
+
   test('skill routing strengthens the top two teams before spending value on the third', () => {
     const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
     const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
@@ -537,38 +566,180 @@ describe('recommendTeams — global formation optimization', () => {
     expect(teamOf('h0')).toBe(teamOf('h1'));
   });
 
-  test('>12 pool trim reserves low-strength 输出核心/体系核心 before filling by strength', () => {
-    // 13 heroes so the pool must be trimmed to 12. The three soft cores are the
-    // *weakest* by individual H-weight, so a pure top-12-by-strength trim would
-    // discard them and no team could then get "exactly one core". The
-    // metadata-aware trim must reserve them, letting the soft role rule place
-    // exactly one 输出核心 and one 体系核心 on each team.
-    const heroes = Array.from({ length: 13 }, (_, i) => `h${i}`);
-    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
-    // h0..h9 are fillers each with a *small* positive individual weight so they
-    // out-rank the cores (which have zero weight and would be trimmed by a pure
-    // top-12), yet the weights are tiny enough (≤0.5 display pts) that placing a
-    // reserved core in a team stays inside the 2.5-display-point top-two band —
-    // so the soft role rule is free to distribute the surviving cores.
+  test('considers the full 15-hero pool before the bounded partition prune', () => {
+    const heroes = Array.from({ length: 15 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 28 }, (_, i) => `s${i}`);
+    // h14 is last by individual weight and would have been removed by the old
+    // top-12 pre-trim. Its strong HP synergy with h13 makes their trio globally
+    // useful, so evaluating the complete pool must keep both as teammates.
     const weights: Record<string, number> = {};
-    for (let i = 0; i < 10; i++) weights[`H|h${i}`] = 0.05 - i * 0.002;
+    for (let i = 0; i < 14; i++) weights[`H|h${i}`] = (14 - i) * 0.01;
+    weights['HP|h13|h14'] = 4;
     const data = makeData({ weights, support: {}, n_features: Object.keys(weights).length });
-    const meta = {
-      h10: { camp: 'X', label: '输出核心' },
-      h11: { camp: 'X', label: '体系核心' },
-      h12: { camp: 'X', label: '输出核心' },
+    const catalog = {
+      ...data.catalog,
+      hero_count: heroes.length,
+      skill_count: skills.length,
+      default_skill: Object.fromEntries(heroes.map((hero, i) => [hero, `s${i}`])),
     };
-    const r = recommendTeams(heroes, skills, data, data.catalog, meta);
+
+    const enumeratedHeroes = new Set(
+      enumerateFormationPartitions(heroes, data.model, {}).flat(2)
+    );
+    expect(enumeratedHeroes).toEqual(new Set(heroes));
+
+    const r = recommendTeams(heroes, skills, data, catalog);
     expect(r.incomplete).toBe(false);
-    // All three reserved low-strength cores survived the trim AND were placed.
     const placed = new Set(r.options[0].teams.flatMap((t) => t.heroes.map((h) => h.name)));
-    expect(placed.has('h10')).toBe(true);
-    expect(placed.has('h11')).toBe(true);
-    expect(placed.has('h12')).toBe(true);
-    // Deterministic across repeated calls.
-    const r2 = recommendTeams(heroes, skills, data, data.catalog, meta);
+    expect(placed).toContain('h13');
+    expect(placed).toContain('h14');
+    const teamOf = (name: string) =>
+      r.options[0].teams.findIndex((team) =>
+        team.heroes.some((hero) => hero.name === name)
+      );
+    expect(teamOf('h13')).toBe(teamOf('h14'));
+    expect(placed.size).toBe(9);
+
+    const assignedSkills = r.options[0].teams.flatMap((team) =>
+      team.heroes.flatMap((hero) => hero.skills)
+    );
+    expect(assignedSkills).toHaveLength(18);
+    expect(new Set(assignedSkills).size).toBe(18);
+
+    const r2 = recommendTeams(heroes, skills, data, catalog);
     expect(r2).toEqual(r);
-  }, 60000); // 13→12 trim exercises the full beam; allow extra time.
+  }, 60000);
+
+  test('fully evaluates a hero whose decisive HS value is invisible to hero-only pruning', () => {
+    const heroes = Array.from({ length: 15 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 28 }, (_, i) => `s${i}`);
+    const weights: Record<string, number> = {};
+    for (let i = 0; i < 14; i += 1) weights[`H|h${i}`] = 2;
+    // h14 is far below every other hero in the H/HP-only beam, but becomes the
+    // best main-team hero once the full assignment can route s27 onto it.
+    weights['H|h14'] = -20;
+    weights['HS|h14|s27'] = 30;
+    const data = makeData({
+      weights,
+      support: {},
+      n_features: Object.keys(weights).length,
+    });
+    const catalog = {
+      ...data.catalog,
+      hero_count: heroes.length,
+      skill_count: skills.length,
+      default_skill: Object.fromEntries(heroes.map((hero, i) => [hero, `s${i}`])),
+    };
+
+    const partitions = enumerateFormationPartitions(heroes, data.model, {});
+    expect(
+      partitions.some((partition) => partition.flat().includes('h14'))
+    ).toBe(true);
+
+    const r = recommendTeams(heroes, skills, data, catalog);
+    const placed = r.options[0].teams.flatMap((team) => team.heroes);
+    const h14 = placed.find((hero) => hero.name === 'h14');
+    expect(h14?.skills).toContain('s27');
+  }, 10000);
+
+  test('deterministically caps out-of-contract 16+ hero pools before enumeration', () => {
+    const heroes = Array.from({ length: 17 }, (_, i) => `h${i}`);
+    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
+    const weights = Object.fromEntries(
+      heroes.map((hero, i) => [`H|${hero}`, heroes.length - i])
+    );
+    const data = makeData({
+      weights,
+      support: {},
+      n_features: Object.keys(weights).length,
+    });
+    const catalog = {
+      ...data.catalog,
+      hero_count: heroes.length,
+      default_skill: Object.fromEntries(heroes.map((hero, i) => [hero, `s${i}`])),
+    };
+
+    const partitions = enumerateFormationPartitions(heroes, data.model, {});
+    const again = enumerateFormationPartitions([...heroes].reverse(), data.model, {});
+    const covered = new Set(partitions.flat(2));
+    expect(covered).toEqual(new Set(heroes.slice(0, 15)));
+    expect(partitions.length).toBeLessThanOrEqual(PARTITION_EVAL_CAP);
+    expect(again).toEqual(partitions);
+
+    const r = recommendTeams(heroes, skills, data, catalog);
+    const placed = r.options[0].teams.flatMap((team) =>
+      team.heroes.map((hero) => hero.name)
+    );
+    expect(placed.every((hero) => !['h15', 'h16'].includes(hero))).toBe(true);
+  }, 10000);
+
+  test('realistic 15-hero / 28-skill round-10 pool stays within the interactive budget', () => {
+    const heroMeta = Object.fromEntries(
+      TEN_ROUND_HERO_POOL.map((name) => [
+        name,
+        {
+          camp: database.heroes[name].camp,
+          label: database.heroes[name].label,
+        },
+      ])
+    );
+
+    const partitions = enumerateFormationPartitions(
+      [...TEN_ROUND_HERO_POOL],
+      recommendationData.model,
+      heroMeta
+    );
+    expect(new Set(partitions.flat(2))).toEqual(new Set(TEN_ROUND_HERO_POOL));
+    expect(partitions.length).toBeLessThanOrEqual(PARTITION_EVAL_CAP);
+    expect(
+      enumerateFormationPartitions(
+        [...TEN_ROUND_HERO_POOL],
+        recommendationData.model,
+        heroMeta
+      )
+    ).toEqual(partitions);
+
+    const startedAt = performance.now();
+    const r = recommendTeams(
+      [...TEN_ROUND_HERO_POOL],
+      [...TEN_ROUND_SKILL_POOL],
+      recommendationData,
+      recommendationData.catalog,
+      heroMeta
+    );
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(r.incomplete).toBe(false);
+    expect(r.options.length).toBeGreaterThan(0);
+    for (const option of r.options) {
+      const assignedHeroes = option.teams.flatMap((team) => team.heroes);
+      expect(assignedHeroes).toHaveLength(9);
+      expect(new Set(assignedHeroes.map((hero) => hero.name)).size).toBe(9);
+      const assignedSkills = assignedHeroes.flatMap((hero) => hero.skills);
+      expect(assignedSkills).toHaveLength(18);
+      expect(new Set(assignedSkills).size).toBe(18);
+      for (const hero of assignedHeroes) {
+        expect(hero.skills).toHaveLength(2);
+        expect(hero.skills).not.toContain(
+          recommendationData.catalog.default_skill[hero.name]
+        );
+      }
+    }
+    expect(
+      recommendTeams(
+        [...TEN_ROUND_HERO_POOL],
+        [...TEN_ROUND_SKILL_POOL],
+        recommendationData,
+        recommendationData.catalog,
+        heroMeta
+      )
+    ).toEqual(r);
+    // Leave headroom for shared/CI hosts while guarding against an accidental
+    // return to unbounded full-partition evaluation. The engineering target on
+    // a developer machine is approximately two seconds.
+    expect(elapsedMs).toBeLessThan(5_000);
+    console.info(`recommendTeams 15 heroes / 28 skills: ${elapsedMs.toFixed(1)} ms`);
+  }, 20000);
 
   test('is deterministic with hero metadata', () => {
     const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);

--- a/web/src/services/__tests__/telemetry.test.ts
+++ b/web/src/services/__tests__/telemetry.test.ts
@@ -80,6 +80,39 @@ describe('round telemetry construction', () => {
     expect(createRoundTelemetryEvent({ ...INPUT, pairedScores: [1, 2] })).toBeNull();
   });
 
+  test('accepts round 9 and 10 with their repeated offer shapes', () => {
+    const round9 = createRoundTelemetryEvent({
+      ...INPUT,
+      roundNumber: 9,
+      offeredSets: INPUT.offeredSets.map((set) => set.slice(0, 2)),
+    });
+    const round10 = createRoundTelemetryEvent({
+      ...INPUT,
+      roundNumber: 10,
+      roundType: 'skill',
+    });
+
+    expect(round9).toMatchObject({ round_number: 9, round_type: 'hero' });
+    expect(round10).toMatchObject({ round_number: 10, round_type: 'skill' });
+  });
+
+  test('rejects a mismatched round type, offer size, or round 11', () => {
+    expect(
+      createRoundTelemetryEvent({
+        ...INPUT,
+        roundNumber: 9,
+        roundType: 'skill',
+        offeredSets: INPUT.offeredSets.map((set) => set.slice(0, 2)),
+      })
+    ).toBeNull();
+    expect(
+      createRoundTelemetryEvent({ ...INPUT, roundNumber: 9 })
+    ).toBeNull();
+    expect(
+      createRoundTelemetryEvent({ ...INPUT, roundNumber: 11 })
+    ).toBeNull();
+  });
+
   test('records the exact displayed preference model and normalized probabilities', () => {
     const event = createRoundTelemetryEvent({
       ...INPUT,

--- a/web/src/services/__tests__/telemetryData.test.ts
+++ b/web/src/services/__tests__/telemetryData.test.ts
@@ -242,6 +242,58 @@ const insufficientV4Artifact = (): Record<string, any> => {
   return artifact;
 };
 
+const insufficientV5Artifact = (): Record<string, any> => {
+  const artifact = insufficientV4Artifact();
+  artifact.schema.version = 5;
+  artifact.rounds.push(
+    {
+      ...clone(artifact.rounds[6]),
+      round_number: 9,
+      round_type: 'hero',
+    },
+    {
+      ...clone(artifact.rounds[7]),
+      round_number: 10,
+      round_type: 'skill',
+    }
+  );
+  return artifact;
+};
+
+const readyV5Artifact = (): Record<string, any> => {
+  const artifact = readyV4Artifact();
+  artifact.schema.version = 5;
+  artifact.rounds.push(
+    {
+      round_number: 9,
+      round_type: 'hero',
+      event_count: 0,
+      recommendation_accepted_count: 0,
+      chosen_position_counts: [0, 0, 0],
+      recommended_position_counts: [0, 0, 0],
+      rate_suppressed: true,
+      preference_top_disagreement_count: 0,
+      meaningful_preference_disagreement_count: 0,
+      player_preference_agreement_count: 0,
+      average_meaningful_preference_disagreement_margin: null,
+    },
+    {
+      round_number: 10,
+      round_type: 'skill',
+      event_count: 0,
+      recommendation_accepted_count: 0,
+      chosen_position_counts: [0, 0, 0],
+      recommended_position_counts: [0, 0, 0],
+      rate_suppressed: true,
+      preference_top_disagreement_count: 0,
+      meaningful_preference_disagreement_count: 0,
+      player_preference_agreement_count: 0,
+      average_meaningful_preference_disagreement_margin: null,
+    }
+  );
+  return artifact;
+};
+
 const responseFor = (body: unknown): Response =>
   ({
     ok: true,
@@ -256,14 +308,16 @@ afterEach(() => {
 });
 
 describe('static telemetry artifact boundary', () => {
-  test('accepts the generated schema-v3/v4 hand-off during transition', () => {
+  test('accepts the generated schema-v3+ hand-off during transition', () => {
     const telemetry = parseTelemetryData(telemetryRaw);
 
     expect(telemetry.summary.event_count).toBe(
       telemetry.rounds.reduce((sum, round) => sum + round.event_count, 0)
     );
-    expect(telemetry.rounds).toHaveLength(8);
-    expect([3, 4]).toContain(telemetry.schema.version);
+    expect(telemetry.rounds).toHaveLength(
+      telemetry.schema.version === 5 ? 10 : 8
+    );
+    expect([3, 4, 5]).toContain(telemetry.schema.version);
     expect(telemetry.analytics?.minimum_rate_support).toBe(10);
     expect(telemetry.preference_model?.status).toMatch(
       /^(insufficient_evidence|quality_gate_failed|ready)$/
@@ -272,10 +326,24 @@ describe('static telemetry artifact boundary', () => {
       expect(telemetry.summary.session_count).toBeTypeOf('number');
       expect(telemetry.summary.estimated_session_count).toBeUndefined();
     } else {
-      expect(telemetry.schema.version).toBe(4);
+      expect([4, 5]).toContain(telemetry.schema.version);
       expect(telemetry.summary.estimated_session_count).toBeTypeOf('number');
       expect(telemetry.summary.session_count).toBeUndefined();
     }
+  });
+
+  test('requires ten ordered rounds for schema v5 while preserving v4', () => {
+    expect(parseTelemetryData(insufficientV5Artifact()).rounds).toHaveLength(
+      10
+    );
+
+    const shortV5 = insufficientV5Artifact();
+    shortV5.rounds.pop();
+    expect(() => parseTelemetryData(shortV5)).toThrow('contract');
+
+    const longV4 = insufficientV4Artifact();
+    longV4.rounds.push(clone(longV4.rounds[0]));
+    expect(() => parseTelemetryData(longV4)).toThrow('contract');
   });
 
   test('continues to accept the frozen schema-v2 contract', () => {
@@ -501,6 +569,25 @@ describe('static telemetry artifact boundary', () => {
       ])
     );
     expect(() => parseTelemetryData(tooMany)).toThrow('ready model');
+  });
+
+  test('caps frozen model round features at eight and allows ten in v5', () => {
+    for (const artifact of [readyArtifact(), readyV4Artifact()]) {
+      artifact.preference_model.weights = { '["round_score",8]': 0.5 };
+      artifact.preference_model.support = { '["round_score",8]': 30 };
+      expect(parseTelemetryData(artifact).preference_model?.status).toBe(
+        'ready'
+      );
+
+      artifact.preference_model.weights = { '["round_score",9]': 0.5 };
+      artifact.preference_model.support = { '["round_score",9]': 30 };
+      expect(() => parseTelemetryData(artifact)).toThrow('ready model');
+    }
+
+    const current = readyV5Artifact();
+    current.preference_model.weights = { '["round_score",10]': 0.5 };
+    current.preference_model.support = { '["round_score",10]': 30 };
+    expect(parseTelemetryData(current).preference_model?.status).toBe('ready');
   });
 
   test('cross-checks item opportunities, item suppression, and margin totals', () => {

--- a/web/src/services/gameLogic.ts
+++ b/web/src/services/gameLogic.ts
@@ -3,6 +3,37 @@
  */
 import type { GameState, RoundType } from '../types/game';
 
+export const TOTAL_ROUNDS = 10;
+export const ROUND_NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
+
+interface RoundDefinition {
+  roundType: RoundType;
+  itemsPerSet: number;
+  cycleNumber: number;
+  roundInCycle: number;
+}
+
+const ROUND_DEFINITIONS: Record<number, RoundDefinition> = {
+  1: { roundType: 'hero', itemsPerSet: 3, cycleNumber: 1, roundInCycle: 1 },
+  2: { roundType: 'skill', itemsPerSet: 3, cycleNumber: 1, roundInCycle: 2 },
+  3: { roundType: 'skill', itemsPerSet: 3, cycleNumber: 1, roundInCycle: 3 },
+  4: { roundType: 'hero', itemsPerSet: 3, cycleNumber: 2, roundInCycle: 1 },
+  5: { roundType: 'skill', itemsPerSet: 3, cycleNumber: 2, roundInCycle: 2 },
+  6: { roundType: 'skill', itemsPerSet: 3, cycleNumber: 2, roundInCycle: 3 },
+  7: { roundType: 'hero', itemsPerSet: 2, cycleNumber: 3, roundInCycle: 1 },
+  8: { roundType: 'skill', itemsPerSet: 3, cycleNumber: 3, roundInCycle: 2 },
+  9: { roundType: 'hero', itemsPerSet: 2, cycleNumber: 4, roundInCycle: 1 },
+  10: { roundType: 'skill', itemsPerSet: 3, cycleNumber: 4, roundInCycle: 2 },
+};
+
+const getRoundDefinition = (roundNumber: number): RoundDefinition => {
+  const definition = ROUND_DEFINITIONS[roundNumber];
+  if (!definition) {
+    throw new RangeError(`Unsupported round number: ${roundNumber}`);
+  }
+  return definition;
+};
+
 /**
  * Create initial game state from starting heroes and skills.
  */
@@ -50,7 +81,7 @@ export const updateGameState = (
   });
 
   // Check if game is complete before advancing round
-  const gameComplete = newState.round_number >= 8;
+  const gameComplete = newState.round_number >= TOTAL_ROUNDS;
 
   // Advance round
   newState.round_number += 1;
@@ -59,20 +90,17 @@ export const updateGameState = (
 };
 
 /**
- * Get round type based on round number. Rounds 1/4/7 = hero; the rest = skill.
+ * Get round type based on the canonical round definition.
  */
 export const getRoundType = (roundNumber: number): RoundType => {
-  return roundNumber === 1 || roundNumber === 4 || roundNumber === 7 ? 'hero' : 'skill';
+  return getRoundDefinition(roundNumber).roundType;
 };
 
 /**
  * Get items per set based on round number.
  */
 export const getItemsPerSet = (roundNumber: number): number => {
-  // Round 7: 2 heroes per set, Round 8: 3 skills per set
-  if (roundNumber === 7) return 2;
-  if (roundNumber === 8) return 3;
-  return 3; // Default for rounds 1-6
+  return getRoundDefinition(roundNumber).itemsPerSet;
 };
 
 export interface RoundInfo {
@@ -89,21 +117,12 @@ export interface RoundInfo {
  * Get round information for display.
  */
 export const getRoundInfo = (roundNumber: number): RoundInfo => {
-  const roundType = getRoundType(roundNumber);
-  const itemsPerSet = getItemsPerSet(roundNumber);
-
-  let cycleNumber: number;
-  let roundInCycle: number;
-  if (roundNumber <= 3) {
-    cycleNumber = 1;
-    roundInCycle = roundNumber;
-  } else if (roundNumber <= 6) {
-    cycleNumber = 2;
-    roundInCycle = roundNumber - 3;
-  } else {
-    cycleNumber = 3;
-    roundInCycle = roundNumber - 6;
-  }
+  const {
+    roundType,
+    itemsPerSet,
+    cycleNumber,
+    roundInCycle,
+  } = getRoundDefinition(roundNumber);
 
   const typeText = roundType === 'hero' ? '武将' : '战法';
 

--- a/web/src/services/promptGenerator.ts
+++ b/web/src/services/promptGenerator.ts
@@ -43,6 +43,7 @@ const promptInstructions = () => [
 ];
 
 const ROUND_FOUR_HERO_TIP = '第4轮选将提醒：下一次选将要等到第7轮，不要只为未来阵容画饼；本轮武将应优先评估能否立刻与已有武将或同组选项成队。';
+const ROUND_SEVEN_HERO_TIP = '第7轮选将提醒：第9轮还有一次选将机会；本轮先补强能立即组成的队伍，再把最后缺口留给第9轮。';
 
 const model = recommendationData.model;
 const analytics = recommendationData.analytics;
@@ -406,6 +407,8 @@ export async function generateLLMPrompt({
   lines.push(`第 ${gameState.round_number} 轮 | 选择类型: ${roundTypeText}`);
   if (roundType === 'hero' && gameState.round_number === 4) {
     lines.push(`提示：${ROUND_FOUR_HERO_TIP}`);
+  } else if (roundType === 'hero' && gameState.round_number === 7) {
+    lines.push(`提示：${ROUND_SEVEN_HERO_TIP}`);
   }
   lines.push('');
 

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -647,10 +647,25 @@ const TOP_TWO_BAND = 2.5;
  * worst-case product (~56·18·8) can exceed the pre-structure search size; this
  * cap pulls the fully-evaluated set back near the previous ~1920 bound while a
  * deterministic strength/structure interleave (see {@link capPartitions}) keeps
- * a deliberate mix of both kinds of candidate. Pools of 9–11 heroes enumerate
- * far fewer than this, so the cap only bites on the largest (12-hero) pools.
+ * a deliberate mix of both kinds of candidate. Small pools enumerate far fewer
+ * than this; the cap keeps the full 15-hero post-round-10 pool bounded without
+ * excluding heroes before trio strength and structure have been evaluated.
  */
 export const PARTITION_EVAL_CAP = 1920;
+
+/** Maximum hero pool supported by the ten-round draft contract. */
+const FORMATION_HERO_POOL_CAP = 15;
+
+/**
+ * Full 13–15-hero pools produce far more third-team variants than improve the
+ * primary objective. Retain this many disjoint two-trio candidates—interleaved
+ * between hero-strength and soft-structure rankings—before constructing the
+ * third trio from the remaining heroes. At up to two third-trio variants per
+ * pair, this keeps the expensive full assignment pass near the interactive
+ * budget while generating prospective main-team trios from all available
+ * heroes rather than pre-trimming the pool.
+ */
+const LARGE_POOL_PAIR_CAP = 160;
 
 /** Hero-only strength (hero + internal hero-pair weights) of a trio. */
 function trioHeroStrength(trio: string[], m: PairedModel): number {
@@ -728,25 +743,55 @@ function assignSkills(
 ): Map<string, { skills: string[]; score: number }> | null {
   const heroes = trios.flat();
   const need = heroes.length * 2;
-  // Deterministic candidate order (skills fixed length; keep the strongest by
-  // best-possible hero-skill weight first, then name) and take exactly `need`.
-  const bestHsWeight = (skill: string): number => {
+  const uniqueSkills = [...new Set(skillPool)];
+
+  // Score the shortlist once per skill. Alongside standalone and best-possible
+  // hero-skill value, credit the strongest *positive* feasible within-hero pair
+  // the skill can form. Crediting both members keeps an individually weak but
+  // jointly decisive pair together through the 28→18 prune; the subsequent
+  // global assignment still decides whether that potential can be realised.
+  const bestHsWeight = new Map<string, number>();
+  for (const skill of uniqueSkills) {
     let w = -Infinity;
     for (const hero of heroes) {
       if (skill === catalog.default_skill[hero]) continue;
       const hw = weightOf(m, heroSkillId(hero, skill));
       if (hw > w) w = hw;
     }
-    return w === -Infinity ? 0 : w;
-  };
-  const orderedSkills = [...new Set(skillPool)].sort((a, b) => {
-    // S| is constant only after the 18 skills have been chosen. Include it when
-    // selecting which 18 to use from a manually-expanded pool.
-    const wa = weightOf(m, skillId(a)) + bestHsWeight(a);
-    const wb = weightOf(m, skillId(b)) + bestHsWeight(b);
-    if (wb !== wa) return wb - wa;
-    return a.localeCompare(b);
-  });
+    bestHsWeight.set(skill, w === -Infinity ? 0 : w);
+  }
+  const bestPositiveSp = new Map(uniqueSkills.map((skill) => [skill, 0]));
+  for (const hero of heroes) {
+    const signature = catalog.default_skill[hero];
+    for (let i = 0; i < uniqueSkills.length; i += 1) {
+      const first = uniqueSkills[i];
+      if (first === signature) continue;
+      for (let j = i + 1; j < uniqueSkills.length; j += 1) {
+        const second = uniqueSkills[j];
+        if (second === signature) continue;
+        const synergy = weightOf(m, skillPairId(hero, first, second));
+        if (synergy <= 0) continue;
+        if (synergy > (bestPositiveSp.get(first) ?? 0)) {
+          bestPositiveSp.set(first, synergy);
+        }
+        if (synergy > (bestPositiveSp.get(second) ?? 0)) {
+          bestPositiveSp.set(second, synergy);
+        }
+      }
+    }
+  }
+  const orderedSkills = uniqueSkills
+    .map((skill) => ({
+      skill,
+      score:
+        weightOf(m, skillId(skill)) +
+        (bestHsWeight.get(skill) ?? 0) +
+        (bestPositiveSp.get(skill) ?? 0),
+    }))
+    .sort((a, b) =>
+      b.score !== a.score ? b.score - a.score : a.skill.localeCompare(b.skill)
+    )
+    .map(({ skill }) => skill);
 
   const assign = new Map<string, string[]>();
   heroes.forEach((h) => assign.set(h, []));
@@ -901,51 +946,6 @@ function structureScore(trios: string[][], meta: HeroMeta): StructureScore {
   return { outputCoreTeams, systemCoreTeams, sameCampTeams };
 }
 
-/** How many of each soft core the formation reserves when trimming a big pool. */
-const RESERVED_PER_CORE = 3;
-
-/**
- * Trim a strength-ranked hero list to at most `cap` heroes, metadata-aware.
- *
- * A pure top-`cap`-by-weight trim can discard every low-weight 输出核心/体系核心
- * before the structural rules ever run, making "exactly one core per team"
- * impossible. To avoid that we first *reserve* up to {@link RESERVED_PER_CORE}
- * of the strongest available 输出核心 and up to {@link RESERVED_PER_CORE} of the
- * strongest available 体系核心 (a hero labelled as both counts for both, but is
- * only added once), then fill the remaining slots from the strength-ranked list,
- * deduping. `ranked` is assumed already sorted strongest-first deterministically,
- * so the result is deterministic. When no metadata is present the reservation is
- * empty and this degrades to the plain top-`cap` trim.
- */
-function trimPool(ranked: string[], meta: HeroMeta, cap: number): string[] {
-  if (ranked.length <= cap) return [...ranked];
-
-  const reserved: string[] = [];
-  const seen = new Set<string>();
-  const reserveByLabel = (label: string) => {
-    let taken = 0;
-    for (const h of ranked) {
-      if (taken >= RESERVED_PER_CORE || reserved.length >= cap) break;
-      if (seen.has(h)) continue;
-      if (meta[h]?.label !== label) continue;
-      reserved.push(h);
-      seen.add(h);
-      taken += 1;
-    }
-  };
-  reserveByLabel(OUTPUT_CORE_LABEL);
-  reserveByLabel(SYSTEM_CORE_LABEL);
-
-  const out = [...reserved];
-  for (const h of ranked) {
-    if (out.length >= cap) break;
-    if (seen.has(h)) continue;
-    seen.add(h);
-    out.push(h);
-  }
-  return out;
-}
-
 /** Compact positive, family-grouped evidence for one fully-assigned team. */
 function buildTeamEvidence(team: AssignedHero[], m: PairedModel): TeamEvidence {
   const active = activeTeamContributions(team, m);
@@ -1061,6 +1061,178 @@ function partitionKey(trios: string[][]): string {
     .join('||');
 }
 
+/** Canonical, order-independent key for the two prospective main teams. */
+function trioPairKey(trios: [string[], string[]]): string {
+  return trios
+    .map((trio) => [...trio].sort().join('|'))
+    .sort()
+    .join('||');
+}
+
+interface TrioPairCandidate {
+  trios: [string[], string[]];
+  strength: number;
+  structure: number;
+  key: string;
+}
+
+/**
+ * Interleave hero-strength and soft-structure rankings for prospective main
+ * team pairs. This mirrors {@link capPartitions}, but happens before selecting
+ * a third team so the full 15-hero pool does not spend most of its runtime
+ * skill-assigning minor third-team variants.
+ */
+function capTrioPairs(
+  candidates: TrioPairCandidate[],
+  cap: number
+): TrioPairCandidate[] {
+  if (candidates.length <= cap) return candidates;
+  const cmpKey = (a: TrioPairCandidate, b: TrioPairCandidate) =>
+    a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+  const byStrength = [...candidates].sort((a, b) =>
+    b.strength !== a.strength
+      ? b.strength - a.strength
+      : b.structure !== a.structure
+        ? b.structure - a.structure
+        : cmpKey(a, b)
+  );
+  const byStructure = [...candidates].sort((a, b) =>
+    b.structure !== a.structure
+      ? b.structure - a.structure
+      : b.strength !== a.strength
+        ? b.strength - a.strength
+        : cmpKey(a, b)
+  );
+  const picked: TrioPairCandidate[] = [];
+  const seen = new Set<string>();
+  let i = 0;
+  let j = 0;
+  const take = (candidate: TrioPairCandidate) => {
+    if (seen.has(candidate.key)) return;
+    seen.add(candidate.key);
+    picked.push(candidate);
+  };
+  while (picked.length < cap && (i < byStrength.length || j < byStructure.length)) {
+    if (i < byStrength.length) take(byStrength[i++]);
+    if (picked.length >= cap) break;
+    if (j < byStructure.length) take(byStructure[j++]);
+  }
+  return picked;
+}
+
+/**
+ * Build one deterministic, hero-strength-first partition containing `hero`.
+ * This is used only as a coverage fallback after the normal large-pool
+ * trio/pair beam. It ensures a hero whose decisive value lives in HS/SP
+ * features still reaches the full skill-assignment scorer at least once.
+ */
+function coveragePartition(
+  hero: string,
+  pool: string[],
+  m: PairedModel,
+  heroMeta: HeroMeta
+): [string[], string[], string[]] | null {
+  const first = beamTrios(
+    combinations3(pool).filter((trio) => trio.includes(hero)),
+    m,
+    heroMeta,
+    1,
+    0
+  )[0];
+  if (!first) return null;
+
+  const usedFirst = new Set(first);
+  const remainingAfterFirst = pool.filter((candidate) => !usedFirst.has(candidate));
+  const second = beamTrios(
+    combinations3(remainingAfterFirst),
+    m,
+    heroMeta,
+    1,
+    0
+  )[0];
+  if (!second) return null;
+
+  const used = new Set([...first, ...second]);
+  const remaining = pool.filter((candidate) => !used.has(candidate));
+  const third = beamTrios(combinations3(remaining), m, heroMeta, 1, 0)[0];
+  return third ? [first, second, third] : null;
+}
+
+/**
+ * Large-pool search: find prospective main-team pairs first, then construct the
+ * third team from the nine or fewer remaining heroes. Final ranking is still
+ * performed only after global 18-skill assignment in {@link recommendTeams};
+ * this is a bounded candidate-generation strategy, not a replacement score.
+ */
+function enumerateLargePoolPartitions(
+  pool: string[],
+  m: PairedModel,
+  heroMeta: HeroMeta
+): [string[], string[], string[]][] {
+  const pairCandidates: TrioPairCandidate[] = [];
+  const seenPairs = new Set<string>();
+  const firstTrios = beamTrios(combinations3(pool), m, heroMeta, 40, 16);
+  for (const first of firstTrios) {
+    const usedFirst = new Set(first);
+    const remainingAfterFirst = pool.filter((hero) => !usedFirst.has(hero));
+    const secondTrios = beamTrios(
+      combinations3(remainingAfterFirst),
+      m,
+      heroMeta,
+      12,
+      6
+    );
+    for (const second of secondTrios) {
+      const trios: [string[], string[]] = [first, second];
+      const key = trioPairKey(trios);
+      if (seenPairs.has(key)) continue;
+      seenPairs.add(key);
+      pairCandidates.push({
+        trios,
+        strength: trioHeroStrength(first, m) + trioHeroStrength(second, m),
+        structure:
+          trioStructureRank(first, heroMeta) +
+          trioStructureRank(second, heroMeta),
+        key,
+      });
+    }
+  }
+
+  const selectedPairs = capTrioPairs(pairCandidates, LARGE_POOL_PAIR_CAP);
+  const partitions: [string[], string[], string[]][] = [];
+  const seenPartitions = new Set<string>();
+  const coveredHeroes = new Set<string>();
+  const addPartition = (partition: [string[], string[], string[]]) => {
+    const key = partitionKey(partition);
+    if (seenPartitions.has(key)) return;
+    seenPartitions.add(key);
+    partitions.push(partition);
+    for (const hero of partition.flat()) coveredHeroes.add(hero);
+  };
+  for (const { trios: [first, second] } of selectedPairs) {
+    const used = new Set([...first, ...second]);
+    const remaining = pool.filter((hero) => !used.has(hero));
+    // Keep the strongest and the most structurally useful construction of team
+    // three. The union is deterministic and de-duplicated by beamTrios.
+    const thirdTrios = beamTrios(combinations3(remaining), m, heroMeta, 1, 1);
+    for (const third of thirdTrios) {
+      addPartition([first, second, third]);
+    }
+  }
+
+  // Hero-only trio and pair pruning cannot see HS/SP value. Reserve one
+  // strongest feasible partition for each hero that the normal beam missed, so
+  // all supported heroes survive into the expensive full evaluation pass. The
+  // fallback adds at most one partition per hero and therefore remains far
+  // below PARTITION_EVAL_CAP on a 15-hero pool.
+  for (const hero of pool) {
+    if (coveredHeroes.has(hero)) continue;
+    const partition = coveragePartition(hero, pool, m, heroMeta);
+    if (partition) addPartition(partition);
+  }
+  return capPartitions(partitions, m, heroMeta, PARTITION_EVAL_CAP);
+}
+
 /**
  * Deterministically cap the fully-evaluated partition set at {@link PARTITION_EVAL_CAP}.
  *
@@ -1125,28 +1297,43 @@ function capPartitions(
 }
 
 /**
- * Enumerate the bounded, deterministic beam of disjoint 3×3 hero partitions for
- * a pool, then cap the fully-evaluated set at {@link PARTITION_EVAL_CAP}. Each
- * level unions a strength-ranked and a structure-ranked slice so structurally
- * good partitions survive the prune; {@link capPartitions} then interleaves the
- * two rankings globally so the evaluated count stays bounded without biasing the
- * mix. Exported for the evaluation-bound regression test.
+ * Enumerate a bounded, deterministic beam of disjoint 3×3 hero partitions. For
+ * pools up to 12 heroes, each level unions strength- and structure-ranked
+ * slices. For 13–15 heroes, the search selects the two prospective main teams
+ * first and constructs a third team from the remaining heroes. Both paths cap
+ * the fully-evaluated set at {@link PARTITION_EVAL_CAP}; exported for the
+ * evaluation-bound regression test.
  */
 export function enumerateFormationPartitions(
   pool: string[],
   m: PairedModel,
   heroMeta: HeroMeta
 ): [string[], string[], string[]][] {
+  // The game contract tops out at 15 heroes. Canonically rank and cap any
+  // out-of-contract caller before combination generation, preventing a 16+
+  // input from turning into an unbounded combinatorial search.
+  const boundedPool = [...new Set(pool)]
+    .sort((a, b) => {
+      const wa = weightOf(m, heroId(a));
+      const wb = weightOf(m, heroId(b));
+      return wb !== wa ? wb - wa : a.localeCompare(b);
+    })
+    .slice(0, FORMATION_HERO_POOL_CAP);
+
+  if (boundedPool.length > 12) {
+    return enumerateLargePoolPartitions(boundedPool, m, heroMeta);
+  }
+
   const partitions: [string[], string[], string[]][] = [];
   const seen = new Set<string>();
-  const firstTrios = beamTrios(combinations3(pool), m, heroMeta, 40, 16);
+  const firstTrios = beamTrios(combinations3(boundedPool), m, heroMeta, 40, 16);
   for (const t1 of firstTrios) {
     const used1 = new Set(t1);
-    const rest1 = pool.filter((h) => !used1.has(h));
+    const rest1 = boundedPool.filter((h) => !used1.has(h));
     const secondTrios = beamTrios(combinations3(rest1), m, heroMeta, 12, 6);
     for (const t2 of secondTrios) {
       const used2 = new Set([...t1, ...t2]);
-      const rest2 = pool.filter((h) => !used2.has(h));
+      const rest2 = boundedPool.filter((h) => !used2.has(h));
       const thirdTrios = beamTrios(combinations3(rest2), m, heroMeta, 4, 4);
       for (const t3 of thirdTrios) {
         const canon = partitionKey([t1, t2, t3]);
@@ -1312,9 +1499,10 @@ function selectDiverseOptions(
  * `heroMeta` carries the soft 阵营/定位 labels from the database; when omitted the
  * structural preferences are simply inert.
  *
- * Deterministic and bounded for pools of 9–12 heroes. Larger pools are trimmed
- * to 12 heroes with a metadata-aware trim (see {@link trimPool}) that reserves
- * up to three of each soft core before filling by individual weight.
+ * Deterministic and bounded for the full 9–15-hero progression pool. Every
+ * supported hero reaches at least one fully evaluated partition; out-of-contract
+ * 16+ pools are deterministically capped to the 15 strongest individual heroes.
+ * {@link PARTITION_EVAL_CAP} bounds the expensive full skill-assignment pass.
  */
 export function recommendTeams(
   heroPool: string[],
@@ -1333,26 +1521,23 @@ export function recommendTeams(
   };
   if (heroes.length < 9 || skills.length < 18) return incompleteResult;
 
-  // Trim large pools to a bounded set (keeps the beam enumeration tractable);
-  // exactly-9 pools use all 9. Trimming by raw individual weight alone would
-  // drop every low-weight 输出核心/体系核心 before the structural rules run, so
-  // the trim is metadata-aware: reserve up to the three strongest available
-  // 输出核心 and up to the three strongest available 体系核心, then fill the
-  // remaining slots by individual strength. Missing metadata is inert (no hero
-  // is reserved), and the whole trim stays deterministic.
+  // Canonically rank the complete supported pool before feeding it to the
+  // bounded beam. Do not trim within the 15-hero game contract: a low-weight
+  // hero can still form a top trio through HP/HS synergy or provide structure
+  // metadata. Out-of-contract input is deterministically capped before any
+  // combination generation.
   const rankedHeroes = [...heroes].sort((a, b) => {
     const wa = weightOf(m, heroId(a));
     const wb = weightOf(m, heroId(b));
     if (wb !== wa) return wb - wa;
     return a.localeCompare(b);
   });
-  const pool = trimPool(rankedHeroes, heroMeta, 12);
+  const pool = rankedHeroes.slice(0, FORMATION_HERO_POOL_CAP);
 
-  // Build a bounded, deterministic beam of disjoint partitions (each level
-  // unions a strength-ranked and a structure-ranked slice so good structure
-  // survives the prune), then cap the fully-evaluated set at PARTITION_EVAL_CAP
-  // with a deterministic strength/structure interleave. The winner is chosen
-  // later by the full comparator.
+  // Build a bounded, deterministic beam of disjoint partitions. Large pools
+  // identify prospective main-team pairs before constructing team three; small
+  // pools keep the existing per-level beam. The winner is chosen later by the
+  // full global skill-assignment comparator.
   const partitions = enumerateFormationPartitions(pool, m, heroMeta);
 
   // Stage 1: score every feasible fully-assigned partition into candidates.

--- a/web/src/services/telemetry.ts
+++ b/web/src/services/telemetry.ts
@@ -1,6 +1,11 @@
 import { recommendationData } from '../data';
 import type { RoundTelemetryEvent, RoundTelemetryInput } from '../types/telemetry';
 import {
+  getItemsPerSet,
+  getRoundType,
+  TOTAL_ROUNDS,
+} from './gameLogic';
+import {
   enqueueTelemetryEvent,
   getOrCreateTelemetrySession,
   loadTelemetryQueue,
@@ -17,6 +22,15 @@ let flushInFlight: Promise<void> | null = null;
 let initialized = false;
 
 const isValidInput = (input: RoundTelemetryInput): boolean => {
+  if (
+    !Number.isInteger(input.roundNumber) ||
+    input.roundNumber < 1 ||
+    input.roundNumber > TOTAL_ROUNDS
+  ) {
+    return false;
+  }
+  const roundType = getRoundType(input.roundNumber);
+  const itemsPerSet = getItemsPerSet(input.roundNumber);
   const offeredItems = input.offeredSets.flat();
   const occupiedItems =
     input.roundType === 'hero'
@@ -52,10 +66,11 @@ const isValidInput = (input: RoundTelemetryInput): boolean => {
     ) <= 1e-6;
 
   return (
-    Number.isInteger(input.roundNumber) &&
-    input.roundNumber >= 1 &&
-    input.roundNumber <= 8 &&
+    roundType === input.roundType &&
     input.offeredSets.length === 3 &&
+    input.offeredSets.every(
+      (offeredSet) => offeredSet.length === itemsPerSet
+    ) &&
     new Set(offeredItems).size === offeredItems.length &&
     !offeredItems.some((item) => occupiedItems.includes(item)) &&
     input.pairedScores.length === 3 &&

--- a/web/src/services/telemetryData.ts
+++ b/web/src/services/telemetryData.ts
@@ -24,13 +24,18 @@ const UNIFORM_LOG_LOSS = 1.098612288668;
 const MODEL_VERSION_OTHER_BUCKET = 'other';
 const PREFERENCE_VERSION_OTHER_BUCKET = 'other';
 
-const ROUND_TYPES = [
+const LEGACY_ROUND_TYPES = [
   'hero',
   'skill',
   'skill',
   'hero',
   'skill',
   'skill',
+  'hero',
+  'skill',
+] as const;
+const CURRENT_ROUND_TYPES = [
+  ...LEGACY_ROUND_TYPES,
   'hero',
   'skill',
 ] as const;
@@ -246,7 +251,10 @@ const validVersionCounts = (
   return total === expectedTotal;
 };
 
-const preferenceFeatureParts = (featureId: string): unknown[] | null => {
+const preferenceFeatureParts = (
+  featureId: string,
+  maximumRoundNumber: number
+): unknown[] | null => {
   if (!isShortString(featureId, 512)) return null;
   let parts: unknown;
   try {
@@ -268,7 +276,7 @@ const preferenceFeatureParts = (featureId: string): unknown[] | null => {
     parts[0] === 'round_score' &&
     Number.isInteger(parts[1]) &&
     (parts[1] as number) >= 1 &&
-    (parts[1] as number) <= 8
+    (parts[1] as number) <= maximumRoundNumber
   ) {
     return parts;
   }
@@ -304,9 +312,11 @@ const preferenceFeatureParts = (featureId: string): unknown[] | null => {
 
 const validateRounds = (
   rounds: unknown,
-  schemaVersion: 2 | 3 | 4
+  schemaVersion: 2 | 3 | 4 | 5
 ): { totalEvents: number; totalAccepted: number } => {
-  if (!Array.isArray(rounds) || rounds.length !== 8) {
+  const roundTypes =
+    schemaVersion === 5 ? CURRENT_ROUND_TYPES : LEGACY_ROUND_TYPES;
+  if (!Array.isArray(rounds) || rounds.length !== roundTypes.length) {
     throw new Error('Telemetry artifact contract is invalid');
   }
 
@@ -317,7 +327,7 @@ const validateRounds = (
     if (
       !hasExactKeys(round, expectedKeys) ||
       round.round_number !== index + 1 ||
-      round.round_type !== ROUND_TYPES[index] ||
+      round.round_type !== roundTypes[index] ||
       !isCount(round.event_count) ||
       !isCount(round.recommendation_accepted_count) ||
       round.recommendation_accepted_count > round.event_count ||
@@ -336,7 +346,7 @@ const validateRounds = (
 
 const validateSummary = (
   summary: unknown,
-  schemaVersion: 2 | 3 | 4,
+  schemaVersion: 2 | 3 | 4 | 5,
   totalEvents: number,
   totalAccepted: number
 ): Record<string, unknown> => {
@@ -347,7 +357,7 @@ const validateSummary = (
         ? V3_SUMMARY_KEYS
         : V4_SUMMARY_KEYS;
   const sessionCount =
-    schemaVersion === 4
+    schemaVersion >= 4
       ? isRecord(summary)
         ? summary.estimated_session_count
         : undefined
@@ -381,7 +391,7 @@ const validateSummary = (
       totalEvents,
       MAX_MODEL_VERSIONS,
       (version) =>
-        (schemaVersion === 4 && version === MODEL_VERSION_OTHER_BUCKET) ||
+        (schemaVersion >= 4 && version === MODEL_VERSION_OTHER_BUCKET) ||
         MODEL_VERSION_RE.test(version)
     ) ||
     !validVersionCounts(
@@ -445,7 +455,8 @@ const validHeldOutMetrics = (
 const validReadyCoefficients = (
   weights: Record<string, unknown>,
   support: Record<string, unknown>,
-  featureSchemaVersion: 1 | 2
+  featureSchemaVersion: 1 | 2,
+  maximumRoundNumber: number
 ): boolean => {
   const featureIds = Object.keys(weights);
   const supportIds = Object.keys(support);
@@ -458,7 +469,7 @@ const validReadyCoefficients = (
     return false;
   }
   return featureIds.every((featureId) => {
-    const parts = preferenceFeatureParts(featureId);
+    const parts = preferenceFeatureParts(featureId, maximumRoundNumber);
     const minimumSupport =
       parts?.[0] === 'round_score' ||
       (featureSchemaVersion === 2 && parts?.[0] === 'score')
@@ -569,7 +580,12 @@ const validateV3PreferenceModel = (
     !qualityPassed ||
     !isShortString(value.version) ||
     !READY_PREFERENCE_MODEL_VERSION_RE.test(value.version) ||
-    !validReadyCoefficients(weights, support, 1)
+    !validReadyCoefficients(
+      weights,
+      support,
+      1,
+      LEGACY_ROUND_TYPES.length
+    )
   ) {
     throw new Error('Phase 3 telemetry ready model is invalid');
   }
@@ -630,7 +646,8 @@ const validV4Evaluation = (
 const validateV4PreferenceModel = (
   value: unknown,
   summary: Record<string, unknown>,
-  totalEvents: number
+  totalEvents: number,
+  schemaVersion: 4 | 5
 ): 'insufficient_evidence' | 'quality_gate_failed' | 'ready' => {
   if (
     !hasExactKeys(value, V4_PREFERENCE_MODEL_KEYS) ||
@@ -716,7 +733,14 @@ const validateV4PreferenceModel = (
     !qualityPassed ||
     !isShortString(value.version) ||
     !READY_INCREMENTAL_PREFERENCE_MODEL_VERSION_RE.test(value.version) ||
-    !validReadyCoefficients(weights, support, 2)
+    !validReadyCoefficients(
+      weights,
+      support,
+      2,
+      schemaVersion === 5
+        ? CURRENT_ROUND_TYPES.length
+        : LEGACY_ROUND_TYPES.length
+    )
   ) {
     throw new Error('Schema-v4 telemetry ready model is invalid');
   }
@@ -817,7 +841,7 @@ const validateAnalytics = (
   rounds: unknown,
   totalEvents: number,
   totalAccepted: number,
-  schemaVersion: 3 | 4
+  schemaVersion: 3 | 4 | 5
 ): void => {
   if (
     !hasExactKeys(value, ANALYTICS_KEYS) ||
@@ -846,7 +870,7 @@ const validateAnalytics = (
   ) {
     throw new Error('Phase 3 telemetry analytics are invalid');
   }
-  if (schemaVersion === 4) {
+  if (schemaVersion >= 4) {
     const expectedItemTotals = rounds.reduce(
       (totals, round) => {
         if (
@@ -859,7 +883,8 @@ const validateAnalytics = (
         }
         const family =
           round.round_type === 'hero' ? totals.heroes : totals.skills;
-        const itemsPerOption = round.round_number === 7 ? 2 : 3;
+        const itemsPerOption =
+          round.round_number === 7 || round.round_number === 9 ? 2 : 3;
         family.offerCount += round.event_count * itemsPerOption * 3;
         family.pickedCount += round.event_count * itemsPerOption;
         return totals;
@@ -886,7 +911,7 @@ const validateAnalytics = (
       !hasExactKeys(row, SCORE_MARGIN_KEYS_REQUIRED) ||
       row.key !== SCORE_MARGIN_KEYS[index] ||
       !isShortString(row.label) ||
-      (schemaVersion === 4 && row.label !== SCORE_MARGIN_LABELS[index]) ||
+      (schemaVersion >= 4 && row.label !== SCORE_MARGIN_LABELS[index]) ||
       !isCount(row.event_count) ||
       !isCount(row.recommendation_accepted_count) ||
       row.recommendation_accepted_count > row.event_count ||
@@ -910,7 +935,8 @@ export const parseTelemetryData = (value: unknown): TelemetryData => {
     !hasExactKeys(value.schema, SCHEMA_KEYS) ||
     (value.schema.version !== 2 &&
       value.schema.version !== 3 &&
-      value.schema.version !== 4) ||
+      value.schema.version !== 4 &&
+      value.schema.version !== 5) ||
     value.schema.source_event_schema_version !== 1
   ) {
     throw new Error('Telemetry artifact contract is invalid');
@@ -961,7 +987,8 @@ export const parseTelemetryData = (value: unknown): TelemetryData => {
       : validateV4PreferenceModel(
           value.preference_model,
           summary,
-          totalEvents
+          totalEvents,
+          schemaVersion
         );
   validatePreferenceRoundFields(value.rounds, modelStatus);
   validateAnalytics(

--- a/web/src/types/game.ts
+++ b/web/src/types/game.ts
@@ -24,8 +24,10 @@ export interface GameState {
   support_skills: string[];
   round_number: number;
   round_history: RoundHistory[];
-  /** Added by the DISMISS_ROUND7_INTERSTITIAL action; absent initially. */
+  /** Absent until the player wins the qualification between rounds 6 and 7. */
   round7_interstitial_dismissed?: boolean;
+  /** Absent until the player wins the qualification between rounds 8 and 9. */
+  round9_interstitial_dismissed?: boolean;
 }
 
 /** Per-hero / per-skill display metadata derived from database.json. */
@@ -110,7 +112,7 @@ export type GameAction =
       maxSeason?: number;
       selectedSeason?: number;
     }
-  | { type: 'DISMISS_ROUND7_INTERSTITIAL' }
+  | { type: 'DISMISS_ROUND_INTERSTITIAL'; roundNumber: 7 | 9 }
   | { type: 'UPDATE_TEAM'; heroes: string[]; skills: string[] }
   | { type: 'SET_SUPPORT_HERO'; hero: string }
   | { type: 'SET_SUPPORT_SKILLS'; skills: string[] }

--- a/web/src/types/telemetryData.ts
+++ b/web/src/types/telemetryData.ts
@@ -120,7 +120,7 @@ export interface TelemetryAnalytics {
 
 export interface TelemetryData {
   schema: {
-    version: 2 | 3 | 4;
+    version: 2 | 3 | 4 | 5;
     source_event_schema_version: number;
   };
   catalog_version: string;
@@ -137,7 +137,7 @@ export interface TelemetryData {
     preference_model_versions: { version: string; event_count: number }[];
   };
   rounds: TelemetryRoundAggregate[];
-  /** Schema v2 uses null; schema v3/v4 emit a status-bearing object. */
+  /** Schema v2 uses null; schema v3+ emits a status-bearing object. */
   preference_model: PreferenceModelArtifact | null;
   /** Added in schema v3; absent from the frozen schema-v2 hand-off. */
   analytics?: TelemetryAnalytics;

--- a/web/src/utils/__tests__/storage.test.ts
+++ b/web/src/utils/__tests__/storage.test.ts
@@ -1,5 +1,9 @@
 import Cookies from 'js-cookie';
-import { storage } from '../storage';
+import {
+  GAME_PROGRESS_STORAGE_KEY,
+  GAME_PROGRESS_STORAGE_VERSION,
+  storage,
+} from '../storage';
 
 const emptyInputs = { set1: [], set2: [], set3: [] };
 const gameState = {
@@ -11,16 +15,205 @@ const gameState = {
   round_history: [],
 };
 
-describe('storage season preference', () => {
+describe('storage', () => {
   beforeEach(() => {
+    localStorage.clear();
     Cookies.remove('gameProgress', { path: '/' });
     Cookies.remove('selectedSeason', { path: '/' });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    localStorage.clear();
     Cookies.remove('gameProgress', { path: '/' });
     Cookies.remove('selectedSeason', { path: '/' });
+  });
+
+  test('stores game progress in a versioned, non-expiring localStorage envelope', () => {
+    storage.saveGameProgress(gameState, emptyInputs);
+
+    expect(JSON.parse(localStorage.getItem(GAME_PROGRESS_STORAGE_KEY)!)).toEqual({
+      version: GAME_PROGRESS_STORAGE_VERSION,
+      gameState,
+      currentRoundInputs: emptyInputs,
+    });
+    expect(Cookies.get('gameProgress')).toBeUndefined();
+    expect(storage.loadGameProgress()).toEqual({
+      gameState,
+      currentRoundInputs: emptyInputs,
+    });
+  });
+
+  test('ignores the legacy game-progress cookie', () => {
+    Cookies.set(
+      'gameProgress',
+      JSON.stringify({ gameState, currentRoundInputs: emptyInputs }),
+      { path: '/' }
+    );
+
+    expect(storage.loadGameProgress()).toBeNull();
+  });
+
+  test('treats browser contexts that deny localStorage access as unavailable', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get: () => {
+        throw new DOMException('Storage is unavailable', 'SecurityError');
+      },
+    });
+
+    try {
+      expect(storage.loadGameProgress()).toBeNull();
+      expect(() => storage.saveGameProgress(gameState, emptyInputs)).not.toThrow();
+      expect(() => storage.clearGameProgress()).not.toThrow();
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(window, 'localStorage', descriptor);
+      }
+    }
+  });
+
+  test('restores a versioned round-9 state without inventing a dismissal flag', () => {
+    const roundNineState = {
+      ...gameState,
+      round_number: 9,
+      round7_interstitial_dismissed: true,
+    };
+    localStorage.setItem(
+      GAME_PROGRESS_STORAGE_KEY,
+      JSON.stringify({
+        version: GAME_PROGRESS_STORAGE_VERSION,
+        gameState: roundNineState,
+        currentRoundInputs: emptyInputs,
+      })
+    );
+
+    const restored = storage.loadGameProgress();
+    expect(restored?.gameState).toEqual(roundNineState);
+    expect(restored?.gameState.round9_interstitial_dismissed).toBeUndefined();
+  });
+
+  test('rejects a localStorage envelope from an unsupported version', () => {
+    localStorage.setItem(
+      GAME_PROGRESS_STORAGE_KEY,
+      JSON.stringify({
+        version: GAME_PROGRESS_STORAGE_VERSION + 1,
+        gameState,
+        currentRoundInputs: emptyInputs,
+      })
+    );
+
+    expect(storage.loadGameProgress()).toBeNull();
+  });
+
+  test('requires the localStorage envelope version', () => {
+    localStorage.setItem(
+      GAME_PROGRESS_STORAGE_KEY,
+      JSON.stringify({
+        gameState,
+        currentRoundInputs: emptyInputs,
+      })
+    );
+
+    expect(storage.loadGameProgress()).toBeNull();
+  });
+
+  test.each([
+    ['an empty object', {}],
+    ['non-string heroes', { ...gameState, current_heroes: ['曹操', 1] }],
+    ['a non-array skill pool', { ...gameState, current_skills: '乱世奸雄' }],
+    ['an invalid support hero', { ...gameState, support_hero: 1 }],
+    ['non-string support skills', { ...gameState, support_skills: ['避其锐气', null] }],
+    ['a fractional current round', { ...gameState, round_number: 1.5 }],
+    ['a current round below the supported range', { ...gameState, round_number: 0 }],
+    ['a current round above the completed state', { ...gameState, round_number: 12 }],
+    ['a non-array history', { ...gameState, round_history: {} }],
+    [
+      'a malformed history entry',
+      {
+        ...gameState,
+        round_number: 2,
+        round_history: [
+          {
+            round_number: 1,
+            round_type: 'hero',
+            chosen_set: ['曹操'],
+            set_index: '0',
+          },
+        ],
+      },
+    ],
+    [
+      'an invalid round-history type',
+      {
+        ...gameState,
+        round_number: 2,
+        round_history: [
+          {
+            round_number: 1,
+            round_type: 'support',
+            chosen_set: ['曹操'],
+            set_index: 0,
+          },
+        ],
+      },
+    ],
+    [
+      'a non-boolean dismissal flag',
+      { ...gameState, round7_interstitial_dismissed: 'yes' },
+    ],
+  ])('rejects a v1 game state containing %s', (_description, malformedGameState) => {
+    localStorage.setItem(
+      GAME_PROGRESS_STORAGE_KEY,
+      JSON.stringify({
+        version: GAME_PROGRESS_STORAGE_VERSION,
+        gameState: malformedGameState,
+      })
+    );
+
+    expect(storage.loadGameProgress()).toBeNull();
+  });
+
+  test.each([
+    ['null', null],
+    ['a missing set', { set1: [], set2: [] }],
+    ['a non-array set', { set1: [], set2: [], set3: '曹操' }],
+    ['a set containing a non-string', { set1: [], set2: [1], set3: [] }],
+    ['an extra set', { set1: [], set2: [], set3: [], set4: [] }],
+  ])('rejects v1 current-round inputs containing %s', (_description, malformedInputs) => {
+    localStorage.setItem(
+      GAME_PROGRESS_STORAGE_KEY,
+      JSON.stringify({
+        version: GAME_PROGRESS_STORAGE_VERSION,
+        gameState,
+        currentRoundInputs: malformedInputs,
+      })
+    );
+
+    expect(storage.loadGameProgress()).toBeNull();
+  });
+
+  test('restores the completed round after round 10', () => {
+    const completedState = {
+      ...gameState,
+      round_number: 11,
+      round7_interstitial_dismissed: true,
+      round9_interstitial_dismissed: true,
+    };
+    localStorage.setItem(
+      GAME_PROGRESS_STORAGE_KEY,
+      JSON.stringify({
+        version: GAME_PROGRESS_STORAGE_VERSION,
+        gameState: completedState,
+        currentRoundInputs: emptyInputs,
+      })
+    );
+
+    expect(storage.loadGameProgress()).toEqual({
+      gameState: completedState,
+      currentRoundInputs: emptyInputs,
+    });
   });
 
   test('uses the same persistent cookie options as other saved state', () => {

--- a/web/src/utils/storage.ts
+++ b/web/src/utils/storage.ts
@@ -1,7 +1,9 @@
 import Cookies from 'js-cookie';
+import { TOTAL_ROUNDS } from '../services/gameLogic';
 import type { CurrentRoundInputs, GameState } from '../types/game';
 
-const GAME_PROGRESS_KEY = 'gameProgress';
+export const GAME_PROGRESS_STORAGE_KEY = 'gameProgress';
+export const GAME_PROGRESS_STORAGE_VERSION = 1;
 const TEAM_BUILDER_KEY = 'teamBuilder';
 const SELECTED_SEASON_KEY = 'selectedSeason';
 
@@ -12,26 +14,133 @@ export interface StoredProgress {
   currentRoundInputs?: CurrentRoundInputs;
 }
 
+interface StoredProgressEnvelope extends StoredProgress {
+  version: typeof GAME_PROGRESS_STORAGE_VERSION;
+}
+
+const CURRENT_ROUND_INPUT_KEYS = ['set1', 'set2', 'set3'] as const;
+
+const getLocalStorage = (): Storage | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    // Some browser/privacy contexts expose Window but throw on storage access.
+    return null;
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+const isCurrentRoundInputs = (value: unknown): value is CurrentRoundInputs => {
+  if (!isRecord(value) || Object.keys(value).length !== CURRENT_ROUND_INPUT_KEYS.length) {
+    return false;
+  }
+
+  return CURRENT_ROUND_INPUT_KEYS.every((key) => isStringArray(value[key]));
+};
+
+const isRoundHistoryEntry = (
+  value: unknown
+): value is GameState['round_history'][number] => {
+  if (!isRecord(value)) return false;
+
+  return (
+    typeof value.round_number === 'number' &&
+    Number.isInteger(value.round_number) &&
+    value.round_number >= 1 &&
+    value.round_number <= TOTAL_ROUNDS &&
+    (value.round_type === 'hero' || value.round_type === 'skill') &&
+    isStringArray(value.chosen_set) &&
+    typeof value.set_index === 'number' &&
+    Number.isInteger(value.set_index) &&
+    value.set_index >= 0 &&
+    value.set_index <= 2
+  );
+};
+
+const isGameState = (value: unknown): value is GameState => {
+  if (!isRecord(value)) return false;
+
+  return (
+    isStringArray(value.current_heroes) &&
+    isStringArray(value.current_skills) &&
+    (value.support_hero === null || typeof value.support_hero === 'string') &&
+    isStringArray(value.support_skills) &&
+    typeof value.round_number === 'number' &&
+    Number.isInteger(value.round_number) &&
+    value.round_number >= 1 &&
+    value.round_number <= TOTAL_ROUNDS + 1 &&
+    Array.isArray(value.round_history) &&
+    value.round_history.every(isRoundHistoryEntry) &&
+    (value.round7_interstitial_dismissed === undefined ||
+      typeof value.round7_interstitial_dismissed === 'boolean') &&
+    (value.round9_interstitial_dismissed === undefined ||
+      typeof value.round9_interstitial_dismissed === 'boolean')
+  );
+};
+
+const parseStoredProgress = (value: unknown): StoredProgress | null => {
+  if (
+    !isRecord(value) ||
+    value.version !== GAME_PROGRESS_STORAGE_VERSION ||
+    !isGameState(value.gameState) ||
+    (value.currentRoundInputs !== undefined &&
+      !isCurrentRoundInputs(value.currentRoundInputs))
+  ) {
+    return null;
+  }
+
+  return {
+    gameState: value.gameState,
+    ...(value.currentRoundInputs !== undefined
+      ? { currentRoundInputs: value.currentRoundInputs }
+      : {}),
+  };
+};
+
 export const storage = {
   saveGameProgress: (gameState: GameState, currentRoundInputs: CurrentRoundInputs): void => {
-    const data = { gameState, currentRoundInputs };
-    Cookies.set(GAME_PROGRESS_KEY, JSON.stringify(data), COOKIE_OPTS);
+    const progressStorage = getLocalStorage();
+    if (!progressStorage) return;
+    const data: StoredProgressEnvelope = {
+      version: GAME_PROGRESS_STORAGE_VERSION,
+      gameState,
+      currentRoundInputs,
+    };
+    try {
+      progressStorage.setItem(GAME_PROGRESS_STORAGE_KEY, JSON.stringify(data));
+    } catch (e) {
+      console.error('Failed to save game progress:', e);
+    }
   },
 
   loadGameProgress: (): StoredProgress | null => {
-    const data = Cookies.get(GAME_PROGRESS_KEY);
-    if (!data) return null;
+    const progressStorage = getLocalStorage();
+    if (!progressStorage) return null;
 
     try {
-      return JSON.parse(data) as StoredProgress;
+      const data = progressStorage.getItem(GAME_PROGRESS_STORAGE_KEY);
+      if (!data) return null;
+      return parseStoredProgress(JSON.parse(data) as unknown);
     } catch (e) {
-      console.error('Failed to parse game progress cookie:', e);
+      console.error('Failed to parse game progress:', e);
       return null;
     }
   },
 
   clearGameProgress: (): void => {
-    Cookies.remove(GAME_PROGRESS_KEY, { path: '/' });
+    const progressStorage = getLocalStorage();
+    if (!progressStorage) return;
+    try {
+      progressStorage.removeItem(GAME_PROGRESS_STORAGE_KEY);
+    } catch (e) {
+      console.error('Failed to clear game progress:', e);
+    }
   },
 
   saveSelectedSeason: (season: number): void => {

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -26,7 +26,7 @@ const completedState = () => {
 
   return {
     ...makeGameState({
-      roundNumber: 9,
+      roundNumber: 11,
       heroes: heroesWithMeta.slice(0, 9),
       skills: rosterSkills.slice(0, 18),
     }),
@@ -35,6 +35,7 @@ const completedState = () => {
     // rather than a full-support conditional, is what hides coaching controls.
     support_skills: rosterSkills.slice(18, 19),
     round7_interstitial_dismissed: true,
+    round9_interstitial_dismissed: true,
   };
 };
 
@@ -162,11 +163,11 @@ test.describe('Accessibility and responsive layout', () => {
     await page.setViewportSize({ width: 390, height: 844 });
     await seedGame(page, lateRoundState(), lateRoundInputs());
 
-    const progress = page.getByRole('list', { name: '8 轮进度' });
+    const progress = page.getByRole('list', { name: '10 轮进度' });
     await expect(progress).toBeVisible();
-    await expect(progress.getByRole('listitem')).toHaveCount(8);
+    await expect(progress.getByRole('listitem')).toHaveCount(10);
     await expect(progress.getByRole('listitem', { name: /第 7 轮.*当前/ })).toHaveAttribute('aria-current', 'step');
-    await expect(page.getByRole('region', { name: '8 轮进度，可横向滚动' })).not.toBeVisible();
+    await expect(page.getByRole('region', { name: '10 轮进度，可横向滚动' })).not.toBeVisible();
   });
 
   test('mobile keeps key recommendation actions visible while details are collapsible', async ({ page }) => {

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -146,6 +146,11 @@ test.describe('Accessibility and responsive layout', () => {
     const rosterMarker = page.getByText('CURRENT ROSTER', { exact: true });
     await expect(action).toBeVisible();
     await expect(rosterMarker).toBeVisible();
+    await expect(
+      page.getByText(
+        '提示：建议先确认核心武将，再围绕核心挑选其余武将与战法。请尽早确认支援选择，AI 才能据此给出更精准的推荐。',
+      ),
+    ).toHaveCount(0);
 
     const [actionBox, rosterBox] = await Promise.all([
       action.boundingBox(),

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test');
 const database = require('../public/game-data/database.json');
+const { seedStoredProgress } = require('./helpers');
 
 // Build a small, deterministic pool from the real database.
 const orangeHeroes = Object.keys(database.heroes || {}).sort();
@@ -17,15 +18,17 @@ const poolSkills = regularSkills.slice(0, 4);
 const supportHero = orangeHeroes[3];
 const supportSkill = regularSkills[4];
 
-// Cookie payload mirrors storage.saveGameProgress: { gameState, currentRoundInputs }
+// Saved-progress payload mirrors storage.saveGameProgress.
 const gameProgress = {
   gameState: {
     current_heroes: poolHeroes,
     current_skills: poolSkills,
     support_hero: supportHero,
     support_skills: [supportSkill],
+    round_number: 1,
+    round_history: [],
   },
-  currentRoundInputs: {},
+  currentRoundInputs: { set1: [], set2: [], set3: [] },
 };
 
 /**
@@ -56,19 +59,13 @@ async function nativeDragAndDrop(page, sourceTestId, targetTestId) {
 }
 
 test.describe('Build a Team (/build-a-team)', () => {
-  test.beforeEach(async ({ context }) => {
-    await context.addCookies([
-      {
-        name: 'gameProgress',
-        value: JSON.stringify(gameProgress),
-        url: 'http://localhost:3000',
-      },
-    ]);
+  test.beforeEach(async ({ page, context }) => {
+    await seedStoredProgress(page, gameProgress);
     // Grant clipboard access for the copy-button assertion.
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
   });
 
-  test('shows the current cookie pool as draggable items', async ({ page }) => {
+  test('shows the current saved pool as draggable items', async ({ page }) => {
     await page.goto('/build-a-team');
     await expect(page.getByRole('heading', { name: /Build a Team/ })).toBeVisible({
       timeout: 30000,
@@ -253,19 +250,15 @@ const completePoolProgress = {
     current_skills: completeSkills,
     support_hero: null,
     support_skills: [],
+    round_number: 1,
+    round_history: [],
   },
-  currentRoundInputs: {},
+  currentRoundInputs: { set1: [], set2: [], set3: [] },
 };
 
 test.describe('Team Builder (/team-builder) formation card', () => {
-  test.beforeEach(async ({ context }) => {
-    await context.addCookies([
-      {
-        name: 'gameProgress',
-        value: JSON.stringify(completePoolProgress),
-        url: 'http://localhost:3000',
-      },
-    ]);
+  test.beforeEach(async ({ page }) => {
+    await seedStoredProgress(page, completePoolProgress);
   });
 
   test('complete pool never flashes the insufficient warning before optimisation', async ({

--- a/web/tests/gameRounds.spec.js
+++ b/web/tests/gameRounds.spec.js
@@ -255,5 +255,6 @@ test.describe('Game Rounds - Skill Selection', () => {
       page.getByRole('heading', { level: 1, name: '对局完成' })
     ).toBeVisible();
     await expect(page.getByText('你已完成全部 10 轮。可查看最终队伍配置。')).toBeVisible();
+    await expect(page.getByText('祝你夺冠 🏆')).toBeVisible();
   });
 });

--- a/web/tests/gameRounds.spec.js
+++ b/web/tests/gameRounds.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test');
 const database = require('../public/game-data/database.json');
+const { seedGame } = require('./helpers');
 
 // Merged database (see web/scripts/merge_database.js):
 //   - heroes: orange heroes only. Each hero has a `skill` field naming its
@@ -17,6 +18,9 @@ const HERO_SKILL_SET = new Set(
 const allSkillNames = Object.keys(database.skills || {});
 const regularSkills = allSkillNames.filter(n => !HERO_SKILL_SET.has(n));
 const heroSkills   = allSkillNames.filter(n => HERO_SKILL_SET.has(n)).sort();
+const allOrangeRegularSkills = regularSkills
+  .filter((s) => database.skills[s]?.color === 'orange')
+  .sort();
 
 // 4 purple regular skills
 const purpleSkills = regularSkills
@@ -148,5 +152,108 @@ test.describe('Game Rounds - Skill Selection', () => {
     await skillInput.fill(anOrangeSkill);
     const orangeOption = page.getByRole('option', { name: anOrangeSkill });
     await expect(orangeOption).toBeVisible({ timeout: 5000 });
+  });
+
+  test('rounds 9 and 10 repeat the late-game offer shapes and finish the game', async ({
+    page,
+  }) => {
+    await page.route('**/api/telemetry/rounds', async route => {
+      const body = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          accepted: body.events.length,
+          duplicates: 0,
+        }),
+      });
+    });
+
+    const currentHeroes = orangeHeroes.slice(0, 12);
+    const roundNineOffers = orangeHeroes.slice(12, 18);
+    const roundTenOffers = allOrangeRegularSkills.slice(0, 9);
+    const currentSkills = regularSkills
+      .filter((skill) => !roundTenOffers.includes(skill))
+      .slice(0, 23);
+
+    await seedGame(
+      page,
+      {
+        current_heroes: currentHeroes,
+        current_skills: currentSkills,
+        support_hero: null,
+        support_skills: [],
+        round_number: 9,
+        round_history: [],
+        round7_interstitial_dismissed: true,
+        // Deliberately omit round9_interstitial_dismissed. Restored states that
+        // predate the new field must stop at the round-8/9 qualification gate.
+      },
+      {
+        set1: roundNineOffers.slice(0, 2),
+        set2: roundNineOffers.slice(2, 4),
+        set3: roundNineOffers.slice(4, 6),
+      }
+    );
+
+    const qualificationAction = page.getByRole('button', {
+      name: '我赢了，进入下一轮',
+    });
+    await expect(qualificationAction).toBeVisible({ timeout: 30000 });
+    await expect(page.getByRole('heading', { name: '整军再战' })).toBeVisible();
+    await qualificationAction.click();
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: '第 9 轮：选择武将' })
+    ).toBeVisible();
+    await expect(page.getByText('第 9 / 10 轮')).toBeVisible();
+    await expect(page.getByText('(2/2)')).toHaveCount(3);
+
+    await expect.poll(async () =>
+      page.evaluate(() => {
+        const saved = localStorage.getItem('gameProgress');
+        return saved
+          ? JSON.parse(saved).gameState.round9_interstitial_dismissed
+          : false;
+      })
+    ).toBe(true);
+
+    await page.reload();
+    await expect(qualificationAction).toHaveCount(0);
+    await expect(
+      page.getByRole('heading', { level: 1, name: '第 9 轮：选择武将' })
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: '获取 AI 推荐' }).click();
+    await expect(page.getByText('推荐：第')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: '选择本组' }).first().click();
+    await page.getByRole('button', { name: '确认选择并进入下一轮' }).click();
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: '第 10 轮：选择战法' })
+    ).toBeVisible();
+    await expect(page.getByText('第 10 / 10 轮')).toBeVisible();
+
+    for (let set = 0; set < 3; set++) {
+      for (let i = 0; i < 3; i++) {
+        const skill = roundTenOffers[set * 3 + i];
+        const input = page.getByLabel('添加战法...').nth(set);
+        await input.click();
+        await input.fill(skill);
+        await page.getByRole('option', { name: skill }).click();
+      }
+    }
+
+    await expect(page.getByText('(3/3)')).toHaveCount(3);
+    await page.getByRole('button', { name: '获取 AI 推荐' }).click();
+    await expect(page.getByText('推荐：第')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: '选择本组' }).first().click();
+    await page.getByRole('button', { name: '确认选择并进入下一轮' }).click();
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: '对局完成' })
+    ).toBeVisible();
+    await expect(page.getByText('你已完成全部 10 轮。可查看最终队伍配置。')).toBeVisible();
   });
 });

--- a/web/tests/helpers.js
+++ b/web/tests/helpers.js
@@ -1,18 +1,31 @@
 const database = require('../public/game-data/database.json');
 
 // ── Game-state seeding ───────────────────────────────────────────────────────
-// The app restores a saved game from the `gameProgress` cookie on mount
-// (see web/src/context/GameContext.js → RESTORE_PROGRESS, and storage.js which
-// stores it via js-cookie). Seeding that cookie lets acceptance tests jump
-// straight into a specific round instead of clicking through the 4-hero/8-skill
-// setup, so they stay focused on the UI under test.
-async function seedGame(page, gameState, currentRoundInputs) {
-  const value = encodeURIComponent(JSON.stringify({ gameState, currentRoundInputs }));
+// The app restores a versioned `gameProgress` localStorage envelope on mount.
+// Seeding it lets acceptance tests jump straight into a specific round instead
+// of clicking through the 4-hero/8-skill setup.
+const GAME_PROGRESS_STORAGE_KEY = 'gameProgress';
+const GAME_PROGRESS_STORAGE_VERSION = 1;
+
+async function seedStoredProgress(page, progress) {
+  const value = JSON.stringify({
+    version: GAME_PROGRESS_STORAGE_VERSION,
+    ...progress,
+  });
   await page.context().clearCookies();
-  // Runs before the app's scripts on the next navigation, so RESTORE_PROGRESS sees it.
-  await page.addInitScript((v) => {
-    document.cookie = `gameProgress=${v}; path=/`;
-  }, value);
+  // The session marker applies each seed once. That lets reload assertions
+  // observe later app writes instead of resetting to the original fixture.
+  await page.addInitScript(({ key, value: storedValue }) => {
+    const markerKey = `${key}:playwright-seed`;
+    if (sessionStorage.getItem(markerKey) !== storedValue) {
+      localStorage.setItem(key, storedValue);
+      sessionStorage.setItem(markerKey, storedValue);
+    }
+  }, { key: GAME_PROGRESS_STORAGE_KEY, value });
+}
+
+async function seedGame(page, gameState, currentRoundInputs) {
+  await seedStoredProgress(page, { gameState, currentRoundInputs });
   await page.goto('/');
 }
 
@@ -85,6 +98,7 @@ function makeValidUploadBattle(winner = '1') {
 module.exports = {
   database,
   seedGame,
+  seedStoredProgress,
   makeGameState,
   heroesWithMeta,
   skillsWithTier,

--- a/web/tests/playerChoiceAnalytics.spec.js
+++ b/web/tests/playerChoiceAnalytics.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test');
 const telemetry = require('../public/game-data/telemetry_data.json');
+const LEGACY_ROUNDS = telemetry.rounds.slice(0, 8);
 
 const byName = (left, right) =>
   left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
@@ -20,7 +21,7 @@ const item = (
 const phaseTwoArtifact = () => ({
   catalog_version: telemetry.catalog_version,
   preference_model: null,
-  rounds: telemetry.rounds.map((round) => ({
+  rounds: LEGACY_ROUNDS.map((round) => ({
     round_number: round.round_number,
     round_type: round.round_type,
     event_count: round.event_count,
@@ -40,36 +41,39 @@ const phaseTwoArtifact = () => ({
 });
 
 const phaseThreeArtifact = () => {
-  const eventCount = telemetry.summary.event_count;
-  const accepted = telemetry.rounds.reduce(
-    (sum, round) => sum + round.recommendation_accepted_count,
-    0
-  );
+  const eventCount = 240;
+  const accepted = 160;
+  const rounds = LEGACY_ROUNDS.map((round) => ({
+    ...round,
+    event_count: 30,
+    recommendation_accepted_count: 20,
+    chosen_position_counts: [10, 10, 10],
+    recommended_position_counts: [12, 10, 8],
+    rate_suppressed: false,
+    preference_top_disagreement_count: null,
+    meaningful_preference_disagreement_count: null,
+    player_preference_agreement_count: null,
+    average_meaningful_preference_disagreement_margin: null,
+  }));
   const opportunityCount = (roundType) =>
-    telemetry.rounds
+    rounds
       .filter((round) => round.round_type === roundType)
       .reduce((sum, round) => sum + round.event_count, 0);
   return {
     ...telemetry,
     schema: { version: 3, source_event_schema_version: 1 },
     summary: {
-      event_count: telemetry.summary.event_count,
+      event_count: eventCount,
       invalid_event_count: telemetry.summary.invalid_event_count,
-      session_count: telemetry.summary.estimated_session_count,
+      session_count: 40,
       recommendation_accepted_count: accepted,
-      preference_event_count: telemetry.summary.preference_event_count,
-      model_versions: telemetry.summary.model_versions,
-      preference_model_versions:
-        telemetry.summary.preference_model_versions,
+      preference_event_count: 0,
+      model_versions: [
+        { version: '2:0000000000000000', event_count: 240 },
+      ],
+      preference_model_versions: [],
     },
-    rounds: telemetry.rounds.map((round) => ({
-      ...round,
-      rate_suppressed: round.event_count < 10,
-      preference_top_disagreement_count: null,
-      meaningful_preference_disagreement_count: null,
-      player_preference_agreement_count: null,
-      average_meaningful_preference_disagreement_margin: null,
-    })),
+    rounds,
     analytics: {
       minimum_rate_support: 10,
       items: {
@@ -120,7 +124,7 @@ const phaseThreeArtifact = () => {
       l2: 0.05,
       evidence: {
         event_count: eventCount,
-        session_count: telemetry.summary.estimated_session_count,
+        session_count: 40,
         recommendation_disagreement_count: eventCount - accepted,
         minimum_event_count: 240,
         minimum_session_count: 40,

--- a/web/tests/playerPreferenceFlow.spec.js
+++ b/web/tests/playerPreferenceFlow.spec.js
@@ -7,6 +7,8 @@ const {
   anySkills,
 } = require('./helpers');
 
+const LEGACY_ROUNDS = telemetry.rounds.slice(0, 8);
+
 const readyArtifact = () => ({
   ...telemetry,
   schema: { version: 3, source_event_schema_version: 1 },
@@ -18,14 +20,14 @@ const readyArtifact = () => ({
     preference_event_count: telemetry.summary.preference_event_count,
     model_versions: [
       {
-        version: telemetry.summary.model_versions[0].version,
+        version: '2:0000000000000000',
         event_count: 240,
       },
     ],
     preference_model_versions:
       telemetry.summary.preference_model_versions,
   },
-  rounds: telemetry.rounds.map((round) => ({
+  rounds: LEGACY_ROUNDS.map((round) => ({
     ...round,
     event_count: 30,
     recommendation_accepted_count: 20,


### PR DESCRIPTION
## Intent

Add rounds 9 and 10 by repeating the round 7 hero and round 8 skill formats; require one-click win qualification between rounds 8 and 9; keep support optional; persist valid progress across browser sessions in non-expiring localStorage without legacy cookie migration; support and benchmark the complete 15-hero/28-skill recommendation pool with bounded best-two-teams-first search; expand anonymous telemetry safely to ten rounds while allowing beta history reset, preserving battle submissions, surfacing old-schema failures for retry, and taking no remote D1 action during implementation. Deliver the validated change as a pull request for human review.

## What Changed

- Extended the draft flow to ten rounds by repeating the round-7 hero and round-8 skill formats for rounds 9 and 10, added a one-click win-qualification gate between rounds 8 and 9, and kept the post-round-6 support pick optional (`GameBoard.tsx`, `RoundInfo.tsx`, `gameLogic.ts`, `GameContext.tsx`, `GAME_RULE.md`, plus reducer/unit/e2e coverage).
- Moved valid game progress into non-expiring `localStorage` with no legacy cookie migration (`storage.ts`, `storage.test.ts`), and expanded the recommendation engine to search and score the full 15-hero/28-skill pool with a bounded best-two-teams-first formation search (`recommendationEngine.ts`, benchmarked in `recommendationEngine.test.ts`).
- Grew anonymous telemetry to cover all ten rounds with a beta-history reset (migration `0004`) that preserves battle submissions and surfaces old-schema events for retry, took no remote D1 action, and rebuilt the schema-v5 telemetry artifacts and checkpoints (`build_telemetry_data.py`, `telemetry_retention.py`, `telemetry.ts`, `telemetryData.ts`, `rounds.js`, workflow and state/data updates).

## Risk Assessment

✅ Low: The change is large but well-bounded and maps cleanly to each stated requirement, with consistent round-count/item-per-set logic across the client, Pages Function, and Python builders, a version-gated storage migration, a deterministic bounded recommendation search, and comprehensive updated tests; the only destructive action (the D1 beta reset) is explicitly authorized and gated behind a manual reset_checkpoint dispatch.

## Testing

Ran the scoped web and telemetry suites plus targeted manual/e2e verification. Web typecheck was clean and all 315 Vitest unit tests passed; the recommendation-engine suite's full 15-hero/28-skill round-10 benchmark completed in ~2.0s within the interactive budget. The Playwright rounds-9/10 e2e passed and produced a video and a game-complete screenshot (14 heroes / 26 skills after all 10 rounds); a small temporary spec captured a full-page screenshot of the round-8/9 one-click win qualification gate showing the 10-step round tracker and round 9 in the round-7 (2-per-set) format. On the data side, 75 telemetry Python tests passed, migration 0004 was confirmed to reset only anonymous round telemetry while preserving battle submissions, and a local build-telemetry run reproduced the schema-v5 ten-round artifact byte-identically with no remote D1 calls. Transient config/spec files and node build outputs were removed, leaving the working tree clean; visual evidence was captured for the UI-facing rounds/qualification behavior.

- Evidence: Round 8/9 one-click win qualification gate (10-round tracker, round 9 in 2-per-set format) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYCG7V96E0MMG8G9X9NSEM9H/round8-9-qualification-gate.png</code>)
- Evidence: Game complete after all 10 rounds (final roster: 14 heroes / 26 skills) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYCG7V96E0MMG8G9X9NSEM9H/pw-output/gameRounds-Game-Rounds---S-a1069--shapes-and-finish-the-game/test-finished-1.png</code>)
- Evidence: Video: rounds 9/10 flow (qualification gate → round 9 → reload persistence → round 10 → completion) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYCG7V96E0MMG8G9X9NSEM9H/pw-output/gameRounds-Game-Rounds---S-a1069--shapes-and-finish-the-game/video.webm</code>)
<details>
<summary>Evidence: Full 15-hero/28-skill round-10 recommendation benchmark within interactive budget</summary>

```text
recommendTeams 15 heroes / 28 skills: 2004.9 ms
✓ realistic 15-hero / 28-skill round-10 pool stays within the interactive budget
Test Files 1 passed (1) Tests 45 passed (45)
```
</details>
<details>
<summary>Evidence: Ten-round telemetry artifact regenerated locally, deterministic, no remote D1</summary>

```text
Wrote web/public/game-data/telemetry_data.json from 0 validated events (0 invalid events skipped)
artifact byte-identical after rebuild: IDENTICAL (deterministic no-op)
num round entries: 10 ; round_numbers: [1,2,3,4,5,6,7,8,9,10]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; pnpm typecheck` (tsc --noEmit) — clean</code>
- <code>`cd web &amp;&amp; pnpm test` (Vitest) — 27 files / 315 tests passed</code>
- <code>`pnpm exec playwright test gameRounds.spec.js` (Node 22, dev server on :3100) — rounds 9/10 flow + qualification gate + reload persistence + game completion passed; video + final-state screenshot captured</code>
- `Temporary Playwright spec seeding the round-8/9 gate — captured full-page screenshot of the 我赢了，进入下一轮 qualification gate and 10-round tracker (spec removed after run)`
- <code>`pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts` — 45 tests passed; full 15-hero/28-skill round-10 benchmark ~2.0s within interactive budget</code>
- <code>`uv run pytest data/test_build_telemetry_data.py data/test_telemetry_incremental_state.py data/test_telemetry_retention.py` — 75 passed</code>
- <code>`make build-telemetry EXPORT=web/migrations/0004_...sql` — schema-v5 artifact rebuilt byte-identically, all 10 rounds enumerated, no remote D1 action</code>
- `Inspected migration 0004: drops only round_telemetry (rounds 1–10), leaves web_battle_submissions untouched`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
