### PR TITLE
fix(web): distinguish fadao matchup team

### DIFF
--- a/web/src/pages/YanwuGuide.tsx
+++ b/web/src/pages/YanwuGuide.tsx
@@ -49,6 +49,19 @@ const isChampionship = (team: GuideTeam) =>
 const teamName = (team: GuideTeam) =>
   team.members.map((member) => member.hero).join(' + ');
 
+const FADAO_SIMA_SKILLS = ['运智铺谋', '谋而后动'] as const;
+
+const matchupTeamName = (team: GuideTeam) =>
+  team.members
+    .map((member) => {
+      const equippedSkills = member.skillSlots.flat();
+      const isFadaoSima =
+        member.hero === '司马懿' &&
+        FADAO_SIMA_SKILLS.every((skill) => equippedSkills.includes(skill));
+      return isFadaoSima ? `(法刀) ${member.hero}` : member.hero;
+    })
+    .join(' + ');
+
 const rankingIndex = (ranking: string) => {
   const index = TEAM_RANKINGS.indexOf(ranking as (typeof TEAM_RANKINGS)[number]);
   return index === -1 ? TEAM_RANKINGS.length : index;
@@ -290,7 +303,11 @@ const YanwuGuide = () => {
           >
             {yanwuGuide.matchups.buildIds.map((teamId) => {
               const team = teamById.get(teamId);
-              return <MenuItem key={teamId} value={teamId}>{team ? teamName(team) : teamId}</MenuItem>;
+              return (
+                <MenuItem key={teamId} value={teamId}>
+                  {team ? matchupTeamName(team) : teamId}
+                </MenuItem>
+              );
             })}
           </Select>
         </FormControl>
@@ -311,7 +328,9 @@ const YanwuGuide = () => {
                 const result = OUTCOME[resultKey ?? 'even'] ?? OUTCOME.even;
                 return (
                   <TableRow key={opponentId}>
-                    <TableCell>{opponent ? teamName(opponent) : opponentId}</TableCell>
+                    <TableCell>
+                      {opponent ? matchupTeamName(opponent) : opponentId}
+                    </TableCell>
                     <TableCell>
                       <Chip
                         label={result.label}

--- a/web/tests/yanwuGuide.spec.js
+++ b/web/tests/yanwuGuide.spec.js
@@ -62,6 +62,31 @@ test.describe('演武攻略', () => {
     expect(guide.championshipGroups).toHaveLength(5);
     expect(guide.analysisSections.length).toBeGreaterThan(0);
 
+    const matchupTable = page.getByRole('table', {
+      name: '阵容克制关系',
+    });
+    await expect(
+      matchupTable.getByText('司马懿 + 曹操 + 曹丕', { exact: true })
+    ).toHaveCount(1);
+    await expect(
+      matchupTable.getByText('曹丕 + 曹操 + (法刀) 司马懿', { exact: true })
+    ).toHaveCount(1);
+
+    await page.getByRole('combobox', { name: '己方阵容' }).click();
+    await expect(
+      page.getByRole('option', {
+        name: '司马懿 + 曹操 + 曹丕',
+        exact: true,
+      })
+    ).toHaveCount(1);
+    await expect(
+      page.getByRole('option', {
+        name: '曹丕 + 曹操 + (法刀) 司马懿',
+        exact: true,
+      })
+    ).toHaveCount(1);
+    await page.keyboard.press('Escape');
+
     await page.getByRole('link', { name: '对局推荐' }).click();
     await expect(page).toHaveURL(/\/$/);
     await expect(page.getByText('攻略数据由三谋吕布提供', { exact: true }))


### PR DESCRIPTION
## Intent

On /guides/yanwu in 阵容克制查询, distinguish the regular 司马懿 + 曹操 + 曹丕 build from the separate 曹丕 + 曹操 + 司马懿 build where 司马懿 equips 运智铺谋 and 谋而后动. Render that skill-defined variant as 曹丕 + 曹操 + (法刀) 司马懿 in both the own-team selector and opponent table, while retaining both distinct matchup-matrix entries. Detect the variant from its skills rather than a hard-coded team ID. Do not add explanatory player-facing text because players already understand 法刀.

## What Changed

- Added a `matchupTeamName` helper in `web/src/pages/YanwuGuide.tsx` that detects the 法刀 司马懿 variant by its equipped skills (`运智铺谋` + `谋而后动`) rather than a hard-coded team ID, rendering that build as `曹丕 + 曹操 + (法刀) 司马懿` while the regular build stays `司马懿 + 曹操 + 曹丕`.
- Applied the new label in both the 阵容克制查询 opponent table and the 己方阵容 selector so the two otherwise-identically-named builds are told apart, keeping both distinct matchup-matrix entries intact and adding no extra player-facing explanatory text.
- Extended `web/tests/yanwuGuide.spec.js` to assert the table and selector each show the regular and 法刀 variant names exactly once.

## Risk Assessment

✅ Low: A small, well-tested display-only change that correctly distinguishes the skill-defined 法刀 司马懿 variant from its skills, satisfies every intent constraint, and touches no scoring or data logic.

## Testing

Ran the scoped web checks on Node 22 (per the repo memory that Node 20 skips the rolldown native binding): Vitest unit suite (393 passing) and typecheck both clean, and the existing Playwright e2e `yanwuGuide.spec.js` passed, asserting the 法刀 变体 label in both the selector and opponent table. I also captured reviewer-visible screenshots of the rendered 阵容克制查询 table and the 己方阵容 selector, which show the regular `司马懿 + 曹操 + 曹丕` build and the skill-defined `曹丕 + 曹操 + (法刀) 司马懿` variant as distinct entries with no extra explanatory copy — directly demonstrating the intent end-to-end. The temporary evidence spec and test-results were removed, leaving a clean working tree.

- Evidence: Matchup table showing regular build vs (法刀) 司马懿 variant as distinct opponent rows (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYPFW05JZRVT10BAH3XHBZZ7/matchup-table.png</code>)
- Evidence: 己方阵容 selector + table rendering the (法刀) 司马懿 variant label (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYPFW05JZRVT10BAH3XHBZZ7/own-team-selector.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `web/public/game-data/database.json`: confirmed two distinct 司马懿/曹操/曹丕 builds (regular skills 未雨绸缪/潜龙在渊; variant 司马懿 with 运智铺谋+谋而后动) and both IDs present in the 13-entry `yanwuGuide.matchups.buildIds`</code>
- <code>`fnm exec --using=22 pnpm exec playwright test yanwuGuide.spec.js` — existing e2e asserts both the table and selector show `司马懿 + 曹操 + 曹丕` and `曹丕 + 曹操 + (法刀) 司马懿` each exactly once</code>
- `Temporary Playwright spec capturing screenshots of the matchup table and己方阵容 selector to the evidence dir (removed after run)`
- <code>`fnm exec --using=22 pnpm typecheck` (Go-native tsc, no errors)</code>
- <code>`fnm exec --using=22 pnpm test` (Vitest: 393 tests passed)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
