### PR TITLE
fix: make routine telemetry updates non-destructive

### DIFF
--- a/.github/workflows/update-telemetry-data.yml
+++ b/.github/workflows/update-telemetry-data.yml
@@ -3,13 +3,7 @@ name: Update telemetry data
 on:
   schedule:
     - cron: "17 3 * * 1"
-  workflow_dispatch:
-    inputs:
-      reset_checkpoint:
-        description: Explicitly discard cumulative telemetry history
-        required: false
-        type: boolean
-        default: false
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -82,60 +76,7 @@ jobs:
             exit 1
           fi
 
-      - name: Capture explicit telemetry reset target
-        if: inputs.reset_checkpoint == true
-        working-directory: web
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: |
-          pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
-            --remote \
-            --command="SELECT (SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'round_telemetry') AS table_sql, COUNT(*) AS row_count, MIN(id) AS min_id, MAX(id) AS max_id FROM round_telemetry" \
-            --json > "$RUNNER_TEMP/d1-reset-target.json"
-
-      - name: Validate explicit telemetry reset target
-        if: inputs.reset_checkpoint == true
-        run: |
-          python data/telemetry_retention.py validate-reset-target \
-            "$RUNNER_TEMP/d1-reset-target.json"
-
-      - name: Apply explicit ten-round telemetry beta reset
-        if: inputs.reset_checkpoint == true
-        working-directory: web
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: |
-          pnpm dlx wrangler@4.112.0 d1 execute \
-            "$CLOUDFLARE_D1_DATABASE_NAME" \
-            --remote \
-            --file=migrations/0004_round_telemetry_rounds_10_reset.sql \
-            --yes
-
-      - name: Capture post-reset D1 metadata
-        if: inputs.reset_checkpoint == true
-        working-directory: web
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: |
-          pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
-            --remote \
-            --command="SELECT (SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'round_telemetry') AS table_sql, COUNT(*) AS row_count, MIN(id) AS min_id, MAX(id) AS max_id, COALESCE((SELECT seq FROM sqlite_sequence WHERE name = 'round_telemetry'), 0) AS sequence_value FROM round_telemetry" \
-            --json > "$RUNNER_TEMP/d1-pre-migration.json"
-
-      - name: Verify explicit telemetry reset result
-        if: inputs.reset_checkpoint == true
-        run: |
-          python data/telemetry_retention.py verify-reset \
-            "$RUNNER_TEMP/d1-pre-migration.json"
-
       - name: Capture pre-migration D1 metadata
-        if: inputs.reset_checkpoint != true
         working-directory: web
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -149,23 +90,11 @@ jobs:
 
       - name: Validate D1 migration preflight
         id: retention_preflight
-        env:
-          RESET_CHECKPOINT: ${{ inputs.reset_checkpoint == true && 'true' || 'false' }}
         run: |
-          reset_args=()
-          case "$RESET_CHECKPOINT" in
-            true) reset_args+=(--reset-checkpoint) ;;
-            false) ;;
-            *)
-              echo "Invalid reset_checkpoint input" >&2
-              exit 1
-              ;;
-          esac
           python data/telemetry_retention.py preflight \
             "$RUNNER_TEMP/d1-pre-migration.json" \
             data/telemetry_state.json \
-            --github-output "$GITHUB_OUTPUT" \
-            "${reset_args[@]}"
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Apply required D1 AUTOINCREMENT migration
         if: steps.retention_preflight.outputs.migration_required == 'true'
@@ -182,7 +111,6 @@ jobs:
             --yes
 
       - name: Capture post-migration D1 metadata
-        if: inputs.reset_checkpoint != true
         working-directory: web
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -195,27 +123,11 @@ jobs:
             --json > "$RUNNER_TEMP/d1-post-migration.json"
 
       - name: Verify D1 migration and sequence
-        if: inputs.reset_checkpoint != true
-        env:
-          RESET_CHECKPOINT: ${{ inputs.reset_checkpoint == true && 'true' || 'false' }}
         run: |
-          reset_args=()
-          case "$RESET_CHECKPOINT" in
-            true)
-              echo "Reset verification uses the dedicated reset path" >&2
-              exit 1
-              ;;
-            false) ;;
-            *)
-              echo "Invalid reset_checkpoint input" >&2
-              exit 1
-              ;;
-          esac
           python data/telemetry_retention.py verify \
             "$RUNNER_TEMP/d1-pre-migration.json" \
             "$RUNNER_TEMP/d1-post-migration.json" \
-            data/telemetry_state.json \
-            "${reset_args[@]}"
+            data/telemetry_state.json
 
       - name: Collect D1 observation data
         working-directory: web
@@ -257,24 +169,12 @@ jobs:
           }
 
       - name: Build public artifact and incremental checkpoint
