### PR TITLE
feat(web): database-first team formation in a client Web Worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,25 +76,40 @@ in the browser:
   roster-strength improvement over the current pool + evidence. The two-support-
   skill pick is chosen as a **joint pair** (each skill's presence + the best
   feasible hero routing + the within-hero skill-pair bonus when both land on one
-  hero), not two independent top-1 picks. The final formation enumerates a
-  deterministic bounded beam of disjoint 3×3 hero partitions (each level unions a
-  strength-ranked and a same-camp-ranked slice so camp-cohesive partitions
-  survive the prune), caps full evaluation at 1,920 partitions, then for **each** candidate performs the global unique
-  18-skill assignment (2/hero, never a hero's signature skill) and scores every
-  team with the full model. The winner is chosen in two global stages: (1) find
-  the single maximum **top-two-team** summed strength and retain every formation
-  within a fixed display-point band of it — so the two strongest main teams are
-  prioritised over the third; (2) rank the retained set by the number of
-  same-camp teams, then the stronger third team, total strength, and a
-  deterministic key. The same-camp preference never overrides
-  skill/signature feasibility and never widens the band. The workbook ranking
-  and matchup guide are presentation-only and do not enter recommendation
+  hero), not two independent top-1 picks. The Team Builder first finds locally
+  usable three-hero builds and owned skill alternatives from
+  `web/public/game-data/database.json`. It favours a globally compatible set of
+  three known builds, preserves their formations, and locks every skill slot
+  that can be matched without duplication. Missing teams and skill slots then
+  fall back to the historical-battle model, so an eligible 9-hero/18-skill pool
+  still receives a complete recommendation even when no exact guide combination
+  exists. The hybrid final formation enumerates a deterministic bounded beam of
+  disjoint 3×3 hero partitions (each level unions guide-biased, strength-ranked,
+  and same-camp-ranked slices so useful partitions survive the prune), retains
+  the existing cap of 1,920 full partition evaluations, then for **each**
+  candidate performs the global unique 18-skill assignment (2/hero, never a
+  hero's signature skill) and scores every team with the full model. Hybrid
+  candidates are first narrowed to the best available guide coverage: exact
+  teams, matched teams, matched skill slots, championship source, guide rank,
+  then stable build ID. Within that guide-equivalent set, the winner follows
+  the model's two global stages: (1) find the single maximum
+  **top-two-team** summed strength and retain every formation within a fixed
+  display-point band of it — so the two strongest main teams are prioritised
+  over the third; (2) rank the retained set by the number of same-camp teams,
+  then the stronger third team, total strength, and a deterministic key. The
+  same-camp preference never overrides
+  skill/signature feasibility and never widens the band. Guide rankings and
+  championship sources order otherwise-compatible known builds, but neither
+  they nor the matchup guide alter the historical model's recommendation
   scores. From that same
   already-scored retained set, the engine returns up to three deterministic,
   distinct formation options: the winner first, then alternatives chosen to
   minimise team overlap without sacrificing the strength band. The Team Builder
-  uses the winner as its one editable default formation; players can then
-  drag, tap, or use the keyboard to rearrange its three teams. The UI shows each
+  uses the winner as its one editable default formation. The bounded search runs
+  in a client Web Worker, with a cooperatively batched main-thread fallback and
+  an in-memory result cache, so it adds no Cloudflare Function usage and keeps
+  the loading UI responsive. Players can then drag, tap, or use the keyboard to
+  rearrange its three teams. The UI shows each
   team's live **评分** and compact positive evidence (武将配合 / 武将与战法 /
   战法搭配, each with 加分 and reference battle counts); there is no aggregate
   总评分.

--- a/web/README.md
+++ b/web/README.md
@@ -24,10 +24,15 @@ the model data is generated and community reports are imported.
   team library, five championship groups, 13×13 matchup explorer, and workbook
   analysis. This full guide is the sole UI location for the 三谋吕布 attribution.
 - **Manual Editing**: Edit team composition manually at any time
-- **Team Builder**: Start from one best three-team recommendation, then
-  rearrange heroes and tactics with pointer, touch, keyboard, or tap-to-place
-  controls; copy an exact-lineup validation prompt backed by the public game
-  database and formula reference
+- **Team Builder**: Start from one best database-first three-team
+  recommendation. Locally usable known builds provide their formation and
+  owned skill alternatives; the historical-battle model fills every unmatched
+  team or skill slot while preserving unique heroes and skills. The bounded
+  optimizer runs in a client Web Worker (with a cooperative fallback and memory
+  cache), keeping the loading screen responsive without consuming Cloudflare
+  Function quota. Players can then rearrange heroes and tactics with pointer,
+  touch, keyboard, or tap-to-place controls, and copy an exact-lineup validation
+  prompt backed by the public game database and formula reference
 - **Analytics Dashboard**: Player-friendly, question-led analytics — hero/skill rankings by 胜率参考 (smoothed win rate, with 参考场次 as supporting context), 组合分 synergy tables, usage, and optional (collapsed) model diagnostics
 - **Auto-save**: Game progress automatically saved in a versioned,
   non-expiring `localStorage` record; the Team Builder uses its own
@@ -184,9 +189,9 @@ selected skills.
   highlights the highest as 玩家选择最高 (independently from the AI 推荐 card), and — only when the
   two tops differ by a meaningful margin — shows a short non-causal A/B/C disagreement note
 - **FormationWorkbench**: The `/team-builder` page's light, game-layout-inspired
-  three-team editor. It seeds the engine winner, keeps live per-team scores,
-  uses canonical formations from `database.json`, and supports drag/drop plus
-  tap-to-place on mobile.
+  three-team editor. It seeds the hybrid database-first/model-fallback winner,
+  keeps live per-team model scores, uses matched formations from
+  `database.json`, and supports drag/drop plus tap-to-place on mobile.
 - **KnownStrongTeams**: Filters the imported strong/championship library against
   the acquired pool and the current offers. Hero rounds keep cards concise;
   skill rounds reveal the source formation and both per-hero skill slots.

--- a/web/src/pages/TeamBuilder.tsx
+++ b/web/src/pages/TeamBuilder.tsx
@@ -28,10 +28,20 @@ import FormationWorkbench from '../components/teamBuilder/FormationWorkbench';
 import { useGame } from '../context/GameContext';
 import { database, recommendationData } from '../data';
 import {
-  recommendTeams,
+  recommendHybridTeamsCooperatively,
   type FormationRecommendation,
   type HeroMeta,
 } from '../services/recommendationEngine';
