### PR TITLE
feat(web): simplify setup, round, and advisor UI for newcomers

### DIFF
--- a/web/src/components/game/CurrentTeam.tsx
+++ b/web/src/components/game/CurrentTeam.tsx
@@ -174,16 +174,26 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
     >
       <Box sx={{ mb: 2 }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 2, flexWrap: 'wrap' }}>
-          <Box sx={{ minWidth: 0 }}>
-            <Typography variant="overline" color="error.main" sx={{ display: 'block', lineHeight: 1.2 }}>CURRENT ROSTER</Typography>
+          <Box sx={{ minWidth: 0, flex: '1 1 180px' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', columnGap: 1, rowGap: 0.5, flexWrap: 'wrap', minWidth: 0 }}>
-              <Typography
-                component="h2"
-                variant="h5"
-                sx={{ fontSize: { xs: '1.25rem', sm: '1.5rem' }, lineHeight: 1.25, whiteSpace: 'nowrap' }}
-              >
-                当前阵容
-              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75, whiteSpace: 'nowrap' }}>
+                <Typography
+                  component="h2"
+                  variant="h5"
+                  sx={{ fontSize: { xs: '1.25rem', sm: '1.5rem' }, lineHeight: 1.25 }}
+                >
+                  当前阵容
+                </Typography>
+                <Typography
+                  component="span"
+                  variant="subtitle1"
+                  color="text.secondary"
+                  data-testid="current-roster-score"
+                  sx={{ fontVariantNumeric: 'tabular-nums', fontSize: { xs: '0.9rem', sm: '1rem' } }}
+                >
+                  评分 {rosterScore.toFixed(1)}
+                </Typography>
+              </Box>
               {selectedSeason !== null && (
                 <Chip
                   label={`赛季 ${selectedSeason}`}
@@ -193,15 +203,6 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
                   data-testid="current-season-chip"
                 />
               )}
-              <Typography
-                component="span"
-                variant="subtitle1"
-                color="text.secondary"
-                data-testid="current-roster-score"
-                sx={{ fontVariantNumeric: 'tabular-nums', fontSize: { xs: '0.9rem', sm: '1rem' }, whiteSpace: 'nowrap' }}
-              >
-                评分：{rosterScore.toFixed(1)}
-              </Typography>
             </Box>
           </Box>
 
@@ -221,6 +222,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
                 variant={editMode ? "contained" : "outlined"}
                 startIcon={editMode ? <CheckIcon /> : <EditIcon />}
                 onClick={handleEditToggle}
+                sx={{ minWidth: 118 }}
               >
                 {editMode ? '保存修改' : '编辑队伍'}
               </Button>
@@ -238,6 +240,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
                 startIcon={<AutoAwesomeIcon />}
                 onClick={handleRecommendHero}
                 disabled={!availableHeroes || availableHeroes.length === 0}
+                sx={{ flex: { xs: '1 1 140px', sm: '0 0 160px' } }}
               >
                 推荐支援武将
               </Button>
@@ -250,6 +253,7 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
                 startIcon={<AutoAwesomeIcon />}
                 onClick={handleRecommendSkills}
                 disabled={!availableSkills || availableSkills.length === 0}
+                sx={{ flex: { xs: '1 1 140px', sm: '0 0 160px' } }}
               >
                 推荐支援战法
               </Button>

--- a/web/src/components/game/OptionSetInput.tsx
+++ b/web/src/components/game/OptionSetInput.tsx
@@ -1,4 +1,4 @@
-import { Paper, Typography, Box, Grid, Alert } from '@mui/material';
+import { Paper, Typography, Box, Grid } from '@mui/material';
 import AutocompleteInput from '../common/AutocompleteInput';
 import TagList from '../common/TagList';
 import type { CurrentRoundInputs, SetName, RoundType, HeroMeta, SkillMeta } from '../../types/game';
@@ -69,7 +69,7 @@ const OptionSetInput = ({
           gap: 2,
           bgcolor: 'rgba(251,248,239,0.58)',
         }}>
-          <Typography component="h3" variant="h6" sx={{ mb: { xs: 1.5, sm: 0 } }}>
+          <Typography component="h2" variant="h6" sx={{ mb: { xs: 1.5, sm: 0 } }}>
             {setLabel} ({currentSet.length}/{itemsPerSet})
           </Typography>
           
@@ -77,49 +77,34 @@ const OptionSetInput = ({
             items={availableItems.filter(item => !allSelected.includes(item))}
             selectedItems={currentSet}
             onAdd={(item) => handleAddItem(setName, item)}
-            label={roundType === 'hero' ? '添加武将...' : '添加战法...'}
-            placeholder={roundType === 'hero' ? '搜索武将...' : '搜索战法...'}
+            label={roundType === 'hero' ? '输入武将名或拼音搜索武将' : '输入战法名或拼音搜索战法'}
+            placeholder={roundType === 'hero' ? '输入武将名或拼音搜索武将' : '输入战法名或拼音搜索战法'}
             maxItems={itemsPerSet}
             disabled={disabled || currentSet.length >= itemsPerSet}
             heroMetadata={roundType === 'hero' ? heroMetadata : null}
             skillMetadata={roundType === 'skill' ? skillMetadata : null}
           />
           
-          <TagList
-            items={currentSet}
-            onRemove={(item) => handleRemoveItem(setName, item)}
-            color={itemColor}
-            heroMetadata={roundType === 'hero' ? heroMetadata : null}
-            skillMetadata={roundType === 'skill' ? skillMetadata : null}
-          />
+          {currentSet.length > 0 && (
+            <TagList
+              items={currentSet}
+              onRemove={(item) => handleRemoveItem(setName, item)}
+              color={itemColor}
+              heroMetadata={roundType === 'hero' ? heroMetadata : null}
+              skillMetadata={roundType === 'skill' ? skillMetadata : null}
+            />
+          )}
         </Box>
       </Grid>
     );
   };
-  
-  const allSetsComplete = 
-    (sets.set1?.length === itemsPerSet) && 
-    (sets.set2?.length === itemsPerSet) && 
-    (sets.set3?.length === itemsPerSet);
-  
+
   return (
-    <Paper sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, borderTop: '3px solid', borderTopColor: 'text.primary' }}>
-      <Typography variant="overline" color="error.main">
-        本轮候选
-      </Typography>
-      <Typography component="h2" variant="h5" gutterBottom>
-        填写三组选项
-      </Typography>
-      <Typography variant="body2" color="text.secondary" paragraph>
-        每组需恰好包含 {itemsPerSet} 个{roundType === 'hero' ? '武将' : '战法'}。将从这三组中选定一组。
-      </Typography>
-      
-      {!allSetsComplete && (
-        <Alert severity="info" sx={{ mb: 2 }}>
-          请先完成三组选项，每组恰好 {itemsPerSet} 个{roundType === 'hero' ? '武将' : '战法'}，再获取推荐。
-        </Alert>
-      )}
-      
+    <Paper
+      component="section"
+      aria-label="本轮三组选项"
+      sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, borderTop: '3px solid', borderTopColor: 'text.primary' }}
+    >
       <Grid container spacing={1.5}>
         {renderSetInput('set1', '第 1 组')}
         {renderSetInput('set2', '第 2 组')}