-        env:
-          RESET_CHECKPOINT: ${{ inputs.reset_checkpoint == true && 'true' || 'false' }}
         run: |
           trap 'rm -f -- "$RUNNER_TEMP/round_telemetry.sql"' EXIT
-          reset_args=()
-          case "$RESET_CHECKPOINT" in
-            true) reset_args+=(--reset-and-fold-export) ;;
-            false) ;;
-            *)
-              echo "Invalid reset_checkpoint input" >&2
-              exit 1
-              ;;
-          esac
           python data/build_telemetry_data.py \
             "$RUNNER_TEMP/round_telemetry.sql" \
             --state data/telemetry_state.json \
-            --output web/public/game-data/telemetry_data.json \
-            "${reset_args[@]}"
+            --output web/public/game-data/telemetry_data.json
           rm -f -- "$RUNNER_TEMP/round_telemetry.sql"
           trap - EXIT
           PYTHONPATH=data python - <<'PY'
@@ -367,7 +267,6 @@ jobs:
         env:
           CHECKOUT_SHA: ${{ steps.source.outputs.sha }}
           PUBLISHED_SHA: ${{ steps.publish.outputs.checkpoint_sha }}
-          RESET_CHECKPOINT: ${{ inputs.reset_checkpoint == true && 'true' || 'false' }}
         run: |
           umask 077
           git show \
@@ -376,20 +275,10 @@ jobs:
           git show \
             "${PUBLISHED_SHA}:data/telemetry_state.json" \
             > "$RUNNER_TEMP/published-telemetry-state.json"
-          reset_args=()
-          case "$RESET_CHECKPOINT" in
-            true) reset_args+=(--reset-checkpoint) ;;
-            false) ;;
-            *)
-              echo "Invalid reset_checkpoint input" >&2
-              exit 1
-              ;;
-          esac
           python data/telemetry_retention.py report-publish \
             "$RUNNER_TEMP/previous-telemetry-state.json" \
             "$RUNNER_TEMP/published-telemetry-state.json" \
-            "$GITHUB_STEP_SUMMARY" \
-            "${reset_args[@]}"
+            "$GITHUB_STEP_SUMMARY"
 
       - name: Prepare bounded purge from the committed checkpoint
         run: |

--- a/data/test_telemetry_retention.py
+++ b/data/test_telemetry_retention.py
@@ -329,48 +329,22 @@ class TelemetryMigrationTests(unittest.TestCase):
             "--file=migrations/0002_round_telemetry_autoincrement.sql",
             source,
         )