+import {
+  getCachedTeamFormation,
+  setCachedTeamFormation,
+  teamFormationCacheKey,
+} from '../services/teamFormationCache';
+import type {
+  TeamFormationStage,
+  TeamFormationWorkerRequest,
+  TeamFormationWorkerResponse,
+} from '../services/teamFormationWorkerProtocol';
 import { generateTeamValidationPrompt } from '../services/promptGenerator';
 import {
   applyTeamBuilderMove,
@@ -87,6 +97,8 @@ const TeamBuilder = () => {
   const [formation, setFormation] =
     useState<FormationRecommendation | null>(null);
   const [resultKey, setResultKey] = useState<string | null>(null);
+  const [formationStage, setFormationStage] =
+    useState<TeamFormationStage>('matching');
   const [layout, setLayout] = useState<TeamBuilderLayout>(
     createEmptyTeamBuilderLayout
   );
@@ -129,6 +141,15 @@ const TeamBuilder = () => {
     () => teamBuilderPoolKey(heroes, skills),
     [heroes, skills]
   );
+  const formationCacheKey = useMemo(
+    () =>
+      teamFormationCacheKey(
+        poolKey,
+        recommendationData,
+        database.team || []
+      ),
+    [poolKey]
+  );
   const isEligible = heroes.length >= 9 && skills.length >= 18;
   const isPending = isEligible && resultKey !== poolKey;
   const hasHero = teamBuilderLayoutHasHero(layout);
@@ -142,6 +163,26 @@ const TeamBuilder = () => {
       return null;
     }
     return layoutFromFormation(formation.options[0]);
+  }, [formation, poolKey, resultKey]);
+  const guideMatchSummary = useMemo(() => {
+    if (
+      resultKey !== poolKey ||
+      !formation ||
+      formation.incomplete ||
+      formation.options.length === 0
+    ) {
+      return null;
+    }
+    const matches = formation.options[0].teams
+      .map(({ knownTeam }) => knownTeam)
+      .filter((knownTeam) => knownTeam !== undefined);
+    return {
+      teams: matches.length,
+      skillSlots: matches.reduce(
+        (sum, match) => sum + match.matchedSkillSlots,
+        0
+      ),
+    };
   }, [formation, poolKey, resultKey]);
 
   useEffect(() => {
@@ -177,43 +218,117 @@ const TeamBuilder = () => {
       setResultKey(null);
       return;
     }
+    if (hydratedKey !== poolKey) return;
 
     let cancelled = false;
-    let handle: number | null = null;
-    const frame = window.requestAnimationFrame(() => {
-      handle = window.setTimeout(() => {
-        let result: FormationRecommendation | null = null;
-        try {
-          result = recommendTeams(
-            heroes,
-            skills,
-            recommendationData,
-            recommendationData.catalog,
-            HERO_META
-          );
-        } catch (error) {
-          console.error('Failed to recommend teams:', error);
-        }
+    let worker: Worker | null = null;
+    let fallbackStarted = false;
 
+    const applyResult = (result: FormationRecommendation) => {
+      if (cancelled) return;
+      setCachedTeamFormation(formationCacheKey, result);
+      setFormation(result);
+      setResultKey(poolKey);
+
+      const bestOption =
+        !result.incomplete ? result.options[0] : undefined;
+      if (bestOption && seededPoolKeyRef.current !== poolKey) {
+        setLayout(layoutFromFormation(bestOption));
+        seededPoolKeyRef.current = poolKey;
+      }
+    };
+
+    const runCooperativeFallback = async () => {
+      if (fallbackStarted || cancelled) return;
+      fallbackStarted = true;
+      worker?.terminate();
+      worker = null;
+      setFormationStage('optimizing');
+      try {
+        const result = await recommendHybridTeamsCooperatively(
+          heroes,
+          skills,
+          recommendationData,
+          recommendationData.catalog,
+          HERO_META,
+          database.team || [],
+          {
+            batchSize: 12,
+            shouldCancel: () => cancelled,
+            yieldControl: () =>
+              new Promise<void>((resolve) =>
+                window.setTimeout(resolve, 0)
+              ),
+          }
+        );
+        applyResult(result);
+      } catch (error) {
         if (cancelled) return;
-        setFormation(result);
+        console.error('Failed to recommend teams:', error);
+        setFormation(null);
         setResultKey(poolKey);
+      }
+    };
 
-        const bestOption =
-          result && !result.incomplete ? result.options[0] : undefined;
-        if (bestOption && seededPoolKeyRef.current !== poolKey) {
-          setLayout(layoutFromFormation(bestOption));
-          seededPoolKeyRef.current = poolKey;
+    const cached = getCachedTeamFormation(formationCacheKey);
+    if (cached) {
+      applyResult(cached);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setFormationStage('matching');
+    try {
+      worker = new Worker(
+        new URL('../workers/teamFormation.worker.ts', import.meta.url),
+        { type: 'module' }
+      );
+      worker.onmessage = ({
+        data,
+      }: MessageEvent<TeamFormationWorkerResponse>) => {
+        if (cancelled || data.requestId !== formationCacheKey) return;
+        if (data.type === 'progress') {
+          setFormationStage(data.stage);
+          return;
         }
-      }, 0);
-    });
+        if (data.type === 'result') {
+          applyResult(data.recommendation);
+          worker?.terminate();
+          worker = null;
+          return;
+        }
+        console.error('Formation worker failed:', data.message);
+        void runCooperativeFallback();
+      };
+      worker.onerror = (event) => {
+        event.preventDefault();
+        console.error('Formation worker failed to load:', event.message);
+        void runCooperativeFallback();
+      };
+      const request: TeamFormationWorkerRequest = {
+        requestId: formationCacheKey,
+        heroes,
+        skills,
+      };
+      worker.postMessage(request);
+    } catch (error) {
+      console.error('Formation worker is unavailable:', error);
+      void runCooperativeFallback();
+    }
 
     return () => {
       cancelled = true;
-      window.cancelAnimationFrame(frame);
-      if (handle !== null) window.clearTimeout(handle);
+      worker?.terminate();
     };
-  }, [heroes, isEligible, poolKey, skills]);
+  }, [
+    formationCacheKey,
+    heroes,
+    hydratedKey,
+    isEligible,
+    poolKey,
+    skills,
+  ]);
 
   const handleUpdateTeam = (
     updatedHeroes: string[],
@@ -268,7 +383,7 @@ const TeamBuilder = () => {
     if (!recommendedLayout) return;
     setLayout(recommendedLayout);
     seededPoolKeyRef.current = poolKey;
-    setSnackbar({ open: true, message: '已恢复当前卡池的系统推荐' });
+    setSnackbar({ open: true, message: '已恢复当前卡池的阵容库推荐' });
   };
 
   const promptInput = useMemo(
@@ -346,7 +461,7 @@ const TeamBuilder = () => {
         >
           <Box>
             <Typography variant="body1" fontWeight={700}>
-              系统默认给出当前卡池的一套最佳三队编排，之后可自由拖动调整。
+              优先匹配阵容库中的武将、阵型与战法，未覆盖部分由历史对局模型补全。
             </Typography>
             <Typography variant="body2" color="text.secondary">
               评分会随武将与战法配置即时更新。
@@ -360,7 +475,7 @@ const TeamBuilder = () => {
                 startIcon={<RestartAltOutlinedIcon />}
                 onClick={handleRestoreRecommendation}
               >
-                恢复系统推荐
+                恢复阵容库推荐
               </Button>
             )}
           </Stack>
@@ -436,7 +551,11 @@ const TeamBuilder = () => {
           >
             <Stack alignItems="center" spacing={1.5}>
               <CircularProgress size={30} />
-              <Typography>正在优化并生成最佳编排...</Typography>
+              <Typography>
+                {formationStage === 'matching'
+                  ? '正在匹配阵容库...'
+                  : '正在补全剩余阵容...'}
+              </Typography>
             </Stack>
           </Paper>
         ) : (
@@ -458,6 +577,20 @@ const TeamBuilder = () => {
                 formation.options.length === 0) && (
                 <Alert severity="warning" sx={{ mb: 1.5 }}>
                   当前卡池未能生成完整推荐，你仍可在下方手动编排。
+                </Alert>
+              )}
+            {isEligible &&
+              formation &&
+              !formation.incomplete &&
+              formation.options.length > 0 &&
+              guideMatchSummary && (
+                <Alert
+                  severity={guideMatchSummary.teams > 0 ? 'success' : 'info'}
+                  sx={{ mb: 1.5 }}
+                >
+                  {guideMatchSummary.teams > 0
+                    ? `已匹配阵容库 ${guideMatchSummary.teams} 支队伍、${guideMatchSummary.skillSlots} 个战法位；其余位置由历史对局模型补全。`
+                    : '当前卡池没有可用的阵容库组合，已由历史对局模型完整补全。'}
                 </Alert>
               )}
             <FormationWorkbench

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -5,6 +5,8 @@ import {
   recommendSingleHero,
   recommendTwoSkills,
   recommendTeams,
+  recommendHybridTeams,
+  recommendHybridTeamsCooperatively,
   enumerateFormationPartitions,
   PARTITION_EVAL_CAP,
   getAnalytics,
@@ -12,6 +14,7 @@ import {
 } from '../recommendationEngine';
 import { recommendationData, database } from '../../data';
 import type { RecommendationData } from '../../types/recommendation';
+import type { TeamComp } from '../../types/domain';
 import {
   TEN_ROUND_HERO_POOL,
   TEN_ROUND_SKILL_POOL,
@@ -37,6 +40,31 @@ function makeData(overrides: Partial<RecommendationData['model']> = {}): Recomme
     backtest: { n_test: 10, accuracy: 0.7, log_loss: 0.5, brier: 0.2, holdout_frac: 0.2, baseline_accuracy: 0.5 },
   };
 }
+
+const makeTeamComp = (
+  id: string,
+  heroes: [string, string, string],
+  skillSlots: [
+    [string[], string[]],
+    [string[], string[]],
+    [string[], string[]],
+  ],
+  options: {
+    formation?: string;
+    ranking?: TeamComp['ranking'];
+    sources?: TeamComp['sources'];
+  } = {}
+): TeamComp => ({
+  id,
+  ranking: options.ranking ?? 'S',
+  sources: options.sources ?? ['strong'],
+  section: 'test',
+  formation: options.formation ?? '测试阵',
+  members: heroes.map((hero, index) => ({
+    hero,
+    skillSlots: skillSlots[index],
+  })) as TeamComp['members'],
+});
 
 describe('recommendHeroSet — marginal roster-strength ranking', () => {
   const data = makeData({
@@ -858,6 +886,242 @@ describe('recommendTeams — global formation optimization', () => {
 
     expect(h0Team.heroes.find((hero) => hero.name === 'h0')!.skills).toContain('s0');
     expect(h0Team.evidence.heroSkill).toEqual([]);
+  });
+});
+
+describe('recommendHybridTeams — database-first with model fallback', () => {
+  const heroes = Array.from({ length: 9 }, (_, index) => `h${index}`);
+  const skills = Array.from({ length: 18 }, (_, index) => `s${index}`);
+  const slotsFor = (offset: number): [
+    [string[], string[]],
+    [string[], string[]],
+    [string[], string[]],
+  ] => [
+    [[`s${offset}`], [`s${offset + 1}`]],
+    [[`s${offset + 2}`], [`s${offset + 3}`]],
+    [[`s${offset + 4}`], [`s${offset + 5}`]],
+  ];
+
+  test('prefers three exact guide builds and carries their formations', () => {
+    const data = makeData();
+    const comps = [
+      makeTeamComp('known-1', ['h0', 'h1', 'h2'], slotsFor(0), {
+        formation: '阵一',
+        sources: ['strong', 'championship'],
+      }),
+      makeTeamComp('known-2', ['h3', 'h4', 'h5'], slotsFor(6), {
+        formation: '阵二',
+      }),
+      makeTeamComp('known-3', ['h6', 'h7', 'h8'], slotsFor(12), {
+        formation: '阵三',
+      }),
+    ];
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      comps
+    );
+
+    expect(result.incomplete).toBe(false);
+    const teams = result.options[0].teams;
+    expect(teams).toHaveLength(3);
+    expect(new Set(teams.map(({ formation }) => formation))).toEqual(
+      new Set(['阵一', '阵二', '阵三'])
+    );
+    expect(
+      teams.map(({ knownTeam }) => knownTeam?.id).sort()
+    ).toEqual(['known-1', 'known-2', 'known-3']);
+    expect(
+      teams.every(
+        ({ knownTeam }) => knownTeam?.matchedSkillSlots === 6
+      )
+    ).toBe(true);
+    const assignedSkills = teams.flatMap(({ heroes: assignedHeroes }) =>
+      assignedHeroes.flatMap(({ skills: assigned }) => assigned)
+    );
+    expect(assignedSkills).toHaveLength(18);
+    expect(new Set(assignedSkills).size).toBe(18);
+  });
+
+  test('keeps a partial guide trio and model-fills every unmatched slot', () => {
+    const data = makeData();
+    const partial = makeTeamComp(
+      'partial',
+      ['h0', 'h1', 'h2'],
+      [
+        [['s0'], ['s1']],
+        [['missing-1'], ['missing-2']],
+        [['missing-3'], ['missing-4']],
+      ],
+      { formation: '局部阵' }
+    );
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      [partial]
+    );
+    const teams = result.options[0].teams;
+    const matched = teams.find(
+      ({ knownTeam }) => knownTeam?.id === 'partial'
+    );
+
+    expect(matched?.formation).toBe('局部阵');
+    expect(matched?.knownTeam?.matchedSkillSlots).toBe(2);
+    expect(
+      new Set(matched?.heroes.map(({ name }) => name))
+    ).toEqual(new Set(['h0', 'h1', 'h2']));
+    expect(teams.flatMap(({ heroes }) => heroes)).toHaveLength(9);
+    const assignedSkills = teams.flatMap(({ heroes: assignedHeroes }) =>
+      assignedHeroes.flatMap(({ skills: assigned }) => assigned)
+    );
+    expect(assignedSkills).toHaveLength(18);
+    expect(new Set(assignedSkills).size).toBe(18);
+  });
+
+  test('resolves guide alternatives globally when teams compete for a skill', () => {
+    const data = makeData();
+    const comps = [
+      makeTeamComp('first', ['h0', 'h1', 'h2'], slotsFor(0)),
+      makeTeamComp('second', ['h3', 'h4', 'h5'], [
+        [['s0', 's6'], ['s7']],
+        [['s8'], ['s9']],
+        [['s10'], ['s11']],
+      ]),
+      makeTeamComp('third', ['h6', 'h7', 'h8'], slotsFor(12)),
+    ];
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      comps
+    );
+    const teams = result.options[0].teams;
+
+    expect(
+      teams.every(
+        ({ knownTeam }) => knownTeam?.matchedSkillSlots === 6
+      )
+    ).toBe(true);
+    const assignedSkills = teams.flatMap(({ heroes: assignedHeroes }) =>
+      assignedHeroes.flatMap(({ skills: assigned }) => assigned)
+    );
+    expect(new Set(assignedSkills).size).toBe(18);
+    expect(assignedSkills).toContain('s0');
+    expect(assignedSkills).toContain('s6');
+  });
+
+  test('chooses the globally compatible variant of the same hero trio', () => {
+    const data = makeData();
+    const comps = [
+      makeTeamComp(
+        'a-locally-tied-but-conflicting',
+        ['h0', 'h1', 'h2'],
+        [
+          [['s0'], ['s1']],
+          [['s2'], ['s3']],
+          [['s4'], ['s6']],
+        ]
+      ),
+      makeTeamComp(
+        'z-globally-compatible',
+        ['h0', 'h1', 'h2'],
+        slotsFor(0)
+      ),
+      makeTeamComp('second', ['h3', 'h4', 'h5'], slotsFor(6)),
+      makeTeamComp('third', ['h6', 'h7', 'h8'], slotsFor(12)),
+    ];
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      comps
+    );
+    const matches = result.options[0].teams.map(
+      ({ knownTeam }) => knownTeam
+    );
+
+    expect(matches.map((match) => match?.id).sort()).toEqual([
+      'second',
+      'third',
+      'z-globally-compatible',
+    ]);
+    expect(
+      matches.every((match) => match?.matchedSkillSlots === 6)
+    ).toBe(true);
+  });
+
+  test('returns the unchanged model result when no guide skill can match', () => {
+    const data = makeData();
+    const unavailable = makeTeamComp(
+      'unavailable',
+      ['h0', 'h1', 'h2'],
+      [
+        [['missing-0'], ['missing-1']],
+        [['missing-2'], ['missing-3']],
+        [['missing-4'], ['missing-5']],
+      ]
+    );
+
+    expect(
+      recommendHybridTeams(
+        heroes,
+        skills,
+        data,
+        data.catalog,
+        {},
+        [unavailable]
+      )
+    ).toEqual(recommendTeams(heroes, skills, data, data.catalog));
+  });
+
+  test('cooperative fallback returns the same deterministic result', async () => {
+    const data = makeData();
+    const comps = [
+      makeTeamComp('known-1', ['h0', 'h1', 'h2'], slotsFor(0)),
+      makeTeamComp('known-2', ['h3', 'h4', 'h5'], slotsFor(6)),
+      makeTeamComp('known-3', ['h6', 'h7', 'h8'], slotsFor(12)),
+    ];
+    const expected = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      comps
+    );
+    const yields: number[] = [];
+
+    const actual = await recommendHybridTeamsCooperatively(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      comps,
+      {
+        batchSize: 1,
+        yieldControl: async () => {
+          yields.push(1);
+        },
+      }
+    );
+
+    expect(actual).toEqual(expected);
+    expect(yields.length).toBeGreaterThan(0);
   });
 });
 