--- a/web/src/components/game/RecommendationPanel.tsx
+++ b/web/src/components/game/RecommendationPanel.tsx
@@ -31,9 +31,6 @@ const RecommendationPanel = ({ recommendation, roundType }: RecommendationPanelP
         <Typography variant="body1" fontWeight="bold">
           推荐：第 {(recommended_set_index as number) + 1} 组
         </Typography>
-        <Typography variant="caption" color="text.secondary">
-          按本轮评分排序，评分越高越推荐。
-        </Typography>
       </Alert>
 
       {round_info && (

--- a/web/src/components/game/RoundInfo.tsx
+++ b/web/src/components/game/RoundInfo.tsx
@@ -1,8 +1,7 @@
-import { Typography, Stepper, Step, StepLabel, Paper, Box, Button, Chip } from '@mui/material';
+import { Typography, Stepper, Step, StepLabel, Paper, Box, Button } from '@mui/material';
 import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
 import { useNavigate } from 'react-router-dom';
 import {
-  getRoundInfo,
   getRoundType,
   ROUND_NUMBERS,
   TOTAL_ROUNDS,
@@ -17,43 +16,48 @@ interface RoundInfoProps {
  */
 const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
   const navigate = useNavigate();
-  const info = getRoundInfo(roundNumber);
+  const roundType = getRoundType(roundNumber);
+  const roundTitle = `第 ${roundNumber} 轮：选择${roundType === 'hero' ? '武将' : '战法'}`;
   
   return (
-    <Paper sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, position: 'relative', borderTop: '3px solid', borderTopColor: 'text.primary' }}>
-      <Box
+    <Paper
+      component="section"
+      aria-labelledby={`round-${roundNumber}-title`}
+      sx={{ p: { xs: 2.25, sm: 3 }, mb: 3, position: 'relative', borderTop: '3px solid', borderTopColor: 'text.primary' }}
+    >
+      <Typography
+        id={`round-${roundNumber}-title`}
+        component="h1"
         sx={{
-          display: 'flex',
-          flexDirection: { xs: 'column', sm: 'row' },
-          justifyContent: 'space-between',
-          alignItems: { xs: 'stretch', sm: 'flex-start' },
-          gap: 2,
-          mb: 2,
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          p: 0,
+          m: '-1px',
+          overflow: 'hidden',
+          clip: 'rect(0 0 0 0)',
+          whiteSpace: 'nowrap',
+          border: 0,
         }}
       >
-        <Box sx={{ flex: 1 }}>
-          <Chip size="small" color="error" variant="outlined" label={`第 ${roundNumber} / ${TOTAL_ROUNDS} 轮`} sx={{ mb: 1.5 }} />
-          <Typography component="h1" variant="h4" gutterBottom>
-            {info.title}
-          </Typography>
-          <Typography variant="body1" color="text.secondary" paragraph>
-            {info.description}
-          </Typography>
-        </Box>
-        {roundNumber > 3 && (
+        {roundTitle}
+      </Typography>
+
+      {roundNumber > 3 && (
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
           <Button
             variant="outlined"
             color="primary"
             size="small"
             startIcon={<AccountTreeOutlinedIcon />}
             onClick={() => navigate('/team-builder')}
-            sx={{ ml: { xs: 0, sm: 2 }, flexShrink: 0, width: { xs: '100%', sm: 'auto' } }}
+            sx={{ width: { xs: '100%', sm: 'auto' } }}
           >
             查看队伍推荐
           </Button>
-        )}
-      </Box>
-      
+        </Box>
+      )}
+
       <Box
         role="list"
         aria-label={`${TOTAL_ROUNDS} 轮进度`}
@@ -61,7 +65,6 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
           display: { xs: 'grid', sm: 'none' },
           gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
           gap: 0.75,
-          pt: 1,
         }}
       >
         {ROUND_NUMBERS.map((round) => {
@@ -106,14 +109,13 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
         sx={{
           display: { xs: 'none', sm: 'block' },
           overflowX: 'auto',
-          pt: 1,
           '&:focus-visible': {
             outline: '3px solid rgba(69,108,95,0.42)',
             outlineOffset: 2,
           },
         }}
       >
-      <Stepper activeStep={roundNumber - 1} alternativeLabel sx={{ mt: 2, minWidth: 820 }}>
+      <Stepper activeStep={roundNumber - 1} alternativeLabel sx={{ minWidth: 820 }}>
         {ROUND_NUMBERS.map((round) => {
           const isHero = getRoundType(round) === 'hero';
           return (

--- a/web/src/components/game/__tests__/RoundInfo.test.tsx
+++ b/web/src/components/game/__tests__/RoundInfo.test.tsx
@@ -3,17 +3,24 @@ import { MemoryRouter } from 'react-router-dom';
 import RoundInfo from '../RoundInfo';
 
 describe('RoundInfo', () => {
-  test('shows all ten rounds and marks round 9 as the active hero round', () => {
+  test('keeps an accessible round title and marks round 9 as active', () => {
     render(
       <MemoryRouter>
         <RoundInfo roundNumber={9} />
       </MemoryRouter>
     );
 
-    expect(
-      screen.getByRole('heading', { level: 1, name: '第 9 轮：选择武将' })
-    ).toBeInTheDocument();
-    expect(screen.getByText('第 9 / 10 轮')).toBeInTheDocument();
+    const title = screen.getByRole('heading', {
+      level: 1,
+      name: '第 9 轮：选择武将',
+    });
+    expect(title).toBeInTheDocument();
+    expect(title).toHaveStyle({
+      position: 'absolute',
+      width: '1px',
+      height: '1px',
+    });
+    expect(screen.queryByText('第 9 / 10 轮')).not.toBeInTheDocument();
 
     const progress = screen.getByRole('list', { name: '10 轮进度' });
     expect(within(progress).getAllByRole('listitem')).toHaveLength(10);

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -98,6 +98,12 @@ const AppLayout = ({ children }: AppLayoutProps) => {
         onClose={handleCloseSetupMenu}
         MenuListProps={{ 'aria-labelledby': 'setup-more-button' }}
       >
+        <MenuItem onClick={() => handleSetupNavigation('/')}>
+          <ListItemIcon>
+            <SportsEsportsOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>对局推荐</ListItemText>
+        </MenuItem>
         <MenuItem onClick={() => handleSetupNavigation('/analytics')}>
           <ListItemIcon>
             <QueryStatsOutlinedIcon fontSize="small" />
@@ -164,11 +170,9 @@ const AppLayout = ({ children }: AppLayoutProps) => {
               </Box>
 
               <Stack direction="row" gap={0.25} sx={{ overflowX: 'auto', flex: 1, minWidth: 0 }}>
-                {!isInitialSetup && (
-                  <Button startIcon={<SportsEsportsOutlinedIcon />} onClick={() => navigate('/')} sx={navButtonSx('/')}>
-                    对局推荐
-                  </Button>
-                )}
+                <Button startIcon={<SportsEsportsOutlinedIcon />} onClick={() => navigate('/')} sx={navButtonSx('/')}>
+                  对局推荐
+                </Button>
                 {roundNumber > 3 && (
                   <Button startIcon={<AccountTreeOutlinedIcon />} onClick={() => navigate('/team-builder')} sx={navButtonSx('/team-builder')}>
                     队伍推荐

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -1,11 +1,22 @@
-import type { ReactNode } from 'react';
-import { Box, Container, Button, Stack, Typography } from '@mui/material';
+import { useState, type MouseEvent, type ReactNode } from 'react';
+import {
+  Box,
+  Button,
+  Container,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Stack,
+  Typography,
+} from '@mui/material';
 import SportsEsportsOutlinedIcon from '@mui/icons-material/SportsEsportsOutlined';
 import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
 import QueryStatsOutlinedIcon from '@mui/icons-material/QueryStatsOutlined';
 import RestartAltOutlinedIcon from '@mui/icons-material/RestartAltOutlined';
 import UploadFileOutlinedIcon from '@mui/icons-material/UploadFileOutlined';
 import EmojiEventsOutlinedIcon from '@mui/icons-material/EmojiEventsOutlined';
+import MoreHorizOutlinedIcon from '@mui/icons-material/MoreHorizOutlined';
 import { useNavigate, useLocation } from 'react-router-dom';
 import Header from './Header';
 import JoinGroupButton from './JoinGroupButton';
@@ -18,6 +29,21 @@ const AppLayout = ({ children }: AppLayoutProps) => {
   const location = useLocation();
   const { state, dispatch } = useGame();
   const roundNumber = state?.gameState?.round_number || 0;
+  const isInitialSetup = location.pathname === '/' && !state.gameState;
+  const [setupMenuAnchor, setSetupMenuAnchor] = useState<HTMLElement | null>(null);
+
+  const handleOpenSetupMenu = (event: MouseEvent<HTMLButtonElement>) => {
+    setSetupMenuAnchor(event.currentTarget);
+  };
+
+  const handleCloseSetupMenu = () => {
+    setSetupMenuAnchor(null);
+  };
+
+  const handleSetupNavigation = (path: string) => {
+    handleCloseSetupMenu();
+    navigate(path);
+  };
 
   const handleResetProgress = () => {
     if (window.confirm('确定要重置全部进度吗？此操作不可恢复。')) {
@@ -39,14 +65,84 @@ const AppLayout = ({ children }: AppLayoutProps) => {
     '&:hover': { bgcolor: 'rgba(69,108,95,0.08)', borderColor: location.pathname === path ? 'error.main' : 'divider' },
   });
 
+  const setupMobileNavigation = isInitialSetup ? (
+    <>
+      <Box component="nav" aria-label="初始设置导航">
+        <Button
+          id="setup-more-button"
+          aria-controls={setupMenuAnchor ? 'setup-more-menu' : undefined}
+          aria-haspopup="menu"
+          aria-expanded={setupMenuAnchor ? 'true' : undefined}
+          color="inherit"
+          size="small"
+          variant="outlined"
+          startIcon={<MoreHorizOutlinedIcon />}
+          onClick={handleOpenSetupMenu}
+          sx={{
+            minWidth: 0,
+            color: 'inherit',
+            borderColor: '#69756f',
+            '&:hover': {
+              borderColor: '#aeb8b1',
+              bgcolor: 'rgba(255,255,255,0.08)',
+            },
+          }}
+        >
+          更多
+        </Button>
+      </Box>
+      <Menu
+        id="setup-more-menu"
+        anchorEl={setupMenuAnchor}
+        open={Boolean(setupMenuAnchor)}
+        onClose={handleCloseSetupMenu}
+        MenuListProps={{ 'aria-labelledby': 'setup-more-button' }}
+      >
+        <MenuItem onClick={() => handleSetupNavigation('/analytics')}>
+          <ListItemIcon>
+            <QueryStatsOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>数据洞察</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={() => handleSetupNavigation('/contributors')}>
+          <ListItemIcon>
+            <EmojiEventsOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>战报贡献榜</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={() => handleSetupNavigation('/contribute')}>
+          <ListItemIcon>
+            <UploadFileOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>上传战报</ListItemText>
+        </MenuItem>
+        <JoinGroupButton menuItem onOpen={handleCloseSetupMenu} />
+      </Menu>
+    </>
+  ) : undefined;
+
   return (
-    <Box sx={{ minHeight: '100vh', display: 'grid', gridTemplateColumns: { xs: 'minmax(0, 1fr)', md: '80px minmax(0, 1fr)' } }}>
-      <Header />
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'grid',
+        gridTemplateColumns: {
+          xs: 'minmax(0, 1fr)',
+          md: '80px minmax(0, 1fr)',
+        },
+        gridTemplateRows: {
+          xs: 'auto minmax(0, 1fr)',
+          md: 'minmax(0, 1fr)',
+        },
+      }}
+    >
+      <Header mobileAction={setupMobileNavigation} />
       <Box sx={{ minWidth: 0 }}>
         <Box
           component="nav"
           aria-label="主要导航"
           sx={{
+            display: { xs: isInitialSetup ? 'none' : 'block', md: 'block' },
             position: { xs: 'relative', md: 'sticky' },
             top: { xs: 0, md: 0 },
             zIndex: 15,
@@ -68,9 +164,11 @@ const AppLayout = ({ children }: AppLayoutProps) => {
               </Box>
 
               <Stack direction="row" gap={0.25} sx={{ overflowX: 'auto', flex: 1, minWidth: 0 }}>
-                <Button startIcon={<SportsEsportsOutlinedIcon />} onClick={() => navigate('/')} sx={navButtonSx('/')}>
-                  对局推荐
-                </Button>
+                {!isInitialSetup && (
+                  <Button startIcon={<SportsEsportsOutlinedIcon />} onClick={() => navigate('/')} sx={navButtonSx('/')}>
+                    对局推荐
+                  </Button>
+                )}
                 {roundNumber > 3 && (
                   <Button startIcon={<AccountTreeOutlinedIcon />} onClick={() => navigate('/team-builder')} sx={navButtonSx('/team-builder')}>
                     队伍推荐
@@ -89,16 +187,20 @@ const AppLayout = ({ children }: AppLayoutProps) => {
 
               <Stack direction="row" gap={0.75} sx={{ display: { xs: 'none', lg: 'flex' } }}>
                 <JoinGroupButton />
-                <Button color="error" variant="text" startIcon={<RestartAltOutlinedIcon />} onClick={handleResetProgress} title="重置所有已保存进度">
-                  重置
-                </Button>
+                {state.gameState && (
+                  <Button color="error" variant="text" startIcon={<RestartAltOutlinedIcon />} onClick={handleResetProgress} title="重置所有已保存进度">
+                    重置
+                  </Button>
+                )}
               </Stack>
             </Stack>
             <Stack direction="row" gap={1} sx={{ display: { xs: 'flex', lg: 'none' }, mt: 1, justifyContent: 'flex-end' }}>
               <JoinGroupButton />
-              <Button color="error" size="small" startIcon={<RestartAltOutlinedIcon />} onClick={handleResetProgress} title="重置所有已保存进度">
-                重置
-              </Button>
+              {state.gameState && (
+                <Button color="error" size="small" startIcon={<RestartAltOutlinedIcon />} onClick={handleResetProgress} title="重置所有已保存进度">
+                  重置
+                </Button>
+              )}
             </Stack>
           </Container>
         </Box>

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,8 +1,13 @@
+import type { ReactNode } from 'react';
 import { Box, Typography } from '@mui/material';
 import UpdateIcon from '@mui/icons-material/Update';
 import { recommendationData } from '../../data';
 
-const Header = () => {
+interface HeaderProps {
+  mobileAction?: ReactNode;
+}
+
+const Header = ({ mobileAction }: HeaderProps) => {
   const counts = recommendationData.battle_counts;
   const totalBattles = counts.total_battles ?? 0;
 
@@ -44,18 +49,33 @@ const Header = () => {
 
       <Box
         sx={{
-          writingMode: { xs: 'horizontal-tb', md: 'vertical-rl' },
           display: 'flex',
+          flexDirection: { xs: 'row', md: 'column' },
           alignItems: 'center',
-          gap: 0.75,
-          color: '#b8c0ba',
-          fontSize: 11,
-          letterSpacing: '0.1em',
-          whiteSpace: 'nowrap',
+          gap: { xs: 1.25, md: 2.5 },
+          ml: { xs: 'auto', md: 0 },
         }}
       >
-        <UpdateIcon sx={{ fontSize: 14 }} />
-        {totalBattles > 0 && <span>已收集 {totalBattles} 场战报</span>}
+        <Box
+          sx={{
+            writingMode: { xs: 'horizontal-tb', md: 'vertical-rl' },
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.75,
+            color: '#b8c0ba',
+            fontSize: 11,
+            letterSpacing: '0.1em',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <UpdateIcon sx={{ fontSize: 14 }} />
+          {totalBattles > 0 && <span>已收集 {totalBattles} 场战报</span>}
+        </Box>
+        {mobileAction && (
+          <Box sx={{ display: { xs: 'block', md: 'none' }, flexShrink: 0 }}>
+            {mobileAction}
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/web/src/components/layout/JoinGroupButton.tsx
+++ b/web/src/components/layout/JoinGroupButton.tsx
@@ -5,6 +5,9 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
   Box,
   Typography,
   IconButton,
@@ -14,6 +17,11 @@ import {
 import CloseIcon from '@mui/icons-material/Close';
 import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 
+interface JoinGroupButtonProps {
+  menuItem?: boolean;
+  onOpen?: () => void;
+}
+
 /**
  * Button that opens a dialog displaying the author's WeChat QR code so users
  * can request to join the 演武 discussion group.
@@ -22,22 +30,34 @@ import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
  * the QR (e.g. after WeChat → Me → My QR Code → Reset), simply replace the
  * file at web/public/wechat-qr.jpg.
  */
-const JoinGroupButton = () => {
+const JoinGroupButton = ({ menuItem = false, onOpen }: JoinGroupButtonProps) => {
   const [open, setOpen] = useState(false);
 
-  const handleOpen = () => setOpen(true);
+  const handleOpen = () => {
+    onOpen?.();
+    setOpen(true);
+  };
   const handleClose = () => setOpen(false);
 
   return (
     <>
-      <Button
-        variant="outlined"
-        onClick={handleOpen}
-        size="small"
-        startIcon={<ForumOutlinedIcon />}
-      >
-        讨论群
-      </Button>
+      {menuItem ? (
+        <MenuItem onClick={handleOpen}>
+          <ListItemIcon>
+            <ForumOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>讨论群</ListItemText>
+        </MenuItem>
+      ) : (
+        <Button
+          variant="outlined"
+          onClick={handleOpen}
+          size="small"
+          startIcon={<ForumOutlinedIcon />}
+        >
+          讨论群
+        </Button>
+      )}
 
       <Dialog
         open={open}

--- a/web/src/components/setup/SetupForm.tsx
+++ b/web/src/components/setup/SetupForm.tsx
@@ -99,11 +99,13 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
   return (
     <Card sx={{ maxWidth: 1040, mx: 'auto', borderTop: '3px solid', borderTopColor: 'text.primary' }}>
       <CardContent sx={{ p: { xs: 2.25, sm: 4 }, '&:last-child': { pb: { xs: 2.25, sm: 4 } } }}>
-        <Typography variant="overline" color="error.main">
+        <Typography
+          component="h1"
+          variant="overline"
+          color="error.main"
+          sx={{ display: 'block', mb: 2 }}
+        >
           初始名册 · 演武开局
-        </Typography>
-        <Typography component="h1" variant="h4" gutterBottom>
-          录入当前阵容
         </Typography>
 
         <FormControl size="small" sx={{ width: { xs: '100%', sm: 160 }, mb: 1 }}>
@@ -123,9 +125,6 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
             ))}
           </Select>
         </FormControl>
-        <Typography variant="body1" color="text.secondary" paragraph>
-          输入初始 4 个武将和 8 个战法以开始对局。
-        </Typography>
 
         {error && (
           <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
@@ -147,21 +146,20 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
             maxItems={4}
             heroMetadata={heroMetadata}
           />
-          <TagList
-            items={heroes}
-            onRemove={handleRemoveHero}
-            color="primary"
-            heroMetadata={heroMetadata}
-          />
+          {heroes.length > 0 && (
+            <TagList
+              items={heroes}
+              onRemove={handleRemoveHero}
+              color="primary"
+              heroMetadata={heroMetadata}
+            />
+          )}
         </Box>
 
         {/* Skills Input */}
         <Box sx={{ mb: 3 }}>
           <Typography component="h2" variant="h6" gutterBottom sx={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid', borderColor: 'divider', pb: 1 }}>
             初始战法 ({skills.length}/8)
-          </Typography>
-          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-            4个橙色战法和4个紫色战法
           </Typography>
           <AutocompleteInput
             items={filteredSkills}
@@ -172,12 +170,14 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
             maxItems={8}
             skillMetadata={skillMetadata}
           />
-          <TagList
-            items={skills}
-            onRemove={handleRemoveSkill}
-            color="secondary"
-            skillMetadata={skillMetadata}
-          />
+          {skills.length > 0 && (
+            <TagList
+              items={skills}
+              onRemove={handleRemoveSkill}
+              color="secondary"
+              skillMetadata={skillMetadata}
+            />
+          )}
         </Box>
 
         {/* Start Button */}
@@ -190,12 +190,6 @@ const SetupForm = ({ onStartGame }: SetupFormProps = {}) => {
         >
           开始对局
         </Button>
-
-        {!canStartGame && (
-          <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block', textAlign: 'center' }}>
-            请选择恰好 4 个武将和 8 个战法以开始
-          </Typography>
-        )}
       </CardContent>
     </Card>
   );

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -40,35 +40,88 @@ const completedState = () => {
 };
 
 test.describe('Accessibility and responsive layout', () => {
-  test('setup instructions render vertically below the season selector', async ({ page }) => {
+  test('mobile setup prioritizes the roster form and keeps secondary destinations in one menu', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.context().clearCookies();
     await page.goto('/');
 
-    const selector = page.getByRole('combobox', { name: '当前赛季' });
-    const instructions = page.getByText(
-      '输入初始 4 个武将和 8 个战法以开始对局。',
-      { exact: true },
-    );
-    await expect(selector).toBeVisible({ timeout: 30000 });
-    await expect(instructions).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: '初始名册 · 演武开局',
+      }),
+    ).toBeVisible({ timeout: 30000 });
 
-    const [selectorBox, instructionsBox] = await Promise.all([
+    const selector = page.getByRole('combobox', { name: '当前赛季' });
+    const heroInput = page.getByLabel('输入武将名或拼音...');
+    await expect(selector).toBeVisible();
+    await expect(heroInput).toBeVisible();
+
+    const [headerBox, selectorBox, heroInputBox] = await Promise.all([
+      page.locator('header').boundingBox(),
       selector.boundingBox(),
-      instructions.boundingBox(),
+      heroInput.boundingBox(),
     ]);
+    expect(headerBox).not.toBeNull();
     expect(selectorBox).not.toBeNull();
-    expect(instructionsBox).not.toBeNull();
+    expect(heroInputBox).not.toBeNull();
     expect(
-      instructionsBox.y,
-      'setup instructions should start below the bottom of the season selector',
+      headerBox.height,
+      'the focused mobile header should remain compact',
+    ).toBeLessThanOrEqual(70);
+    expect(
+      heroInputBox.y,
+      'the first roster input should follow the season selector',
     ).toBeGreaterThanOrEqual(selectorBox.y + selectorBox.height);
+
+    await expect(
+      page.getByRole('navigation', { name: '主要导航' }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole('button', { name: '对局推荐' }),
+    ).toHaveCount(0);
+    await expect(page.getByRole('button', { name: '重置' })).toHaveCount(0);
+
+    const setupNavigation = page.getByRole('navigation', {
+      name: '初始设置导航',
+    });
+    await expect(setupNavigation).toBeVisible();
+    const moreButton = page.locator('#setup-more-button');
+    await expect(moreButton).toHaveRole('button', { name: '更多' });
+    await expect(moreButton).toBeVisible();
+    await expect(moreButton).toHaveAttribute('aria-haspopup', 'menu');
+    await expect(moreButton).not.toHaveAttribute('aria-expanded', 'true');
+    await moreButton.click();
+    await expect(moreButton).toHaveAttribute('aria-expanded', 'true');
+
+    let menu = page.getByRole('menu');
+    await expect(menu).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(moreButton).toBeFocused();
+
+    await moreButton.click();
+    menu = page.getByRole('menu');
+    await expect(menu.getByRole('menuitem', { name: '数据洞察' })).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: '战报贡献榜' })).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: '上传战报' })).toBeVisible();
+    const joinGroupItem = menu.getByRole('menuitem', { name: '讨论群' });
+    await expect(joinGroupItem).toBeVisible();
+    await joinGroupItem.click();
+    await expect(
+      page.getByRole('dialog', { name: '加演武讨论群' }),
+    ).toBeVisible();
   });
 
   test('each primary page exposes one level-one heading', async ({ page }) => {
     await page.context().clearCookies();
     await page.goto('/');
-    await expect(page.getByRole('heading', { level: 1, name: '录入当前阵容' })).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: '初始名册 · 演武开局',
+      }),
+    ).toBeVisible();
 
     await page.goto('/analytics');
     await expect(page.getByRole('heading', { level: 1, name: '数据洞察' })).toBeVisible();

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -77,9 +77,6 @@ test.describe('Accessibility and responsive layout', () => {
     await expect(
       page.getByRole('navigation', { name: '主要导航' }),
     ).not.toBeVisible();
-    await expect(
-      page.getByRole('button', { name: '对局推荐' }),
-    ).toHaveCount(0);
     await expect(page.getByRole('button', { name: '重置' })).toHaveCount(0);
 
     const setupNavigation = page.getByRole('navigation', {
@@ -102,6 +99,7 @@ test.describe('Accessibility and responsive layout', () => {
 
     await moreButton.click();
     menu = page.getByRole('menu');
+    await expect(menu.getByRole('menuitem', { name: '对局推荐' })).toBeVisible();
     await expect(menu.getByRole('menuitem', { name: '数据洞察' })).toBeVisible();
     await expect(menu.getByRole('menuitem', { name: '战报贡献榜' })).toBeVisible();
     await expect(menu.getByRole('menuitem', { name: '上传战报' })).toBeVisible();
@@ -133,7 +131,11 @@ test.describe('Accessibility and responsive layout', () => {
     await expect(page.getByRole('heading', { level: 1, name: '战报贡献榜' })).toBeVisible();
 
     await seedGame(page, lateRoundState(), lateRoundInputs());
-    await expect(page.getByRole('heading', { level: 1, name: '第 7 轮：选择武将' })).toBeVisible();
+    const roundHeading = page.getByRole('heading', {
+      level: 1,
+      name: '第 7 轮：选择武将',
+    });
+    await expect(roundHeading).toHaveCount(1);
 
     await page.goto('/team-builder');
     await expect(page.getByRole('heading', { level: 1, name: '队伍策案' })).toBeVisible();
@@ -179,6 +181,68 @@ test.describe('Accessibility and responsive layout', () => {
     ).toHaveCount(0);
   });
 
+  test('mobile round-one roster keeps its score attached and actions aligned', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await seedGame(
+      page,
+      makeGameState({
+        roundNumber: 1,
+        heroes: heroesWithMeta.slice(0, 4),
+        skills: anySkills(8),
+      }),
+    );
+
+    const roster = page.getByRole('region', { name: '当前阵容' });
+    const heading = roster.getByRole('heading', {
+      level: 2,
+      name: '当前阵容',
+    });
+    const score = roster.getByTestId('current-roster-score');
+    const season = roster.getByTestId('current-season-chip');
+    await expect(heading).toBeVisible();
+    await expect(score).toHaveText(/评分 -?\d+\.\d/);
+    await expect(season).toBeVisible();
+    await expect(
+      roster.getByText('CURRENT ROSTER', { exact: true }),
+    ).toHaveCount(0);
+
+    const [headingBox, scoreBox, seasonBox] = await Promise.all([
+      heading.boundingBox(),
+      score.boundingBox(),
+      season.boundingBox(),
+    ]);
+    expect(headingBox).not.toBeNull();
+    expect(scoreBox).not.toBeNull();
+    expect(seasonBox).not.toBeNull();
+    expect(Math.abs(headingBox.y - scoreBox.y)).toBeLessThanOrEqual(8);
+    expect(scoreBox.x - (headingBox.x + headingBox.width)).toBeLessThanOrEqual(10);
+    expect(seasonBox.y).toBeGreaterThanOrEqual(headingBox.y + headingBox.height);
+
+    const heroSupport = roster.getByRole('button', {
+      name: '推荐支援武将',
+    });
+    const skillSupport = roster.getByRole('button', {
+      name: '推荐支援战法',
+    });
+    const [heroButtonBox, skillButtonBox] = await Promise.all([
+      heroSupport.boundingBox(),
+      skillSupport.boundingBox(),
+    ]);
+    expect(heroButtonBox).not.toBeNull();
+    expect(skillButtonBox).not.toBeNull();
+    expect(Math.abs(heroButtonBox.width - skillButtonBox.width)).toBeLessThan(2);
+    expect(Math.abs(heroButtonBox.height - skillButtonBox.height)).toBeLessThan(2);
+
+    await expect(
+      page.getByRole('region', { name: '本轮三组选项' }),
+    ).toBeVisible();
+    await expect(
+      page.getByLabel('输入武将名或拼音搜索武将'),
+    ).toHaveCount(3);
+  });
+
   test('mobile round-7 interstitial puts its primary action before the roster', async ({
     page,
   }) => {
@@ -193,9 +257,9 @@ test.describe('Accessibility and responsive layout', () => {
     );
 
     const action = page.getByRole('button', { name: '我赢了，进入下一轮' });
-    const rosterMarker = page.getByText('CURRENT ROSTER', { exact: true });
+    const roster = page.getByRole('region', { name: '当前阵容' });
     await expect(action).toBeVisible();
-    await expect(rosterMarker).toBeVisible();
+    await expect(roster).toBeVisible();
     await expect(
       page.getByText(
         '提示：建议先确认核心武将，再围绕核心挑选其余武将与战法。请尽早确认支援选择，AI 才能据此给出更精准的推荐。',
@@ -204,7 +268,7 @@ test.describe('Accessibility and responsive layout', () => {
 
     const [actionBox, rosterBox] = await Promise.all([
       action.boundingBox(),
-      rosterMarker.boundingBox(),
+      roster.boundingBox(),
     ]);
     expect(actionBox).not.toBeNull();
     expect(rosterBox).not.toBeNull();

--- a/web/tests/gameRounds.spec.js
+++ b/web/tests/gameRounds.spec.js
@@ -93,13 +93,22 @@ test.describe('Game Rounds - Skill Selection', () => {
     await page.getByRole('button', { name: '开始对局' }).click();
 
     // ── Round 1 (hero round) - fill 3 sets of 3 heroes each ──
-    await expect(page.getByText('第 1 轮：选择武将')).toBeVisible({ timeout: 5000 });
+    await expect(
+      page.getByRole('heading', { level: 1, name: '第 1 轮：选择武将' }),
+    ).toHaveCount(1);
+    await expect(page.getByText('第 1 / 10 轮')).toHaveCount(0);
+    await expect(page.getByText('本轮候选', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('填写三组选项', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('未选择任何内容', { exact: true })).toHaveCount(0);
+    await expect(
+      page.getByLabel('输入武将名或拼音搜索武将'),
+    ).toHaveCount(3);
 
     for (let set = 0; set < 3; set++) {
       for (let i = 0; i < 3; i++) {
         const hero = round1Heroes[set * 3 + i];
         // After each selection, the filled input disappears, so always target the set's input
-        const input = page.getByLabel('添加武将...').nth(set);
+        const input = page.getByLabel('输入武将名或拼音搜索武将').nth(set);
         await input.click();
         await input.fill(hero);
         await page.getByRole('option', { name: hero }).click();
@@ -137,10 +146,12 @@ test.describe('Game Rounds - Skill Selection', () => {
     expect(loggedRounds[0].recommended_index).toBeLessThanOrEqual(2);
 
     // ── Round 2 (skill round) - verify only orange skills appear ──
-    await expect(page.getByText('第 2 轮：选择战法')).toBeVisible({ timeout: 5000 });
+    await expect(
+      page.getByRole('heading', { level: 1, name: '第 2 轮：选择战法' }),
+    ).toHaveCount(1);
 
     // Type a purple skill name - should show no options
-    const skillInput = page.getByLabel('添加战法...').first();
+    const skillInput = page.getByLabel('输入战法名或拼音搜索战法').first();
     await skillInput.click();
     await skillInput.fill(aPurpleSkill);
     // The AutocompleteInput renders this text when the typed query matches no
@@ -206,8 +217,8 @@ test.describe('Game Rounds - Skill Selection', () => {
 
     await expect(
       page.getByRole('heading', { level: 1, name: '第 9 轮：选择武将' })
-    ).toBeVisible();
-    await expect(page.getByText('第 9 / 10 轮')).toBeVisible();
+    ).toHaveCount(1);
+    await expect(page.getByText('第 9 / 10 轮')).toHaveCount(0);
     await expect(page.getByText('(2/2)')).toHaveCount(3);
 
     await expect.poll(async () =>
@@ -223,7 +234,7 @@ test.describe('Game Rounds - Skill Selection', () => {
     await expect(qualificationAction).toHaveCount(0);
     await expect(
       page.getByRole('heading', { level: 1, name: '第 9 轮：选择武将' })
-    ).toBeVisible();
+    ).toHaveCount(1);
 
     await page.getByRole('button', { name: '获取 AI 推荐' }).click();
     await expect(page.getByText('推荐：第')).toBeVisible({ timeout: 10000 });
@@ -232,13 +243,13 @@ test.describe('Game Rounds - Skill Selection', () => {
 
     await expect(
       page.getByRole('heading', { level: 1, name: '第 10 轮：选择战法' })
-    ).toBeVisible();
-    await expect(page.getByText('第 10 / 10 轮')).toBeVisible();
+    ).toHaveCount(1);
+    await expect(page.getByText('第 10 / 10 轮')).toHaveCount(0);
 
     for (let set = 0; set < 3; set++) {
       for (let i = 0; i < 3; i++) {
         const skill = roundTenOffers[set * 3 + i];
-        const input = page.getByLabel('添加战法...').nth(set);
+        const input = page.getByLabel('输入战法名或拼音搜索战法').nth(set);
         await input.click();
         await input.fill(skill);
         await page.getByRole('option', { name: skill }).click();

--- a/web/tests/optionAnalysisLabels.spec.js
+++ b/web/tests/optionAnalysisLabels.spec.js
@@ -46,10 +46,10 @@ test.describe('选项分析 — hero & skill labels', () => {
       { set1: candidates.slice(0, 3), set2: candidates.slice(3, 6), set3: candidates.slice(6, 9) },
     );
 
-    // The CURRENT ROSTER header shows the roster score even before any AI request.
+    // The 当前阵容 heading keeps the roster score beside it before any AI request.
     const rosterScore = page.getByTestId('current-roster-score');
     await expect(rosterScore).toBeVisible({ timeout: 15000 });
-    await expect(rosterScore).toHaveText(/评分：-?\d+\.\d/);
+    await expect(rosterScore).toHaveText(/评分 -?\d+\.\d/);
 
     await page.getByRole('button', { name: '获取 AI 推荐' }).click();
 

--- a/web/tests/seasonSelection.spec.js
+++ b/web/tests/seasonSelection.spec.js
@@ -119,10 +119,12 @@ test.describe('Season selection', () => {
     await page.getByRole('button', { name: '开始对局' }).click();
 
     await expect(page.getByText(`赛季 ${olderSeason}`, { exact: true })).toBeVisible();
-    await expect(page.getByText('第 1 轮：选择武将')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { level: 1, name: '第 1 轮：选择武将' }),
+    ).toHaveCount(1);
 
     // Newer-season heroes also remain valid offered-set entries.
-    const roundInput = page.getByLabel('添加武将...').first();
+    const roundInput = page.getByLabel('输入武将名或拼音搜索武将').first();
     await roundInput.fill(futureRoundHero);
     await expect(
       page.getByRole('option', { name: futureRoundHero })

--- a/web/tests/setup.spec.js
+++ b/web/tests/setup.spec.js
@@ -144,9 +144,11 @@ test.describe('Initial Setup', () => {
 
     // Starting the game restores the full game navigation.
     await startButton.click();
-    await expect(
-      page.getByRole('heading', { level: 1, name: '第 1 轮：选择武将' }),
-    ).toBeVisible();
+    const roundHeading = page.getByRole('heading', {
+      level: 1,
+      name: '第 1 轮：选择武将',
+    });
+    await expect(roundHeading).toHaveCount(1);
     const navigation = page.getByRole('navigation', { name: '主要导航' });
     await expect(navigation).toBeVisible();
     await expect(

--- a/web/tests/setup.spec.js
+++ b/web/tests/setup.spec.js
@@ -34,9 +34,11 @@ const oneHeroSkill = heroSkills.slice(0, 1);
 const skillsToSelect = [...purpleSkills, ...orangeRegularSkills, ...oneHeroSkill];
 
 test.describe('Initial Setup', () => {
-  test('users can select 4 orange heroes and 8 skills (4 purple + 4 orange, one possibly a hero skill)', async ({
+  test('users can select 4 heroes and 8 skills, then enter the first round', async ({
     page,
   }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+
     // 1. Navigate and wait for the setup form to load
     await page.goto('/');
     await expect(page.getByText('初始武将')).toBeVisible({ timeout: 30000 });
@@ -44,6 +46,25 @@ test.describe('Initial Setup', () => {
     // Verify we start at 0/4 heroes and 0/8 skills
     await expect(page.getByText('初始武将 (0/4)')).toBeVisible();
     await expect(page.getByText('初始战法 (0/8)')).toBeVisible();
+    await expect(
+      page.getByText('未选择任何内容', { exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText('输入初始 4 个武将和 8 个战法以开始对局。', {
+        exact: true,
+      }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText('4个橙色战法和4个紫色战法', { exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText('请选择恰好 4 个武将和 8 个战法以开始', {
+        exact: true,
+      }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText('录入当前阵容', { exact: true }),
+    ).toHaveCount(0);
 
     // Start button should be disabled
     const startButton = page.getByRole('button', { name: '开始对局' });
@@ -120,5 +141,22 @@ test.describe('Initial Setup', () => {
 
     // Start button should now be enabled with 4 heroes + 8 skills
     await expect(startButton).toBeEnabled();
+
+    // Starting the game restores the full game navigation.
+    await startButton.click();
+    await expect(
+      page.getByRole('heading', { level: 1, name: '第 1 轮：选择武将' }),
+    ).toBeVisible();
+    const navigation = page.getByRole('navigation', { name: '主要导航' });
+    await expect(navigation).toBeVisible();
+    await expect(
+      navigation.getByRole('button', { name: '对局推荐' }),
+    ).toBeVisible();
+    await expect(
+      navigation.getByRole('button', { name: '重置' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('navigation', { name: '初始设置导航' }),
+    ).toHaveCount(0);
   });
 });

--- a/web/tests/supportHeroSkills.spec.js
+++ b/web/tests/supportHeroSkills.spec.js
@@ -70,13 +70,15 @@ async function setupGameAndCompleteRound1(page) {
 
   // Start the game
   await page.getByRole('button', { name: '开始对局' }).click();
-  await expect(page.getByText('第 1 轮：选择武将')).toBeVisible({ timeout: 5000 });
+  await expect(
+    page.getByRole('heading', { level: 1, name: '第 1 轮：选择武将' }),
+  ).toHaveCount(1);
 
   // Fill round 1: 3 sets of 3 heroes
   for (let set = 0; set < 3; set++) {
     for (let i = 0; i < 3; i++) {
       const hero = round1Heroes[set * 3 + i];
-      const input = page.getByLabel('添加武将...').nth(set);
+      const input = page.getByLabel('输入武将名或拼音搜索武将').nth(set);
       await input.click();
       await input.fill(hero);
       await page.getByRole('option', { name: hero }).click();
@@ -92,7 +94,9 @@ async function setupGameAndCompleteRound1(page) {
   await confirmButton.click();
 
   // Now on round 2
-  await expect(page.getByText('第 2 轮：选择战法')).toBeVisible({ timeout: 5000 });
+  await expect(
+    page.getByRole('heading', { level: 1, name: '第 2 轮：选择战法' }),
+  ).toHaveCount(1);
 }
 
 test.describe('Support Hero & Skills', () => {

--- a/web/tests/uploadLeaderboard.spec.js
+++ b/web/tests/uploadLeaderboard.spec.js
@@ -64,7 +64,7 @@ test.describe('Static upload leaderboard', () => {
     ).toBeVisible();
     await expect(
       setupNavigation.getByRole('button', { name: '对局推荐' }),
-    ).toHaveCount(0);
+    ).toBeVisible();
     await expect(page.getByRole('button', { name: '重置' })).toHaveCount(0);
 
     await setupNavigation

--- a/web/tests/uploadLeaderboard.spec.js
+++ b/web/tests/uploadLeaderboard.spec.js
@@ -42,15 +42,32 @@ test.describe('Static upload leaderboard', () => {
     await page.goto('/');
 
     await expect(
-      page.getByRole('heading', { level: 1, name: '录入当前阵容' }),
+      page.getByRole('heading', {
+        level: 1,
+        name: '初始名册 · 演武开局',
+      }),
     ).toBeVisible();
     await expect(
       page.getByRole('heading', { level: 2, name: '贡献者排名' }),
     ).toHaveCount(0);
     expect(leaderboardRequests).toBe(0);
 
-    await page
-      .getByRole('navigation', { name: '主要导航' })
+    const setupNavigation = page.getByRole('navigation', {
+      name: '主要导航',
+    });
+    await expect(setupNavigation).toBeVisible();
+    await expect(
+      setupNavigation.getByRole('button', { name: '数据洞察' }),
+    ).toBeVisible();
+    await expect(
+      setupNavigation.getByRole('button', { name: '上传战报' }),
+    ).toBeVisible();
+    await expect(
+      setupNavigation.getByRole('button', { name: '对局推荐' }),
+    ).toHaveCount(0);
+    await expect(page.getByRole('button', { name: '重置' })).toHaveCount(0);
+
+    await setupNavigation
       .getByRole('button', { name: '战报贡献榜' })
       .click();
     await expect(page).toHaveURL(/\/contributors$/);
@@ -110,7 +127,10 @@ test.describe('Static upload leaderboard', () => {
     await page.getByRole('button', { name: '返回对局推荐' }).click();
     await expect(page).toHaveURL(/\/$/);
     await expect(
-      page.getByRole('heading', { level: 1, name: '录入当前阵容' }),
+      page.getByRole('heading', {
+        level: 1,
+        name: '初始名册 · 演武开局',
+      }),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Intent

Simplify the / initial setup and Round 1 experience for newcomers after recent feature growth. On setup, remove redundant setup headings and inventory copy while keeping 当前赛季 because every game session is associated with one season and it affects support-hero availability later. On Round 1 and the shared round UI, remove verbose round headings, English CURRENT ROSTER copy, candidate-section headings, entry instructions, and the premature completion warning; keep all current-roster information, place 当前阵容 directly beside its score, normalize support-action sizing, hide empty selection placeholders, and use 输入武将名或拼音搜索武将 as the hero search label and placeholder. Keep 对局推荐 as a stable navigation item on desktop and mobile instead of hiding it by page, while keeping 重置 conditional on an active game. In the 参谋建议 panel, retain the recommended group but remove 按本轮评分排序，评分越高越推荐。

## What Changed

- Trimmed the initial setup screen (`SetupForm`): removed redundant headings and inventory copy while retaining the 当前赛季 selector, and applied `输入武将名或拼音搜索武将` as the hero search label and placeholder across the option-set inputs.
- Streamlined the shared round UI (`RoundInfo`, `CurrentTeam`, `OptionSetInput`): dropped verbose round headings, English "CURRENT ROSTER" and candidate-section copy, entry instructions, and the premature completion warning; kept all roster info, placed 当前阵容 beside its score, normalized support-action sizing, and hid empty selection placeholders.
- Kept 对局推荐 as a stable desktop and mobile nav item while leaving 重置 conditional on an active game (`AppLayout`, `Header`, `JoinGroupButton`), and removed the "按本轮评分排序，评分越高越推荐" line from the 参谋建议 panel (`RecommendationPanel`).
- Updated Playwright and unit tests to cover the simplified setup, round, layout, and advisor surfaces.

## Risk Assessment

✅ Low: A well-bounded, purely presentational UI simplification that satisfies every required intent criterion, introduces no functional/security/perf risks, leaves no orphaned symbols, and is comprehensively covered by updated unit and e2e tests.

## Testing

Ran the workspace-scoped web checks (typecheck + 356 Vitest unit tests) plus the six e2e specs touching this change (26 Playwright tests) — all green — and additionally drove the real app to capture reviewer-visible screenshots proving each intent constraint end-to-end (mobile/desktop setup, mobile 更多 nav menu, mobile/desktop Round 1). Transient test files/output were removed and the working tree is clean; installed web deps remain (gitignored). No product issues found.

- Evidence: Mobile initial setup — trimmed headings/copy, 当前赛季 kept, 更多 nav button (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYGBE33KJWCFHG9VGMJ88NZQ/01-mobile-setup.png</code>)
- Evidence: Mobile setup 更多 menu — 对局推荐 stays reachable (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYGBE33KJWCFHG9VGMJ88NZQ/02-mobile-setup-more-menu.png</code>)
- Evidence: Desktop setup nav — 对局推荐 present, 重置 hidden without a game (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYGBE33KJWCFHG9VGMJ88NZQ/03-desktop-setup-nav.png</code>)
- Evidence: Mobile Round 1 — 当前阵容 beside 评分, equal-size support actions, new search label, no verbose headings/warning, 重置 shown (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYGBE33KJWCFHG9VGMJ88NZQ/04-mobile-round1.png</code>)
- Evidence: Desktop Round 1 — recommendation panel keeps group, drops sort hint (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYGBE33KJWCFHG9VGMJ88NZQ/05-desktop-round1.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; pnpm typecheck` (tsc --noEmit) — pass</code>
- <code>`cd web &amp;&amp; pnpm test` (Vitest) — 356 tests pass</code>
- <code>`pnpm test:e2e setup.spec.js gameRounds.spec.js accessibilityLayout.spec.js seasonSelection.spec.js supportHeroSkills.spec.js optionAnalysisLabels.spec.js` — 26 e2e tests pass</code>
- `Authored a temporary Playwright spec (tests/simplifiedSetupEvidence.spec.js) to capture 5 screenshots of the setup/Round-1 surfaces on mobile (390×844) and desktop (1280×900), then removed it and the test-results dir`
- `Verified 当前赛季 kept, 对局推荐 present in desktop nav and mobile 更多 menu, 重置 absent on setup and present in Round 1, hero search label/placeholder 输入武将名或拼音搜索武将 applied to all three option-set inputs`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