-        self.assertIn(
-            "if: inputs.reset_checkpoint == true",
+        self.assertNotIn("d1 migrations apply", source)
+
+    def test_workflow_does_not_expose_or_run_destructive_reset(self) -> None:
+        source = UPDATE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("workflow_dispatch: {}", source)
+        self.assertNotIn("reset_checkpoint", source)
+        self.assertNotIn(
+            "Explicitly discard cumulative telemetry history",
             source,
         )
-        self.assertIn(
+        self.assertNotIn(
             "--file=migrations/0004_round_telemetry_rounds_10_reset.sql",
             source,
         )
-        self.assertNotIn("d1 migrations apply", source)
-
-    def test_workflow_validates_reset_before_and_after_destructive_step(
-        self,
-    ) -> None:
-        source = UPDATE_WORKFLOW.read_text(encoding="utf-8")
-        capture_position = source.index(
-            "name: Capture explicit telemetry reset target"
-        )
-        validate_position = source.index(
-            "name: Validate explicit telemetry reset target"
-        )
-        reset_position = source.index(
-            "name: Apply explicit ten-round telemetry beta reset"
-        )
-        verify_position = source.index(
-            "name: Verify explicit telemetry reset result"
-        )
-        export_position = source.index("name: Export round telemetry from D1")
-
-        self.assertLess(capture_position, validate_position)
-        self.assertLess(validate_position, reset_position)
-        self.assertLess(reset_position, verify_position)
-        self.assertLess(verify_position, export_position)
-        self.assertIn(
-            "python data/telemetry_retention.py validate-reset-target",
-            source,
-        )
-        self.assertIn(
-            "python data/telemetry_retention.py verify-reset",
-            source,
-        )
-        self.assertIn("true) reset_args+=(--reset-and-fold-export)", source)
-        self.assertNotIn("true) reset_args+=(--reset-state)", source)
+        self.assertNotIn("--reset-state", source)
+        self.assertNotIn("--reset-and-fold-export", source)
 
     def test_workflow_uses_node24_pnpm_and_reports_published_events(self) -> None:
         source = UPDATE_WORKFLOW.read_text(encoding="utf-8")

--- a/web/README.md
+++ b/web/README.md
@@ -285,20 +285,19 @@ source of truth; no Wrangler configuration file is required.
    `/api/telemetry/rounds` plus `/api/battles` are then served by Pages
    Functions. Static recommendation pages and `/contributors` never query D1.
 
-### Ten-round telemetry reset rollout
+### Ten-round telemetry rollout
 
-The checked-in aggregate checkpoint and public schema-v5 artifact intentionally
-start the ten-round beta contract with zero history. Updating the repository
-does not change the remote D1 database.
+The ten-round beta rollout reset the checked-in aggregate checkpoint and public
+schema-v5 artifact to zero history. Updating the repository alone does not
+change the remote D1 database.
 
-An existing D1 database with the earlier Rounds 1–8 constraint requires one
-manual **Update telemetry data** workflow dispatch with
-`reset_checkpoint=true`. That explicit run applies
-`migrations/0004_round_telemetry_rounds_10_reset.sql`, dropping and recreating
-only `round_telemetry` with the Rounds 1–10 constraint; it preserves
-`web_battle_submissions`. Until this one-time reset succeeds, the old D1 schema
-fails retention preflight closed. Subsequent scheduled runs leave the reset
-option disabled.
+The one-time remote D1 reset for the Rounds 1–10 constraint has completed.
+The routine **Update telemetry data** workflow no longer exposes or invokes a
+destructive reset option, so manual and scheduled runs both preserve cumulative
+history. The recovery migration
+`migrations/0004_round_telemetry_rounds_10_reset.sql` and the builder's
+`--reset-and-fold-export` flag remain available for deliberate incident
+recovery outside the routine workflow.
 
 ### Weekly aggregate workflow
 
@@ -361,20 +360,11 @@ Deleting a row removes it from the live D1 table, but Cloudflare's always-on
 still restore provider history for the plan's recovery window. This workflow
 does not create or retain any additional raw backup.
 
-Manual workflow dispatch exposes an explicit checkpoint-reset option for a
-deliberate catalog/algorithm reset. Normal runs fail if the checkpoint is
-missing or incompatible; they never silently discard cumulative history.
-
-A `reset_checkpoint` dispatch runs the dedicated reset path (see [Ten-round
-telemetry reset rollout](#ten-round-telemetry-reset-rollout)): it validates the
-live `round_telemetry` is a known eight- or ten-round schema, applies
-`migrations/0004_round_telemetry_rounds_10_reset.sql` to drop and recreate the
-Rounds 1–10 table, verifies AUTOINCREMENT and the `sqlite_sequence` value,
-discards the prior aggregates, and folds every row in the fresh export from
-scratch. If the D1 database is instead deliberately replaced, initialize the
-empty replacement database with `migrations/0001_round_telemetry.sql` first,
-then dispatch the same reset. Do not enable the reset option for routine weekly
-retention.
+Manual workflow dispatch follows the same non-destructive path as the weekly
+schedule. Normal runs fail if the checkpoint is missing or incompatible; they
+never silently discard cumulative history. The retained recovery migration and
+builder flag are intentionally not wired into GitHub Actions because either
+can discard telemetry history.
 
 The builder recomputes event scores and tie-breaks from the recorded paired
 model version. Before deploying a new `src/recommendation_data.json`, retain the

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -343,6 +343,8 @@ describe('recommendTeams — global formation optimization', () => {
     expect(new Set(h0.skills)).toEqual(new Set(['s0', 's1']));
   });
 
+  // Shared CI can exceed Vitest's 5s default here; the realistic benchmark
+  // below retains its separate 5s performance budget.
   test('positive SP potential keeps an individually weak decisive pair in the 28→18 shortlist', () => {
     const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
     const skills = Array.from({ length: 28 }, (_, i) => `s${i}`);
@@ -366,7 +368,7 @@ describe('recommendTeams — global formation optimization', () => {
       .find((hero) => hero.name === 'h0')!;
 
     expect(new Set(h0.skills)).toEqual(new Set(['s26', 's27']));
-  });
+  }, 15000);
 
   test('skill routing strengthens the top two teams before spending value on the third', () => {
     const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);


### PR DESCRIPTION
## Intent

Create a safe follow-up PR after the ten-round telemetry beta reset: remove the 'Explicitly discard cumulative telemetry history' GitHub Actions input and all destructive reset branches so telemetry history cannot be accidentally erased, while retaining migration 0004 and lower-level CLI and builder recovery tools outside the routine workflow. Fix the CI failure by giving the expensive 28-to-18 SP-pair regression a 15-second per-test timeout without relaxing the separate 5-second realistic 15-hero and 28-skill performance benchmark. Update documentation and workflow contract tests. Do not rerun the failed reset-enabled workflow; routine manual and scheduled runs must be non-destructive.

## What Changed

- Remove the destructive telemetry reset input and branches so scheduled and manual workflow runs preserve cumulative history.
- Retain the migration and lower-level recovery tools outside the routine workflow, with updated documentation and workflow contract coverage.
- Give the expensive 28→18 SP-pair regression a 15-second timeout while preserving the separate 5-second performance benchmark.

## Risk Assessment

✅ Low: The change is well-bounded and satisfies the intent: routine workflow reset paths are removed, recovery tools remain available, documentation and contract tests are updated, and only the targeted regression receives the 15-second timeout while the separate 5-second performance assertion remains unchanged.

## Testing

No baseline commands were supplied; focused workflow automation, direct product scenarios, timeout-boundary checks, documentation inspection, and cleanup verification succeeded, while full Python and web suites were blocked by the read-only, Node-less environment. Evidence is inline because the designated directory rejected writes; no GitHub Actions screenshot was possible because the target commit is not hosted, and the reset-enabled workflow was intentionally never triggered.

<details>
<summary>Evidence: Routine telemetry workflow contract</summary>

```text
{
"manual_dispatch": "input-free",
"scheduled_dispatch": true,
"destructive_reset_references_in_routine_workflow": [],
"recovery_migration_0004_retained": true,
"builder_recovery_flags_retained": true,
"retention_recovery_cli_retained": true
}
```
</details>
<details>
<summary>Evidence: Non-destructive cumulative-history behavior</summary>

```text
{
"routine_preflight": "already-applied",
"row_stats_preserved_through_verification": true,
"previous_cumulative_events": 100,
"published_cumulative_events": 123,
"new_events_reported": 23,
"history_regression_without_reset_rejected": true,
"rejection": "published validated-event count regressed without a reset"
}
```
</details>
<details>
<summary>Evidence: Formation regression and performance evidence</summary>

```text
28→18 regression: decisive s26+s27 pair preserved in 1364.1 ms with a 15000 ms per-test timeout.
Realistic 15-hero/28-skill benchmark: valid formation in 1496.8 ms against the unchanged 5000 ms performance budget; 309 partitions evaluated under the 1920 cap.
```
</details>
<details>
<summary>Evidence: Timeout contract</summary>

```text
{
"28_to_18_regression_per_test_timeout_ms": 15000,
"realistic_15_hero_28_skill_performance_budget_ms": 5000,
"realistic_benchmark_test_wrapper_timeout_ms": 20000,
"global_timeout_relaxations": []
}
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (7m23s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ The standard full suites could not execute in this validator: Node is absent, web dependencies are not installed, and the read-only sandbox rejects temporary, dependency, and designated evidence-directory writes. The Python suite&#39;s failures occurred during TemporaryDirectory setup, while pnpm exited before starting tests. Re-run the standard suites in writable, Node-enabled CI; no product failure was observed in the executable focused checks.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest data.test_telemetry_retention.TelemetryMigrationTests.test_workflow_does_not_expose_or_run_destructive_reset -v`
- <code>`python3 -c &#39;&lt;workflow contract and retained recovery-tool assertions&gt;&#39;` plus `git diff --quiet 23c4f29672187a3bdb1c576e6d700bf099156a27..6a0bc0f1809f331cbe18ceb4e31a55ba903f6b77 -- web/migrations/0004_round_telemetry_rounds_10_reset.sql data/build_telemetry_data.py data/telemetry_retention.py`</code>
- `PYTHONPATH=data PYTHONDONTWRITEBYTECODE=1 python3 -c '<routine preflight, migration verification, cumulative increment, and regression-rejection scenario>'`
- `bun -e '<28→18 decisive SP-pair recommendation scenario>'`
- `bun -e '<realistic 15-hero/28-skill production-data benchmark>'`
- `python3 -c '<per-test timeout, performance budget, and global-timeout assertions>'`
- <code>`PYTHONDONTWRITEBYTECODE=1 python3 -m unittest data/test_telemetry_retention.py -v` (environment setup errors from unavailable temporary storage)</code>
- <code>`cd web &amp;&amp; pnpm test`; `pnpm test:e2e`; `pnpm build` (could not start because `node` is unavailable)</code>
- `rg -n 'reset_checkpoint|Explicitly discard cumulative telemetry history|reset-enabled|telemetry reset rollout|one-time reset|reset option|reset path' --glob '*.md' --glob '*.yml' --glob '*.yaml' .`
- <code>`git diff --check 23c4f29672187a3bdb1c576e6d700bf099156a27..6a0bc0f1809f331cbe18ceb4e31a55ba903f6b77` and `git status --short`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ `web/src/services/__tests__/recommendationEngine.test.ts:346` - The configured `pnpm typecheck` check could not run because dependencies are absent and the read-only workspace prevented pnpm from installing them. YAML syntax, Python syntax, and `git diff --check` passed.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