--- a/web/src/services/__tests__/teamBuilderArrangement.test.ts
+++ b/web/src/services/__tests__/teamBuilderArrangement.test.ts
@@ -226,7 +226,7 @@ describe('team builder layout creation and persistence migration', () => {
 });
 
 describe('layoutFromFormation', () => {
-  test('seeds three teams with blank formations, front rows, and two skills per hero', () => {
+  test('seeds three teams with guide formations, front rows, and two skills per hero', () => {
     const option: FormationOption = {
       teams: Array.from({ length: 3 }, (_, teamIndex) => ({
         heroes: Array.from({ length: 3 }, (_, heroIndex) => {
@@ -238,6 +238,7 @@ describe('layoutFromFormation', () => {
           };
         }),
         strength: 100 - teamIndex,
+        formation: `阵${teamIndex + 1}`,
         evidence: {
           heroSynergy: [],
           heroSkill: [],
@@ -248,7 +249,11 @@ describe('layoutFromFormation', () => {
 
     const layout = layoutFromFormation(option);
 
-    expect(layout.map((team) => team.formation)).toEqual(['', '', '']);
+    expect(layout.map((team) => team.formation)).toEqual([
+      '阵1',
+      '阵2',
+      '阵3',
+    ]);
     expect(layout[0].heroes[0]).toEqual({
       hero: 'H0',
       row: '前排',

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -16,7 +16,12 @@ import type {
   PairedModel,
   RecommendationCatalog,
 } from '../types/recommendation';
-import type { GameplayDatabase } from '../types/domain';
+import type {
+  GameplayDatabase,
+  TeamComp,
+  TeamRanking,
+  TeamSource,
+} from '../types/domain';
 import {
   type AssignedHero,
   type ActiveContribution,
@@ -600,6 +605,18 @@ export interface ProjectedTeam {
   strength: number;
   /** Compact positive paired-model evidence for this team. */
   evidence: TeamEvidence;
+  /** Canonical guide formation when this team matched `database.team`. */
+  formation?: string;
+  /** Guide provenance and partial/exact skill-slot coverage. */
+  knownTeam?: KnownTeamMatch;
+}
+
+export interface KnownTeamMatch {
+  id: string;
+  ranking: TeamRanking;
+  sources: TeamSource[];
+  matchedSkillSlots: number;
+  totalSkillSlots: 6;
 }
 
 /**
@@ -684,6 +701,251 @@ function combinations3(items: string[]): string[][] {
   return out;
 }
 
+const KNOWN_TEAM_SKILL_SLOTS = 6 as const;
+const KNOWN_TEAM_PARTITION_CAP = 640;
+
+const trioKey = (trio: Iterable<string>): string =>
+  [...trio].sort().join('|');
+
+const teamRankingScore = (ranking: TeamRanking): number =>
+  ranking === 'S' ? 3 : ranking === 'A' ? 2 : 1;
+
+interface KnownTeamPreference {
+  comp: TeamComp;
+  key: string;
+  localMatchedSkillSlots: number;
+}
+
+interface KnownSkillSlot {
+  key: string;
+  teamKey: string;
+  hero: string;
+  slotIndex: number;
+  alternatives: string[];
+}
+
+interface KnownTeamAssignment {
+  preference: KnownTeamPreference;
+  matchedSkillSlots: number;
+}
+
+type KnownTeamIndex = Map<string, KnownTeamPreference[]>;
+
+const isChampionshipComp = (comp: TeamComp): boolean =>
+  comp.sources.includes('championship');
+
+const knownSlots = (
+  preference: KnownTeamPreference,
+  skillPool: Set<string>,
+  catalog: RecommendationCatalog
+): KnownSkillSlot[] =>
+  preference.comp.members.flatMap((member) =>
+    member.skillSlots.map((alternatives, slotIndex) => ({
+      key: `${preference.comp.id}|${member.hero}|${slotIndex}`,
+      teamKey: preference.key,
+      hero: member.hero,
+      slotIndex,
+      alternatives: alternatives.filter(
+        (skill) =>
+          skillPool.has(skill) &&
+          skill !== catalog.default_skill[member.hero]
+      ),
+    }))
+  );
+
+/**
+ * Deterministic maximum-cardinality matching from guide skill slots to owned
+ * skills. This resolves alternatives across all selected guide teams together,
+ * so a skill is never promised to two heroes.
+ */
+function maximumKnownSlotMatching(
+  slots: KnownSkillSlot[]
+): Map<string, string> {
+  const slotByKey = new Map(slots.map((slot) => [slot.key, slot]));
+  const skillOwner = new Map<string, string>();
+  const slotSkill = new Map<string, string>();
+
+  const assign = (
+    slotKey: string,
+    seenSlots: Set<string>,
+    seenSkills: Set<string>
+  ): boolean => {
+    if (seenSlots.has(slotKey)) return false;
+    seenSlots.add(slotKey);
+    const slot = slotByKey.get(slotKey);
+    if (!slot) return false;
+    const previousSkill = slotSkill.get(slotKey);
+
+    for (const skill of slot.alternatives) {
+      if (seenSkills.has(skill)) continue;
+      seenSkills.add(skill);
+      const owner = skillOwner.get(skill);
+      if (
+        owner === undefined ||
+        assign(owner, seenSlots, seenSkills)
+      ) {
+        if (previousSkill !== undefined) skillOwner.delete(previousSkill);
+        skillOwner.set(skill, slotKey);
+        slotSkill.set(slotKey, skill);
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // Process lower-priority slots first. Later (higher-priority) slots may
+  // displace them through the augmenting path while preserving max cardinality.
+  for (const slot of [...slots].reverse()) {
+    assign(slot.key, new Set(), new Set());
+  }
+  return slotSkill;
+}
+
+function compareKnownPreferences(
+  left: KnownTeamPreference,
+  right: KnownTeamPreference
+): number {
+  if (left.localMatchedSkillSlots !== right.localMatchedSkillSlots) {
+    return right.localMatchedSkillSlots - left.localMatchedSkillSlots;
+  }
+  const championshipDelta =
+    Number(isChampionshipComp(right.comp)) -
+    Number(isChampionshipComp(left.comp));
+  if (championshipDelta !== 0) return championshipDelta;
+  const rankingDelta =
+    teamRankingScore(right.comp.ranking) -
+    teamRankingScore(left.comp.ranking);
+  if (rankingDelta !== 0) return rankingDelta;
+  return left.comp.id < right.comp.id
+    ? -1
+    : left.comp.id > right.comp.id
+      ? 1
+      : 0;
+}
+
+function buildKnownTeamIndex(
+  teamComps: TeamComp[],
+  heroPool: Set<string>,
+  skillPool: Set<string>,
+  catalog: RecommendationCatalog
+): KnownTeamIndex {
+  const grouped = new Map<string, KnownTeamPreference[]>();
+  for (const comp of teamComps) {
+    if (!comp.members.every(({ hero }) => heroPool.has(hero))) continue;
+    const key = trioKey(comp.members.map(({ hero }) => hero));
+    const provisional: KnownTeamPreference = {
+      comp,
+      key,
+      localMatchedSkillSlots: 0,
+    };
+    const localMatchedSkillSlots = maximumKnownSlotMatching(
+      knownSlots(provisional, skillPool, catalog)
+    ).size;
+    // A hero trio with no usable guide skill is a pure model fallback, not a
+    // database-backed match.
+    if (localMatchedSkillSlots === 0) continue;
+    const preference = { ...provisional, localMatchedSkillSlots };
+    const variants = grouped.get(key) ?? [];
+    variants.push(preference);
+    grouped.set(key, variants);
+  }
+
+  const index: KnownTeamIndex = new Map();
+  for (const [key, variants] of grouped) {
+    variants.sort(compareKnownPreferences);
+    index.set(key, variants);
+  }
+  return index;
+}
+
+function selectKnownPreferences(
+  trios: string[][],
+  knownTeamIndex: KnownTeamIndex,
+  skillPool: string[],
+  catalog: RecommendationCatalog,
+  cache: Map<string, KnownTeamPreference[]>
+): KnownTeamPreference[] {
+  const keys = trios
+    .map(trioKey)
+    .filter((key) => knownTeamIndex.has(key))
+    .sort();
+  const cacheKey = keys.join('||');
+  const cached = cache.get(cacheKey);
+  if (cached) return cached;
+  if (keys.length === 0) {
+    cache.set(cacheKey, []);
+    return [];
+  }
+
+  const skillSet = new Set(skillPool);
+  const groups = keys.map((key) => knownTeamIndex.get(key)!);
+  let best: KnownTeamPreference[] = [];
+  let bestScore: GuideCandidateScore | null = null;
+
+  const visit = (groupIndex: number, selected: KnownTeamPreference[]) => {
+    if (groupIndex < groups.length) {
+      for (const preference of groups[groupIndex]) {
+        visit(groupIndex + 1, [...selected, preference]);
+      }
+      return;
+    }
+
+    const ordered = [...selected].sort(compareKnownPreferences);
+    const slots = ordered.flatMap((preference) =>
+      knownSlots(preference, skillSet, catalog)
+    );
+    const matching = maximumKnownSlotMatching(slots);
+    const matchedByTeam = new Map<string, number>();
+    for (const slot of slots) {
+      if (!matching.has(slot.key)) continue;
+      matchedByTeam.set(
+        slot.teamKey,
+        (matchedByTeam.get(slot.teamKey) ?? 0) + 1
+      );
+    }
+    const matches = ordered
+      .map((preference) => ({
+        preference,
+        matchedSkillSlots: matchedByTeam.get(preference.key) ?? 0,
+      }))
+      .filter(({ matchedSkillSlots }) => matchedSkillSlots > 0);
+    const score: GuideCandidateScore = {
+      exactTeams: matches.filter(
+        ({ matchedSkillSlots }) =>
+          matchedSkillSlots === KNOWN_TEAM_SKILL_SLOTS
+      ).length,
+      matchedTeams: matches.length,
+      matchedSkillSlots: matches.reduce(
+        (sum, { matchedSkillSlots }) => sum + matchedSkillSlots,
+        0
+      ),
+      championshipTeams: matches.filter(({ preference }) =>
+        isChampionshipComp(preference.comp)
+      ).length,
+      rankingScore: matches.reduce(
+        (sum, { preference }) =>
+          sum + teamRankingScore(preference.comp.ranking),
+        0
+      ),
+      key: matches
+        .map(({ preference }) => preference.comp.id)
+        .sort()
+        .join('|'),
+    };
+    if (
+      bestScore === null ||
+      compareGuideCandidateScores(score, bestScore) < 0
+    ) {
+      best = ordered;
+      bestScore = score;
+    }
+  };
+
+  visit(0, []);
+  cache.set(cacheKey, best);
+  return best;
+}
+
 /**
  * Marginal contribution of assigning `skill` to `hero`, given the skills already
  * on that hero: the hero-skill weight plus any within-hero skill-pair weights it
@@ -723,23 +985,50 @@ function heroAssignedScore(
   return s;
 }
 
+interface SkillAssignmentResult {
+  heroes: Map<string, { skills: string[]; score: number }>;
+  knownTeams: Map<string, KnownTeamAssignment>;
+}
+
 /**
  * Globally assign exactly 18 unique skills across the three teams (2 per hero),
- * never a hero's own signature skill. A deterministic greedy affinity build is
- * followed by bounded swaps that raise a top-two-weighted objective
- * (topTwoSum + 0.25 * thirdStrength), so skills concentrate on the two
- * strongest teams before helping the third. Returns null if the supplied pool
- * has no valid signature-safe assignment.
+ * never a hero's own signature skill. Guide-slot matches are locked first;
+ * every remaining slot is filled by the existing model assignment and bounded
+ * swap pass. Returns null if the supplied pool has no valid signature-safe
+ * assignment.
  */
 function assignSkills(
   trios: string[][],
   skillPool: string[],
   m: PairedModel,
-  catalog: RecommendationCatalog
-): Map<string, { skills: string[]; score: number }> | null {
+  catalog: RecommendationCatalog,
+  knownPreferences: KnownTeamPreference[] = []
+): SkillAssignmentResult | null {
   const heroes = trios.flat();
   const need = heroes.length * 2;
   const uniqueSkills = [...new Set(skillPool)];
+  const skillSet = new Set(uniqueSkills);
+
+  const orderedPreferences = [...knownPreferences].sort(
+    compareKnownPreferences
+  );
+  const guideSlots = orderedPreferences.flatMap((preference) =>
+    knownSlots(preference, skillSet, catalog)
+  );
+  const guideMatching = maximumKnownSlotMatching(guideSlots);
+  const guideSlotByKey = new Map(guideSlots.map((slot) => [slot.key, slot]));
+  const preferredSlotSkills = new Map<string, [string | null, string | null]>();
+  const lockedSkills = new Map<string, Set<string>>();
+  heroes.forEach((hero) => {
+    preferredSlotSkills.set(hero, [null, null]);
+    lockedSkills.set(hero, new Set());
+  });
+  for (const [slotKey, skill] of guideMatching) {
+    const slot = guideSlotByKey.get(slotKey);
+    if (!slot) continue;
+    preferredSlotSkills.get(slot.hero)![slot.slotIndex] = skill;
+    lockedSkills.get(slot.hero)!.add(skill);
+  }
 
   // Score the shortlist once per skill. Alongside standalone and best-possible
   // hero-skill value, credit the strongest *positive* feasible within-hero pair
@@ -790,11 +1079,23 @@ function assignSkills(
     .map(({ skill }) => skill);
 
   const assign = new Map<string, string[]>();
-  heroes.forEach((h) => assign.set(h, []));
+  heroes.forEach((hero) => {
+    assign.set(
+      hero,
+      preferredSlotSkills
+        .get(hero)!
+        .filter((skill): skill is string => skill !== null)
+    );
+  });
   const capacity = new Map<string, number>();
-  heroes.forEach((h) => capacity.set(h, 2));
+  heroes.forEach((hero) =>
+    capacity.set(hero, 2 - (assign.get(hero)?.length ?? 0))
+  );
 
-  const remaining = orderedSkills.slice(0, need);
+  const matchedGuideSkills = new Set(guideMatching.values());
+  const remaining = orderedSkills
+    .filter((skill) => !matchedGuideSkills.has(skill))
+    .slice(0, need - matchedGuideSkills.size);
 
   // Greedy: repeatedly place the (open-slot hero, remaining skill) with the max
   // marginal gain. Deterministic tie-breaks by hero then skill name.
@@ -836,6 +1137,7 @@ function assignSkills(
       if (otherHero === hero || own === catalog.default_skill[otherHero]) continue;
       const otherSkills = assign.get(otherHero)!;
       for (let i = 0; i < otherSkills.length; i++) {
+        if (lockedSkills.get(otherHero)!.has(otherSkills[i])) continue;
         if (otherSkills[i] === catalog.default_skill[hero]) continue;
         [ownSkills[badIndex], otherSkills[i]] = [otherSkills[i], ownSkills[badIndex]];
         repaired = true;
@@ -876,6 +1178,12 @@ function assignSkills(
         const sb = assign.get(hb)!;
         for (let i = 0; i < sa.length; i++) {
           for (let j = 0; j < sb.length; j++) {
+            if (
+              lockedSkills.get(ha)!.has(sa[i]) ||
+              lockedSkills.get(hb)!.has(sb[j])
+            ) {
+              continue;
+            }
             // Never assign a hero its own signature skill via a swap.
             if (sb[j] === catalog.default_skill[ha] || sa[i] === catalog.default_skill[hb]) continue;
             const before = assignmentObjective();
@@ -895,10 +1203,34 @@ function assignSkills(
 
   const result = new Map<string, { skills: string[]; score: number }>();
   for (const hero of heroes) {
-    const skills = (assign.get(hero) ?? []).slice().sort();
-    result.set(hero, { skills, score: heroAssignedScore(hero, skills, m) });
+    const preferred = preferredSlotSkills.get(hero) ?? [null, null];
+    const fallback = (assign.get(hero) ?? [])
+      .filter((skill) => !lockedSkills.get(hero)!.has(skill))
+      .sort();
+    const skills = [...preferred];
+    for (let index = 0; index < skills.length; index += 1) {
+      if (skills[index] === null) skills[index] = fallback.shift() ?? null;
+    }
+    const completeSkills = skills.filter(
+      (skill): skill is string => skill !== null
+    );
+    result.set(hero, {
+      skills: completeSkills,
+      score: heroAssignedScore(hero, completeSkills, m),
+    });
   }
-  return result;
+  const knownTeams = new Map<string, KnownTeamAssignment>();
+  for (const preference of orderedPreferences) {
+    const matchedSkillSlots = guideSlots.filter(
+      (slot) =>
+        slot.teamKey === preference.key && guideMatching.has(slot.key)
+    ).length;
+    knownTeams.set(preference.key, {
+      preference,
+      matchedSkillSlots,
+    });
+  }
+  return { heroes: result, knownTeams };
 }
 
 /** True when every hero on the team shares the same (defined) camp. */
@@ -962,6 +1294,7 @@ interface DraftTeam {
   assigned: AssignedHero[];
   /** Real `scoreTeam` strength (raw units). */
   strength: number;
+  knownTeam?: KnownTeamAssignment;
 }
 
 /** Assemble fully-assigned draft teams + their real `scoreTeam` strengths. */
@@ -969,18 +1302,33 @@ function projectFormation(
   trios: string[][],
   skillPool: string[],
   m: PairedModel,
-  catalog: RecommendationCatalog
+  catalog: RecommendationCatalog,
+  knownPreferences: KnownTeamPreference[] = []
 ): { teams: DraftTeam[]; strengths: number[] } | null {
-  const assignment = assignSkills(trios, skillPool, m, catalog);
+  const assignment = assignSkills(
+    trios,
+    skillPool,
+    m,
+    catalog,
+    knownPreferences
+  );
   if (!assignment) return null;
   const teams: DraftTeam[] = trios.map((trio) => {
     const heroes: ProjectedHero[] = trio.map((name) => {
-      const a = assignment.get(name)!;
+      const a = assignment.heroes.get(name)!;
       return { name, skills: a.skills, skillScore: displayScore(a.score) };
     });
     const assigned = heroes.map((p) => ({ name: p.name, skills: p.skills }));
     const strength = scoreTeam(assigned, m);
-    return { heroes, assigned, strength };
+    const knownTeam = assignment.knownTeams.get(trioKey(trio));
+    return {
+      heroes,
+      assigned,
+      strength,
+      ...(knownTeam && knownTeam.matchedSkillSlots > 0
+        ? { knownTeam }
+        : {}),
+    };
   });
   return { teams, strengths: teams.map((t) => t.strength) };
 }
@@ -1030,7 +1378,7 @@ function beamTrios(
 /** Canonical, order-independent key for a hero partition (order trios & heroes). */
 function partitionKey(trios: string[][]): string {
   return trios
-    .map((t) => [...t].sort().join('|'))
+    .map(trioKey)
     .sort()
     .join('||');
 }
@@ -1319,6 +1667,177 @@ export function enumerateFormationPartitions(
   return capPartitions(partitions, m, heroMeta, PARTITION_EVAL_CAP);
 }
 
+interface KnownPartitionProxy {
+  partition: [string[], string[], string[]];
+  knownTeams: number;
+  matchedSlots: number;
+  championshipTeams: number;
+  rankingScore: number;
+  sameCampTeams: number;
+  heroStrength: number;
+  key: string;
+}
+
+const triosAreDisjoint = (trios: string[][]): boolean =>
+  new Set(trios.flat()).size === trios.length * 3;
+
+function knownPartitionProxy(
+  partition: [string[], string[], string[]],
+  knownTeamIndex: KnownTeamIndex,
+  m: PairedModel,
+  heroMeta: HeroMeta
+): KnownPartitionProxy {
+  const preferences = partition
+    .map((trio) => knownTeamIndex.get(trioKey(trio))?.[0])
+    .filter(
+      (preference): preference is KnownTeamPreference =>
+        preference !== undefined
+    );
+  return {
+    partition,
+    knownTeams: preferences.length,
+    matchedSlots: preferences.reduce(
+      (sum, preference) => sum + preference.localMatchedSkillSlots,
+      0
+    ),
+    championshipTeams: preferences.filter(({ comp }) =>
+      isChampionshipComp(comp)
+    ).length,
+    rankingScore: preferences.reduce(
+      (sum, { comp }) => sum + teamRankingScore(comp.ranking),
+      0
+    ),
+    sameCampTeams: structureScore(partition, heroMeta).sameCampTeams,
+    heroStrength: partition.reduce(
+      (sum, trio) => sum + trioHeroStrength(trio, m),
+      0
+    ),
+    key: partitionKey(partition),
+  };
+}
+
+function compareKnownPartitionProxies(
+  left: KnownPartitionProxy,
+  right: KnownPartitionProxy
+): number {
+  if (left.knownTeams !== right.knownTeams)
+    return right.knownTeams - left.knownTeams;
+  if (left.matchedSlots !== right.matchedSlots)
+    return right.matchedSlots - left.matchedSlots;
+  if (left.championshipTeams !== right.championshipTeams)
+    return right.championshipTeams - left.championshipTeams;
+  if (left.rankingScore !== right.rankingScore)
+    return right.rankingScore - left.rankingScore;
+  if (left.sameCampTeams !== right.sameCampTeams)
+    return right.sameCampTeams - left.sameCampTeams;
+  if (Math.abs(left.heroStrength - right.heroStrength) > 1e-9)
+    return right.heroStrength - left.heroStrength;
+  return left.key < right.key ? -1 : left.key > right.key ? 1 : 0;
+}
+
+/**
+ * Reserve a bounded set of partitions containing usable `database.team`
+ * trios, then fill the rest of the unchanged 1,920-candidate budget with the
+ * model beam. The hybrid search therefore never performs a second unbounded
+ * optimisation pass.
+ */
+function enumerateHybridFormationPartitions(
+  pool: string[],
+  m: PairedModel,
+  heroMeta: HeroMeta,
+  knownTeamIndex: KnownTeamIndex
+): [string[], string[], string[]][] {
+  const modelPartitions = enumerateFormationPartitions(pool, m, heroMeta);
+  if (knownTeamIndex.size === 0) return modelPartitions;
+
+  const knownTrios = [...knownTeamIndex.values()]
+    .map((variants) => variants[0])
+    .sort(compareKnownPreferences)
+    .map(({ comp }) => comp.members.map(({ hero }) => hero));
+  const preferred: [string[], string[], string[]][] = [];
+  const seenPreferred = new Set<string>();
+  const addPreferred = (trios: string[][]) => {
+    if (trios.length !== 3 || !triosAreDisjoint(trios)) return;
+    const partition = trios as [string[], string[], string[]];
+    const key = partitionKey(partition);
+    if (seenPreferred.has(key)) return;
+    seenPreferred.add(key);
+    preferred.push(partition);
+  };
+
+  for (let first = 0; first < knownTrios.length; first += 1) {
+    const firstTrio = knownTrios[first];
+    const usedFirst = new Set(firstTrio);
+    const afterFirst = pool.filter((hero) => !usedFirst.has(hero));
+
+    const secondFallbacks = beamTrios(
+      combinations3(afterFirst),
+      m,
+      heroMeta,
+      8,
+      4
+    );
+    for (const secondTrio of secondFallbacks) {
+      const used = new Set([...firstTrio, ...secondTrio]);
+      const remaining = pool.filter((hero) => !used.has(hero));
+      const thirdFallbacks = beamTrios(
+        combinations3(remaining),
+        m,
+        heroMeta,
+        2,
+        2
+      );
+      for (const thirdTrio of thirdFallbacks) {
+        addPreferred([firstTrio, secondTrio, thirdTrio]);
+      }
+    }
+
+    for (let second = first + 1; second < knownTrios.length; second += 1) {
+      const secondTrio = knownTrios[second];
+      if (!triosAreDisjoint([firstTrio, secondTrio])) continue;
+      const used = new Set([...firstTrio, ...secondTrio]);
+      const remaining = pool.filter((hero) => !used.has(hero));
+      const thirdFallbacks = beamTrios(
+        combinations3(remaining),
+        m,
+        heroMeta,
+        2,
+        2
+      );
+      for (const thirdTrio of thirdFallbacks) {
+        addPreferred([firstTrio, secondTrio, thirdTrio]);
+      }
+
+      for (
+        let third = second + 1;
+        third < knownTrios.length;
+        third += 1
+      ) {
+        addPreferred([firstTrio, secondTrio, knownTrios[third]]);
+      }
+    }
+  }
+
+  const rankedPreferred = preferred
+    .map((partition) =>
+      knownPartitionProxy(partition, knownTeamIndex, m, heroMeta)
+    )
+    .sort(compareKnownPartitionProxies)
+    .slice(0, KNOWN_TEAM_PARTITION_CAP)
+    .map(({ partition }) => partition);
+
+  const combined: [string[], string[], string[]][] = [];
+  const seen = new Set<string>();
+  for (const partition of [...rankedPreferred, ...modelPartitions]) {
+    const key = partitionKey(partition);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    combined.push(partition);
+    if (combined.length === PARTITION_EVAL_CAP) break;
+  }
+  return combined;
+}
+
 interface FormationCandidate {
   teams: DraftTeam[];
   /** Fully-assigned team strengths, sorted strongest-first. */
@@ -1329,6 +1848,65 @@ interface FormationCandidate {
   structure: StructureScore;
   /** Deterministic canonical key over the hero partition. */
   key: string;
+  guide: GuideCandidateScore;
+}
+
+interface GuideCandidateScore {
+  exactTeams: number;
+  matchedTeams: number;
+  matchedSkillSlots: number;
+  championshipTeams: number;
+  rankingScore: number;
+  key: string;
+}
+
+function guideCandidateScore(teams: DraftTeam[]): GuideCandidateScore {
+  const matches = teams
+    .map(({ knownTeam }) => knownTeam)
+    .filter(
+      (knownTeam): knownTeam is KnownTeamAssignment =>
+        knownTeam !== undefined && knownTeam.matchedSkillSlots > 0
+    );
+  return {
+    exactTeams: matches.filter(
+      ({ matchedSkillSlots }) =>
+        matchedSkillSlots === KNOWN_TEAM_SKILL_SLOTS
+    ).length,
+    matchedTeams: matches.length,
+    matchedSkillSlots: matches.reduce(
+      (sum, { matchedSkillSlots }) => sum + matchedSkillSlots,
+      0
+    ),
+    championshipTeams: matches.filter(({ preference }) =>
+      isChampionshipComp(preference.comp)
+    ).length,
+    rankingScore: matches.reduce(
+      (sum, { preference }) =>
+        sum + teamRankingScore(preference.comp.ranking),
+      0
+    ),
+    key: matches
+      .map(({ preference }) => preference.comp.id)
+      .sort()
+      .join('|'),
+  };
+}
+
+function compareGuideCandidateScores(
+  left: GuideCandidateScore,
+  right: GuideCandidateScore
+): number {
+  if (left.exactTeams !== right.exactTeams)
+    return right.exactTeams - left.exactTeams;
+  if (left.matchedTeams !== right.matchedTeams)
+    return right.matchedTeams - left.matchedTeams;
+  if (left.matchedSkillSlots !== right.matchedSkillSlots)
+    return right.matchedSkillSlots - left.matchedSkillSlots;
+  if (left.championshipTeams !== right.championshipTeams)
+    return right.championshipTeams - left.championshipTeams;
+  if (left.rankingScore !== right.rankingScore)
+    return right.rankingScore - left.rankingScore;
+  return left.key < right.key ? -1 : left.key > right.key ? 1 : 0;
 }
 
 /**
@@ -1376,6 +1954,18 @@ function candidateToOption(candidate: FormationCandidate, m: PairedModel): Forma
     heroes: t.heroes,
     strength: displayScore(t.strength),
     evidence: buildTeamEvidence(t.assigned, m),
+    ...(t.knownTeam
+      ? {
+          formation: t.knownTeam.preference.comp.formation,
+          knownTeam: {
+            id: t.knownTeam.preference.comp.id,
+            ranking: t.knownTeam.preference.comp.ranking,
+            sources: [...t.knownTeam.preference.comp.sources],
+            matchedSkillSlots: t.knownTeam.matchedSkillSlots,
+            totalSkillSlots: KNOWN_TEAM_SKILL_SLOTS,
+          },
+        }
+      : {}),
   }));
   return { teams };
 }
@@ -1450,44 +2040,59 @@ function selectDiverseOptions(
  *     while runtime stays bounded.
  *  2. For every retained partition, run the global unique 18-skill assignment
  *     (2/hero, never a signature skill) and score each team with the full model.
- *  3. Select in two global stages, never pairwise: (a) find the single absolute
- *     maximum top-two-team summed strength across all feasible formations, and
- *     retain every formation whose top-two sum is within a
+ *  3. Hybrid callers first retain the best feasible guide-coverage class
+ *     (exact teams, matched teams, matched slots, source/rank, stable ID).
+ *     Within it, select in the original two global model stages, never
+ *     pairwise: (a) find the single absolute maximum top-two-team summed
+ *     strength and retain every formation whose top-two sum is within a
  *     {@link TOP_TWO_BAND}-point display band of that maximum; (b) rank the
  *     retained set with a pure, transitive lexicographic comparator — same-camp
  *     teams, then the stronger third team, total strength, and a deterministic
- *     key. Camp preference never overrides skill/signature feasibility and never
- *     widens the band.
+ *     key. Camp preference never overrides skill/signature feasibility and
+ *     never widens the band.
  *  4. Option one is that winner; options two and three are a deterministic
  *     diversity selection over the *same already-scored candidates* (distinct
  *     canonical partition keys, minimal hero-overlap) — no extra evaluation.
  *
  * No aggregate 总评分 is produced; each team carries its own display 评分.
  * `heroMeta` carries camp metadata from the database; when omitted the camp
- * preference is simply inert. Hero ranking is presentation-only and is not
- * accepted by or included in recommendation scoring.
+ * preference is simply inert. Hero ranking is presentation-only; known-team
+ * guide rank can break hybrid guide ties, but is never added to model scores.
  *
  * Deterministic and bounded for the full 9–15-hero progression pool. Every
  * supported hero reaches at least one fully evaluated partition; out-of-contract
  * 16+ pools are deterministically capped to the 15 strongest individual heroes.
  * {@link PARTITION_EVAL_CAP} bounds the expensive full skill-assignment pass.
  */
-export function recommendTeams(
+const incompleteFormationRecommendation = (): FormationRecommendation => ({
+  options: [],
+  incomplete: true,
+});
+
+interface FormationSearch {
+  m: PairedModel;
+  skills: string[];
+  catalog: RecommendationCatalog;
+  heroMeta: HeroMeta;
+  partitions: [string[], string[], string[]][];
+  knownTeamIndex?: KnownTeamIndex;
+  knownPreferenceCache: Map<string, KnownTeamPreference[]>;
+  preferKnownTeams: boolean;
+}
+
+function prepareFormationSearch(
   heroPool: string[],
   skillPool: string[],
   data: RecommendationData,
   catalog: RecommendationCatalog,
-  heroMeta: HeroMeta = {}
-): FormationRecommendation {
+  heroMeta: HeroMeta,
+  teamComps?: TeamComp[]
+): FormationSearch | null {
   const m = model(data);
   const heroes = [...new Set(heroPool)];
   const skills = [...new Set(skillPool)];
 
-  const incompleteResult: FormationRecommendation = {
-    options: [],
-    incomplete: true,
-  };
-  if (heroes.length < 9 || skills.length < 18) return incompleteResult;
+  if (heroes.length < 9 || skills.length < 18) return null;
 
   // Canonically rank the complete supported pool before feeding it to the
   // bounded beam. Do not trim within the 15-hero game contract: a low-weight
@@ -1502,31 +2107,89 @@ export function recommendTeams(
   });
   const pool = rankedHeroes.slice(0, FORMATION_HERO_POOL_CAP);
 
-  // Build a bounded, deterministic beam of disjoint partitions. Large pools
-  // identify prospective main-team pairs before constructing team three; small
-  // pools keep the existing per-level beam. The winner is chosen later by the
-  // full global skill-assignment comparator.
-  const partitions = enumerateFormationPartitions(pool, m, heroMeta);
+  const knownTeamIndex = teamComps
+    ? buildKnownTeamIndex(
+        teamComps,
+        new Set(pool),
+        new Set(skills),
+        catalog
+      )
+    : undefined;
+  const partitions = knownTeamIndex
+    ? enumerateHybridFormationPartitions(
+        pool,
+        m,
+        heroMeta,
+        knownTeamIndex
+      )
+    : enumerateFormationPartitions(pool, m, heroMeta);
 
-  // Stage 1: score every feasible fully-assigned partition into candidates.
-  const candidates: FormationCandidate[] = [];
-  for (const trios of partitions) {
-    const projected = projectFormation(trios, skills, m, catalog);
-    if (!projected) continue;
-    const { teams, strengths } = projected;
-    const sorted = [...strengths].sort((a, b) => b - a);
-    candidates.push({
-      teams,
-      sorted,
-      topTwoSum: sorted[0] + sorted[1],
-      thirdStrength: sorted[2],
-      totalStrength: strengths.reduce((a, b) => a + b, 0),
-      structure: structureScore(trios, heroMeta),
-      key: partitionKey(trios),
-    });
+  return {
+    m,
+    skills,
+    catalog,
+    heroMeta,
+    partitions,
+    knownTeamIndex,
+    knownPreferenceCache: new Map(),
+    preferKnownTeams: teamComps !== undefined,
+  };
+}
+
+function evaluateFormationPartition(
+  search: FormationSearch,
+  trios: [string[], string[], string[]]
+): FormationCandidate | null {
+  const knownPreferences = search.knownTeamIndex
+    ? selectKnownPreferences(
+        trios,
+        search.knownTeamIndex,
+        search.skills,
+        search.catalog,
+        search.knownPreferenceCache
+      )
+    : [];
+  const projected = projectFormation(
+    trios,
+    search.skills,
+    search.m,
+    search.catalog,
+    knownPreferences
+  );
+  if (!projected) return null;
+  const { teams, strengths } = projected;
+  const sorted = [...strengths].sort((a, b) => b - a);
+  return {
+    teams,
+    sorted,
+    topTwoSum: sorted[0] + sorted[1],
+    thirdStrength: sorted[2],
+    totalStrength: strengths.reduce((a, b) => a + b, 0),
+    structure: structureScore(trios, search.heroMeta),
+    key: partitionKey(trios),
+    guide: guideCandidateScore(teams),
+  };
+}
+
+function finishFormationRecommendation(
+  candidates: FormationCandidate[],
+  search: FormationSearch
+): FormationRecommendation {
+  if (candidates.length === 0) return incompleteFormationRecommendation();
+
+  // Hybrid stage 1: database coverage is lexicographically primary. Model-only
+  // callers give every candidate the same empty guide score and remain exactly
+  // equivalent to the original search.
+  let eligible = candidates;
+  if (search.preferKnownTeams) {
+    const bestGuide = [...candidates]
+      .map(({ guide }) => guide)
+      .sort(compareGuideCandidateScores)[0];
+    eligible = candidates.filter(
+      ({ guide }) =>
+        compareGuideCandidateScores(guide, bestGuide) === 0
+    );
   }
-
-  if (candidates.length === 0) return incompleteResult;
 
   // Stage 2: true global band. Find the single absolute-maximum top-two sum,
   // retain every candidate whose top-two sum is no more than TOP_TWO_BAND
@@ -1534,9 +2197,12 @@ export function recommendTeams(
   // pure lexicographic comparator (same-camp, then third team, total, key).
   // This is order-independent: the band is fixed once against a global anchor,
   // never applied pairwise.
-  const maxTopTwo = Math.max(...candidates.map((c) => c.topTwoSum));
+  const maxTopTwo = Math.max(...eligible.map((c) => c.topTwoSum));
   const bandRaw = TOP_TWO_BAND / 10; // display points → raw units
-  const retained = candidates.filter((c) => c.topTwoSum >= maxTopTwo - bandRaw - 1e-9);
+  const retained = eligible.filter(
+    (candidate) =>
+      candidate.topTwoSum >= maxTopTwo - bandRaw - 1e-9
+  );
   retained.sort(compareCandidates);
 
   // Keep every surfaced option inside the same 2.5-display-point top-two band
@@ -1549,12 +2215,114 @@ export function recommendTeams(
   // diversity selection over the ranked set — distinct canonical partition keys,
   // minimal hero overlap. When fewer than three distinct feasible candidates
   // exist, only those available are returned.
-  const options = selectDiverseOptions(rankedFromWinner, m);
+  const options = selectDiverseOptions(rankedFromWinner, search.m);
 
   return {
     options,
     incomplete: false,
   };
+}
+
+function runFormationSearch(search: FormationSearch): FormationRecommendation {
+  const candidates: FormationCandidate[] = [];
+  for (const trios of search.partitions) {
+    const candidate = evaluateFormationPartition(search, trios);
+    if (candidate) candidates.push(candidate);
+  }
+  return finishFormationRecommendation(candidates, search);
+}
+
+export function recommendTeams(
+  heroPool: string[],
+  skillPool: string[],
+  data: RecommendationData,
+  catalog: RecommendationCatalog,
+  heroMeta: HeroMeta = {}
+): FormationRecommendation {
+  const search = prepareFormationSearch(
+    heroPool,
+    skillPool,
+    data,
+    catalog,
+    heroMeta
+  );
+  return search
+    ? runFormationSearch(search)
+    : incompleteFormationRecommendation();
+}
+
+/**
+ * Database-first Team Builder recommendation. Usable guide trios and skill
+ * alternatives are preferred lexicographically; the paired model fills every
+ * unmatched skill and any remaining team without exceeding the original
+ * partition-evaluation cap.
+ */
+export function recommendHybridTeams(
+  heroPool: string[],
+  skillPool: string[],
+  data: RecommendationData,
+  catalog: RecommendationCatalog,
+  heroMeta: HeroMeta,
+  teamComps: TeamComp[]
+): FormationRecommendation {
+  const search = prepareFormationSearch(
+    heroPool,
+    skillPool,
+    data,
+    catalog,
+    heroMeta,
+    teamComps
+  );
+  return search
+    ? runFormationSearch(search)
+    : incompleteFormationRecommendation();
+}
+
+export interface CooperativeFormationOptions {
+  batchSize?: number;
+  shouldCancel?: () => boolean;
+  yieldControl?: () => Promise<void>;
+}
+
+/**
+ * Main-thread safety fallback for browsers where a module worker cannot start.
+ * It evaluates the same deterministic hybrid search in small batches and
+ * yields between them so loading UI and navigation remain responsive.
+ */
+export async function recommendHybridTeamsCooperatively(
+  heroPool: string[],
+  skillPool: string[],
+  data: RecommendationData,
+  catalog: RecommendationCatalog,
+  heroMeta: HeroMeta,
+  teamComps: TeamComp[],
+  options: CooperativeFormationOptions = {}
+): Promise<FormationRecommendation> {
+  const search = prepareFormationSearch(
+    heroPool,
+    skillPool,
+    data,
+    catalog,
+    heroMeta,
+    teamComps
+  );
+  if (!search) return incompleteFormationRecommendation();
+
+  const batchSize = Math.max(1, options.batchSize ?? 12);
+  const yieldControl =
+    options.yieldControl ??
+    (() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+  const candidates: FormationCandidate[] = [];
+  for (let index = 0; index < search.partitions.length; index += 1) {
+    if (options.shouldCancel?.()) return incompleteFormationRecommendation();
+    const candidate = evaluateFormationPartition(
+      search,
+      search.partitions[index]
+    );
+    if (candidate) candidates.push(candidate);
+    if ((index + 1) % batchSize === 0) await yieldControl();
+  }
+  return finishFormationRecommendation(candidates, search);
 }
 
 // --------------------------------------------------------------------------- #

--- a/web/src/services/teamBuilderArrangement.ts
+++ b/web/src/services/teamBuilderArrangement.ts
@@ -286,6 +286,9 @@ export function layoutFromFormation(option: FormationOption): TeamBuilderLayout 
   ) {
     const projectedTeam = option.teams[teamIndex];
     if (!projectedTeam) continue;
+    if (projectedTeam.formation) {
+      layout[teamIndex].formation = projectedTeam.formation;
+    }
 
     for (
       let heroIndex = 0;

--- a/web/src/services/teamFormationCache.ts
+++ b/web/src/services/teamFormationCache.ts
@@ -1,0 +1,29 @@
+import type { FormationRecommendation } from './recommendationEngine';
+import type { RecommendationData } from '../types/recommendation';
+import type { TeamComp } from '../types/domain';
+
+const cache = new Map<string, FormationRecommendation>();
+
+export function teamFormationCacheKey(
+  poolKey: string,
+  recommendationData: RecommendationData,
+  teamComps: TeamComp[]
+): string {
+  return JSON.stringify({
+    poolKey,
+    catalog: recommendationData.catalog.catalog_version,
+    corpus: recommendationData.battle_counts.corpus_version,
+    teams: teamComps.map(({ id }) => id),
+  });
+}
+
+export const getCachedTeamFormation = (
+  key: string
+): FormationRecommendation | null => cache.get(key) ?? null;
+
+export const setCachedTeamFormation = (
+  key: string,
+  recommendation: FormationRecommendation
+): void => {
+  cache.set(key, recommendation);
+};

--- a/web/src/services/teamFormationWorkerProtocol.ts
+++ b/web/src/services/teamFormationWorkerProtocol.ts
@@ -1,0 +1,26 @@
+import type { FormationRecommendation } from './recommendationEngine';
+
+export type TeamFormationStage = 'matching' | 'optimizing';
+
+export interface TeamFormationWorkerRequest {
+  requestId: string;
+  heroes: string[];
+  skills: string[];
+}
+
+export type TeamFormationWorkerResponse =
+  | {
+      type: 'progress';
+      requestId: string;
+      stage: TeamFormationStage;
+    }
+  | {
+      type: 'result';
+      requestId: string;
+      recommendation: FormationRecommendation;
+    }
+  | {
+      type: 'error';
+      requestId: string;
+      message: string;
+    };

--- a/web/src/workers/teamFormation.worker.ts
+++ b/web/src/workers/teamFormation.worker.ts
@@ -1,0 +1,67 @@
+import { database, recommendationData } from '../data';
+import {
+  recommendHybridTeams,
+  type HeroMeta,
+} from '../services/recommendationEngine';
+import type {
+  TeamFormationWorkerRequest,
+  TeamFormationWorkerResponse,
+} from '../services/teamFormationWorkerProtocol';
+
+const heroMeta: HeroMeta = Object.fromEntries(
+  Object.entries(database.heroes || {}).map(([name, hero]) => [
+    name,
+    { camp: hero.camp },
+  ])
+);
+
+const workerScope = self as unknown as {
+  addEventListener: (
+    type: 'message',
+    listener: (event: MessageEvent<TeamFormationWorkerRequest>) => void
+  ) => void;
+  postMessage: (message: TeamFormationWorkerResponse) => void;
+};
+
+workerScope.addEventListener('message', ({ data }) => {
+  const { requestId, heroes, skills } = data;
+  workerScope.postMessage({
+    type: 'progress',
+    requestId,
+    stage: 'matching',
+  });
+
+  // Yield once inside the worker so the progress message reaches the page
+  // before the synchronous bounded optimiser starts.
+  setTimeout(() => {
+    workerScope.postMessage({
+      type: 'progress',
+      requestId,
+      stage: 'optimizing',
+    });
+    try {
+      const recommendation = recommendHybridTeams(
+        heroes,
+        skills,
+        recommendationData,
+        recommendationData.catalog,
+        heroMeta,
+        database.team || []
+      );
+      workerScope.postMessage({
+        type: 'result',
+        requestId,
+        recommendation,
+      });
+    } catch (error) {
+      workerScope.postMessage({
+        type: 'error',
+        requestId,
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Unknown formation worker error',
+      });
+    }
+  }, 0);
+});

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -19,8 +19,30 @@ const smallHeroes = heroNames.slice(0, 3);
 const smallSkills = regularSkills.slice(0, 4);
 const supportHero = heroNames[3];
 const supportSkill = regularSkills[4];
-const completeHeroes = heroNames.slice(0, 9);
-const completeSkills = regularSkills.slice(0, 18);
+const completeTeamIds = [
+  'yanwu-司马懿-曹操-曹丕-73954cef88c92b17',
+  'yanwu-袁术-皇甫嵩2-孙坚2-5a51cfe3cf60e395',
+  'yanwu-祝融-孟获-诸葛亮2-f6d9988bcd6821cb',
+];
+const completeTeamComps = completeTeamIds.map((id) => {
+  const comp = database.team.find((team) => team.id === id);
+  if (!comp) throw new Error(`Missing Team Builder fixture ${id}`);
+  return comp;
+});
+const completeHeroes = completeTeamComps.flatMap((team) =>
+  team.members.map(({ hero }) => hero)
+);
+const completeSkills = completeTeamComps.flatMap((team) =>
+  team.members.flatMap(({ skillSlots }) =>
+    skillSlots.map((alternatives) => alternatives[0])
+  )
+);
+if (
+  new Set(completeHeroes).size !== 9 ||
+  new Set(completeSkills).size !== 18
+) {
+  throw new Error('Team Builder fixture must contain 9 heroes and 18 unique skills');
+}
 
 const progressFor = ({
   heroes,
@@ -418,12 +440,21 @@ test.describe('Team Builder best default', () => {
     page,
   }) => {
     await page.addInitScript(() => {
-      const flags = { warningSeen: false, loadingSeen: false };
+      const flags = {
+        warningSeen: false,
+        loadingSeen: false,
+        ticksWhileLoading: 0,
+      };
       window.__teamBuilderFlashFlags = flags;
       const scan = () => {
         const text = document.body ? document.body.innerText : '';
         if (text.includes('不足以推荐完整的编排')) flags.warningSeen = true;
-        if (text.includes('正在优化')) flags.loadingSeen = true;
+        if (
+          text.includes('正在匹配阵容库') ||
+          text.includes('正在补全剩余阵容')
+        ) {
+          flags.loadingSeen = true;
+        }
       };
       const start = () => {
         scan();
@@ -432,6 +463,15 @@ test.describe('Team Builder best default', () => {
           subtree: true,
           characterData: true,
         });
+        window.setInterval(() => {
+          const text = document.body ? document.body.innerText : '';
+          if (
+            text.includes('正在匹配阵容库') ||
+            text.includes('正在补全剩余阵容')
+          ) {
+            flags.ticksWhileLoading += 1;
+          }
+        }, 10);
       };
       if (document.documentElement) start();
       else document.addEventListener('DOMContentLoaded', start);
@@ -441,26 +481,40 @@ test.describe('Team Builder best default', () => {
     const flags = await page.evaluate(() => window.__teamBuilderFlashFlags);
     expect(flags.loadingSeen).toBe(true);
     expect(flags.warningSeen).toBe(false);
+    expect(flags.ticksWhileLoading).toBeGreaterThan(2);
   });
 
   test('keeps the player-chosen formation after refresh', async ({ page }) => {
     await openBuilder(page);
 
     await expect(page.locator('[data-testid^="hero-camp-"]')).toHaveCount(9);
+    const seededFormation = await page
+      .getByTestId('formation-select-0')
+      .inputValue();
+    const replacementFormation = Object.keys(database.formations).find(
+      (formation) => formation !== seededFormation
+    );
+    expect(replacementFormation).toBeTruthy();
     await page.getByRole('combobox', { name: '阵型' }).first().click();
-    await page.getByRole('option', { name: '锥形阵' }).click();
-    await expect(page.getByTestId('formation-select-0')).toHaveValue('锥形阵');
+    await page
+      .getByRole('option', { name: replacementFormation })
+      .click();
+    await expect(page.getByTestId('formation-select-0')).toHaveValue(
+      replacementFormation
+    );
     await expect(
-      page.getByRole('button', { name: '恢复系统推荐' })
+      page.getByRole('button', { name: '恢复阵容库推荐' })
     ).toBeVisible();
 
     await page.reload();
     await expect(
       page.getByRole('heading', { name: '我的比赛阵容' })
     ).toBeVisible({ timeout: 30000 });
-    await expect(page.getByTestId('formation-select-0')).toHaveValue('锥形阵');
+    await expect(page.getByTestId('formation-select-0')).toHaveValue(
+      replacementFormation
+    );
     await expect(
-      page.getByRole('button', { name: '恢复系统推荐' })
+      page.getByRole('button', { name: '恢复阵容库推荐' })
     ).toBeVisible();
   });
 
@@ -470,13 +524,16 @@ test.describe('Team Builder best default', () => {
     await page.addInitScript(() => {
       localStorage.setItem(
         'teamBuilder',
-        JSON.stringify([{ formation: '锥形阵', heroes: [] }])
+        JSON.stringify([{ formation: '方圆阵', heroes: [] }])
       );
     });
 
     await openBuilder(page);
     await expect(page.locator('[data-testid^="hero-camp-"]')).toHaveCount(9);
-    await expect(page.getByTestId('formation-select-0')).toHaveValue('');
+    await expect(page.getByTestId('formation-select-0')).not.toHaveValue(
+      '方圆阵'
+    );
+    await expect(page.getByTestId('formation-select-0')).not.toHaveValue('');
   });
 
   test('seeds exactly one best editable three-team formation', async ({
@@ -486,7 +543,7 @@ test.describe('Team Builder best default', () => {
 
     await expect(
       page.getByText(
-        '系统默认给出当前卡池的一套最佳三队编排，之后可自由拖动调整。',
+        '优先匹配阵容库中的武将、阵型与战法，未覆盖部分由历史对局模型补全。',
         { exact: true }
       )
     ).toBeVisible();
@@ -496,8 +553,11 @@ test.describe('Team Builder best default', () => {
     await expect(page.getByText(/阵型和前后排由你确认/)).toHaveCount(0);
     await expect(page.getByText('最佳推荐', { exact: true })).toHaveCount(0);
     await expect(
-      page.getByRole('button', { name: '恢复系统推荐' })
+      page.getByRole('button', { name: '恢复阵容库推荐' })
     ).toHaveCount(0);
+    await expect(
+      page.getByText('已匹配阵容库 3 支队伍、18 个战法位；其余位置由历史对局模型补全。')
+    ).toBeVisible();
     await expect(page.getByRole('button', { name: '清空编排' })).toHaveCount(0);
     await expect(
       page.getByRole('heading', { name: /^队伍 [123]$/ })
@@ -524,6 +584,12 @@ test.describe('Team Builder best default', () => {
     expect(body).not.toContain('胜率');
     expect(body).toContain('加分');
     expect(body).toContain('参考');
+    const seededFormations = await page
+      .locator('[data-testid^="formation-select-"]')
+      .evaluateAll((elements) =>
+        elements.map((element) => element.value).sort()
+      );
+    expect(seededFormations).toEqual(['锥形阵', '雁形阵', '雁形阵'].sort());
     const evidenceRows = page.getByTestId('team-evidence');
     expect(await evidenceRows.count()).toBeGreaterThan(0);
     for (const row of await evidenceRows.all()) {
@@ -541,11 +607,11 @@ test.describe('Team Builder best default', () => {
       .getByRole('button', { name: `${firstRecommendedHero} 后排` })
       .click();
     const restoreButton = page.getByRole('button', {
-      name: '恢复系统推荐',
+      name: '恢复阵容库推荐',
     });
     await expect(restoreButton).toBeVisible();
     await restoreButton.click();
-    await expect(page.getByText('已恢复当前卡池的系统推荐')).toBeVisible();
+    await expect(page.getByText('已恢复当前卡池的阵容库推荐')).toBeVisible();
     await expect(restoreButton).toHaveCount(0);
 
     const header = page.getByTestId('formation-workbench-header');

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -48,6 +48,12 @@ const gameDatabase = () => ({
 // https://vite.dev/config/  (defineConfig from vitest/config also types the `test` block)
 export default defineConfig({
   plugins: [gameDatabase(), react()],
+  // Worker bundles run through a separate Vite plugin pipeline. Recreate the
+  // database plugin there so the formation worker can import the same canonical
+  // public JSON without a second checked-in copy.
+  worker: {
+    plugins: () => [gameDatabase()],
+  },
   // The app is served from the domain root on Cloudflare Pages.
   base: '/',
   server: {


### PR DESCRIPTION
## Intent

On /team-builder, prefer known three-hero builds, formations, and alternative skill slots from web/public/game-data/database.json; allow partial matches and fill unmatched skill or team slots with recommendation_data.json while preserving 9 unique heroes and 18 unique legal skills. Keep the original 1,920 partition cap and run the heavy hybrid optimizer in a client Web Worker with responsive loading, cooperative fallback, caching, and no new Cloudflare Function so the Pages free plan remains static and free. Preserve saved editable layouts and live model scores and evidence.

## What Changed

- Reworked `recommendationEngine.ts` and `TeamBuilder.tsx` so the Team Builder first draws three-hero builds, formations, and alternative skill slots from `database.json`, allows partial matches, and fills any unmatched team or skill slots from the historical `recommendation_data.json` model while preserving 9 unique heroes and 18 unique legal skills; live model scores and evidence and saved editable layouts are retained.
- Moved the heavy hybrid formation optimizer (unchanged 1,920-partition cap) off the main thread into a client Web Worker (`workers/teamFormation.worker.ts`, `teamFormationWorkerProtocol.ts`), with a cooperative main-thread fallback, an in-memory `teamFormationCache.ts`, responsive loading UI, and no new Cloudflare Function.
- Added Vitest coverage in `recommendationEngine.test.ts`, extended the `buildATeam` Playwright e2e spec, wired the worker build in `vite.config.js`, and updated `README.md`/`web/README.md` to document the database-first, worker-backed flow.

## Risk Assessment

✅ Low: The change is well-bounded, satisfies every required intent constraint (1,920 cap preserved, worker + cooperative fallback + cache, no new Cloudflare Function, unique 9-hero/18-skill assignment, preserved layouts/scores), and is backed by substantial new unit and e2e tests with no correctness defects found.

## Testing

Ran the web Vitest unit suite (393 passing) and the tsc typecheck (clean) under Node 22, then ran the Team Builder Playwright e2e spec (12/12 passing) which drives the real rendered /team-builder flow — confirming the Web Worker loading UI paints responsively without an insufficient-warning flash, a player-chosen formation persists across reload, and the guide-match banner reports 3 matched teams / 18 skill slots. I also captured a full-page screenshot of the completed builder as reviewer-visible visual evidence showing preferred known builds, preserved formations, a full 9-hero/18-skill roster, and live 评分 scores with 加分/参考 evidence rows. All checks passed; transient test artifacts and the temporary capture spec were removed, leaving the worktree clean.

- Evidence: Team Builder — guide-matched three-team formation (/team-builder) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYNP3JVNEAMJZ5DKETPWD2JG/team-builder-guide-matched.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `web/src/services/teamFormationCache.ts:5` - teamFormationCache.ts uses a module-level Map with no eviction, so it retains a full FormationRecommendation for every distinct card pool visited during a session. This is bounded by the number of distinct pools a user explores and is explicitly an intended in-memory cache (README), so it is not a practical concern, but there is no upper bound if a session churns through many pools.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; corepack pnpm test` (Vitest — 393 tests across 34 files passed)</code>
- <code>`cd web &amp;&amp; corepack pnpm typecheck` (Go-native tsc, no errors)</code>
- <code>`corepack pnpm exec playwright test tests/buildATeam.spec.js` (12 e2e tests passed, incl. worker loading responsiveness, formation-survives-refresh, and &#39;seeds exactly one best editable three-team formation&#39; asserting the guide-match banner)</code>
- `Manual evidence capture: temporary Playwright spec seeding a complete 9-hero/18-skill pool, navigating to /team-builder, and screenshotting the finished guide-matched formation (spec removed after run)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
