### PR TITLE
fix(web): clarify option-analysis combination evidence display

### DIFF
--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -83,10 +83,10 @@ const AnalysisGrid = ({
   const renderContributions = (items: Contribution[]) => {
     if (!items || items.length === 0) return null;
     return (
-      <Box sx={{ mb: 2, p: 1, bgcolor: 'action.hover', borderRadius: 1 }}>
-        <Typography variant="caption" color="text.secondary" display="block" gutterBottom>
-          关键组合依据（已计入评分）
-        </Typography>
+      <Box
+        data-testid="combination-evidence"
+        sx={{ mb: 2, p: 1, bgcolor: 'action.hover', borderRadius: 1 }}
+      >
         {items.map((c, i) => (
           <Box key={i} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.25 }}>
             <Chip label={c.label} size="small" color={c.weight >= 0 ? itemColor : 'default'} variant="outlined" />

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -1,4 +1,4 @@
-import { Grid, Card, CardContent, Typography, Button, Box, Chip } from '@mui/material';
+import { Grid, Card, CardContent, Typography, Button, Box, Chip, Tooltip } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import StarIcon from '@mui/icons-material/Star';
 import { formatHeroRanking } from '../../utils/itemMetadata';
@@ -22,6 +22,11 @@ interface AnalysisGridProps {
 
 /** One-decimal score with an explicit sign (+ for nonnegative, − for negative). */
 const fmtSigned = (x: number): string => `${x >= 0 ? '+' : '−'}${Math.abs(x).toFixed(1)}`;
+
+const isComboContribution = (contribution: Contribution): boolean =>
+  contribution.family === 'HP' ||
+  contribution.family === 'HS' ||
+  contribution.family === 'SP';
 
 /**
  * Display 3 option sets as cards. Each card shows the option's per-round score
@@ -59,6 +64,20 @@ const AnalysisGrid = ({
       ? `AI 按当前阵容强度推荐 ${optionLetter(recommendedIndex)}；玩家选择模型认为 ${optionLetter(preference.top_index)} 更常被选（${(preference.probabilities[preference.top_index] * 100).toFixed(1)}%）。${preference.explanation_driver} 这描述玩家偏好，不会改变 AI 推荐。`
       : null;
 
+  const combinationEvidence = (option?: OptionAnalysis): Contribution[] => {
+    if (!option) return [];
+    return [...option.combo_synergies, ...option.combo_tradeoffs]
+      .filter(isComboContribution)
+      .sort((a, b) => Math.abs(b.weight) - Math.abs(a.weight))
+      .slice(0, 5);
+  };
+  const maxCombinationMagnitude = Math.max(
+    0,
+    ...(analysis ?? []).flatMap((option) =>
+      combinationEvidence(option).map((contribution) => Math.abs(contribution.weight))
+    )
+  );
+
   const itemChipLabel = (item: string) => {
     if (roundType === 'hero') {
       const tag = formatHeroRanking(heroMetadata?.[item]);
@@ -67,19 +86,66 @@ const AnalysisGrid = ({
     return item;
   };
 
-  const renderContributions = (title: string, items: Contribution[]) => {
+  const renderContributions = (items: Contribution[]) => {
     if (!items || items.length === 0) return null;
     return (
       <Box sx={{ mb: 2, p: 1, bgcolor: 'action.hover', borderRadius: 1 }}>
         <Typography variant="caption" color="text.secondary" display="block" gutterBottom>
-          {title}
+          关键组合依据（已计入评分）
         </Typography>
         {items.map((c, i) => (
           <Box key={i} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.25 }}>
             <Chip label={c.label} size="small" color={c.weight >= 0 ? itemColor : 'default'} variant="outlined" />
-            <Typography variant="body2" color={c.weight >= 0 ? 'success.main' : 'error.main'} sx={{ ml: 1 }}>
-              {c.weight >= 0 ? '+' : '−'}{Math.abs(c.weight * 10).toFixed(1)}
-            </Typography>
+            <Tooltip title={fmtSigned(c.weight * 10)} arrow placement="top">
+              <Box
+                component="span"
+                role="img"
+                tabIndex={0}
+                aria-label={`${c.label}，${c.weight >= 0 ? '正向' : '负向'}组合影响`}
+                sx={{
+                  position: 'relative',
+                  width: 72,
+                  height: 14,
+                  ml: 1,
+                  flex: '0 0 72px',
+                  borderRadius: 1,
+                  bgcolor: 'action.selected',
+                  outline: 'none',
+                  '&:focus-visible': {
+                    boxShadow: (theme) => `0 0 0 2px ${theme.palette.primary.main}`,
+                  },
+                }}
+              >
+                <Box
+                  aria-hidden="true"
+                  sx={{
+                    position: 'absolute',
+                    top: 2,
+                    bottom: 2,
+                    left: '50%',
+                    width: '1px',
+                    bgcolor: 'divider',
+                  }}
+                />
+                <Box
+                  data-testid="combination-impact-bar"
+                  data-direction={c.weight >= 0 ? 'positive' : 'negative'}
+                  aria-hidden="true"
+                  sx={{
+                    position: 'absolute',
+                    top: 3,
+                    height: 8,
+                    width: `${maxCombinationMagnitude > 0 ? (Math.abs(c.weight) / maxCombinationMagnitude) * 50 : 0}%`,
+                    left:
+                      c.weight >= 0
+                        ? '50%'
+                        : `${50 - (maxCombinationMagnitude > 0 ? (Math.abs(c.weight) / maxCombinationMagnitude) * 50 : 0)}%`,
+                    bgcolor: c.weight >= 0 ? 'success.main' : 'error.main',
+                    borderRadius: 0.75,
+                  }}
+                />
+              </Box>
+            </Tooltip>
           </Box>
         ))}
       </Box>
@@ -98,7 +164,7 @@ const AnalysisGrid = ({
     }
 
     const gain = setAnalysis?.final_score;
-    const comboSynergies = setAnalysis?.combo_synergies ?? [];
+    const comboEvidence = combinationEvidence(setAnalysis);
 
     return (
       <Grid
@@ -186,9 +252,6 @@ const AnalysisGrid = ({
             </Box>
 
             <Box sx={{ mb: 2, minWidth: 0 }}>
-              <Typography component="div" variant="subtitle2" gutterBottom>
-                单项加分:
-              </Typography>
               {items.map((item, idx) => {
                 const itemScore = setAnalysis?.item_scores?.find((s) => s.item === item);
                 return (
@@ -205,9 +268,9 @@ const AnalysisGrid = ({
             </Box>
 
             <ResponsiveDisclosure label={`第${index + 1}组详细分析`}>
-              {renderContributions('组合加分项:', comboSynergies) ?? (
+              {renderContributions(comboEvidence) ?? (
                 <Typography variant="body2" color="text.secondary">
-                  暂无明显加分项。
+                  暂无关键组合依据。
                 </Typography>
               )}
             </ResponsiveDisclosure>

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -1,4 +1,4 @@
-import { Grid, Card, CardContent, Typography, Button, Box, Chip, Tooltip } from '@mui/material';
+import { Grid, Card, CardContent, Typography, Button, Box, Chip } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import StarIcon from '@mui/icons-material/Star';
 import { formatHeroRanking } from '../../utils/itemMetadata';
@@ -27,14 +27,6 @@ const isComboContribution = (contribution: Contribution): boolean =>
   contribution.family === 'HP' ||
   contribution.family === 'HS' ||
   contribution.family === 'SP';
-
-/** Stable, compact weak/medium/strong scale in display-score units. */
-const combinationImpactLevel = (weight: number): 1 | 2 | 3 => {
-  const magnitude = Math.abs(weight * 10);
-  if (magnitude >= 4) return 3;
-  if (magnitude >= 2) return 2;
-  return 1;
-};
 
 /**
  * Display 3 option sets as cards. Each card shows the option's per-round score
@@ -95,37 +87,18 @@ const AnalysisGrid = ({
         <Typography variant="caption" color="text.secondary" display="block" gutterBottom>
           关键组合依据（已计入评分）
         </Typography>
-        {items.map((c, i) => {
-          const level = combinationImpactLevel(c.weight);
-          const icon = c.weight >= 0 ? '👍' : '👎';
-          return (
-            <Box key={i} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.25 }}>
-              <Chip label={c.label} size="small" color={c.weight >= 0 ? itemColor : 'default'} variant="outlined" />
-              <Tooltip title={fmtSigned(c.weight * 10)} arrow placement="top">
-                <Box
-                  component="span"
-                  role="img"
-                  tabIndex={0}
-                  aria-label={`${c.label}，${c.weight >= 0 ? '正向' : '负向'}组合影响，强度${level}级`}
-                  sx={{
-                    minWidth: 72,
-                    ml: 1,
-                    textAlign: 'right',
-                    whiteSpace: 'nowrap',
-                    cursor: 'help',
-                    outline: 'none',
-                    '&:focus-visible': {
-                      borderRadius: 1,
-                      boxShadow: (theme) => `0 0 0 2px ${theme.palette.primary.main}`,
-                    },
-                  }}
-                >
-                  {icon.repeat(level)}
-                </Box>
-              </Tooltip>
-            </Box>
-          );
-        })}
+        {items.map((c, i) => (
+          <Box key={i} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.25 }}>
+            <Chip label={c.label} size="small" color={c.weight >= 0 ? itemColor : 'default'} variant="outlined" />
+            <Typography
+              variant="body2"
+              color={c.weight >= 0 ? 'success.main' : 'error.main'}
+              sx={{ ml: 1, fontVariantNumeric: 'tabular-nums' }}
+            >
+              {fmtSigned(c.weight * 10)}
+            </Typography>
+          </Box>
+        ))}
       </Box>
     );
   };

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -28,6 +28,14 @@ const isComboContribution = (contribution: Contribution): boolean =>
   contribution.family === 'HS' ||
   contribution.family === 'SP';
 
+/** Stable, compact weak/medium/strong scale in display-score units. */
+const combinationImpactLevel = (weight: number): 1 | 2 | 3 => {
+  const magnitude = Math.abs(weight * 10);
+  if (magnitude >= 4) return 3;
+  if (magnitude >= 2) return 2;
+  return 1;
+};
+
 /**
  * Display 3 option sets as cards. Each card shows the option's per-round score
  * (`评分：±X`, one decimal) — the marginal roster-strength gain that option adds
@@ -71,12 +79,6 @@ const AnalysisGrid = ({
       .sort((a, b) => Math.abs(b.weight) - Math.abs(a.weight))
       .slice(0, 5);
   };
-  const maxCombinationMagnitude = Math.max(
-    0,
-    ...(analysis ?? []).flatMap((option) =>
-      combinationEvidence(option).map((contribution) => Math.abs(contribution.weight))
-    )
-  );
 
   const itemChipLabel = (item: string) => {
     if (roundType === 'hero') {
@@ -93,61 +95,37 @@ const AnalysisGrid = ({
         <Typography variant="caption" color="text.secondary" display="block" gutterBottom>
           关键组合依据（已计入评分）
         </Typography>
-        {items.map((c, i) => (
-          <Box key={i} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.25 }}>
-            <Chip label={c.label} size="small" color={c.weight >= 0 ? itemColor : 'default'} variant="outlined" />
-            <Tooltip title={fmtSigned(c.weight * 10)} arrow placement="top">
-              <Box
-                component="span"
-                role="img"
-                tabIndex={0}
-                aria-label={`${c.label}，${c.weight >= 0 ? '正向' : '负向'}组合影响`}
-                sx={{
-                  position: 'relative',
-                  width: 72,
-                  height: 14,
-                  ml: 1,
-                  flex: '0 0 72px',
-                  borderRadius: 1,
-                  bgcolor: 'action.selected',
-                  outline: 'none',
-                  '&:focus-visible': {
-                    boxShadow: (theme) => `0 0 0 2px ${theme.palette.primary.main}`,
-                  },
-                }}
-              >
+        {items.map((c, i) => {
+          const level = combinationImpactLevel(c.weight);
+          const icon = c.weight >= 0 ? '👍' : '👎';
+          return (
+            <Box key={i} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.25 }}>
+              <Chip label={c.label} size="small" color={c.weight >= 0 ? itemColor : 'default'} variant="outlined" />
+              <Tooltip title={fmtSigned(c.weight * 10)} arrow placement="top">
                 <Box
-                  aria-hidden="true"
+                  component="span"
+                  role="img"
+                  tabIndex={0}
+                  aria-label={`${c.label}，${c.weight >= 0 ? '正向' : '负向'}组合影响，强度${level}级`}
                   sx={{
-                    position: 'absolute',
-                    top: 2,
-                    bottom: 2,
-                    left: '50%',
-                    width: '1px',
-                    bgcolor: 'divider',
+                    minWidth: 72,
+                    ml: 1,
+                    textAlign: 'right',
+                    whiteSpace: 'nowrap',
+                    cursor: 'help',
+                    outline: 'none',
+                    '&:focus-visible': {
+                      borderRadius: 1,
+                      boxShadow: (theme) => `0 0 0 2px ${theme.palette.primary.main}`,
+                    },
                   }}
-                />
-                <Box
-                  data-testid="combination-impact-bar"
-                  data-direction={c.weight >= 0 ? 'positive' : 'negative'}
-                  aria-hidden="true"
-                  sx={{
-                    position: 'absolute',
-                    top: 3,
-                    height: 8,
-                    width: `${maxCombinationMagnitude > 0 ? (Math.abs(c.weight) / maxCombinationMagnitude) * 50 : 0}%`,
-                    left:
-                      c.weight >= 0
-                        ? '50%'
-                        : `${50 - (maxCombinationMagnitude > 0 ? (Math.abs(c.weight) / maxCombinationMagnitude) * 50 : 0)}%`,
-                    bgcolor: c.weight >= 0 ? 'success.main' : 'error.main',
-                    borderRadius: 0.75,
-                  }}
-                />
-              </Box>
-            </Tooltip>
-          </Box>
-        ))}
+                >
+                  {icon.repeat(level)}
+                </Box>
+              </Tooltip>
+            </Box>
+          );
+        })}
       </Box>
     );
   };

--- a/web/src/components/game/__tests__/AnalysisGrid.test.tsx
+++ b/web/src/components/game/__tests__/AnalysisGrid.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import AnalysisGrid from '../AnalysisGrid';
 import type { OptionAnalysis } from '../../../services/recommendationEngine';
 
@@ -155,7 +155,7 @@ describe('AnalysisGrid player preference display', () => {
     expect(screen.queryByText(/T[0-9]/)).not.toBeInTheDocument();
   });
 
-  test('shows combination direction and strength with thumbs while keeping exact values in tooltips', async () => {
+  test('shows exact signed values for positive and negative combination evidence', () => {
     const combinationAnalysis = analysis.map((entry) => ({ ...entry }));
     combinationAnalysis[0] = {
       ...combinationAnalysis[0],
@@ -180,23 +180,9 @@ describe('AnalysisGrid player preference display', () => {
 
     expect(screen.queryByText('单项加分:')).not.toBeInTheDocument();
     expect(screen.getByText('关键组合依据（已计入评分）')).toBeInTheDocument();
-    expect(screen.queryByText('+4.5')).not.toBeInTheDocument();
-    expect(screen.queryByText('+3.6')).not.toBeInTheDocument();
-    expect(screen.queryByText('−1.8')).not.toBeInTheDocument();
-
-    expect(
-      screen.getByRole('img', { name: '戊 + 己，正向组合影响，强度3级' })
-    ).toHaveTextContent('👍👍👍');
-    expect(
-      screen.getByRole('img', { name: '甲 + 乙，正向组合影响，强度2级' })
-    ).toHaveTextContent('👍👍');
-    expect(
-      screen.getByRole('img', { name: '丙 + 丁，负向组合影响，强度1级' })
-    ).toHaveTextContent('👎');
-
-    fireEvent.mouseOver(
-      screen.getByRole('img', { name: '甲 + 乙，正向组合影响，强度2级' })
-    );
-    await waitFor(() => expect(screen.getByRole('tooltip')).toHaveTextContent('+3.6'));
+    expect(screen.getByText('+4.5')).toBeInTheDocument();
+    expect(screen.getByText('+3.6')).toBeInTheDocument();
+    expect(screen.getByText('−1.8')).toBeInTheDocument();
+    expect(screen.queryByText(/👍|👎/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/game/__tests__/AnalysisGrid.test.tsx
+++ b/web/src/components/game/__tests__/AnalysisGrid.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import AnalysisGrid from '../AnalysisGrid';
 import type { OptionAnalysis } from '../../../services/recommendationEngine';
 
@@ -10,6 +10,7 @@ const option = (setIndex: number, score: number): OptionAnalysis => ({
   item_scores: [],
   synergies: [],
   combo_synergies: [],
+  combo_tradeoffs: [],
   tradeoffs: [],
   evidence: { featureCount: 0, totalSupport: 0, minSupport: 0 },
 });
@@ -152,5 +153,40 @@ describe('AnalysisGrid player preference display', () => {
 
     expect(screen.getByText('战法甲')).toBeInTheDocument();
     expect(screen.queryByText(/T[0-9]/)).not.toBeInTheDocument();
+  });
+
+  test('shows combination direction and relative strength while keeping exact values in tooltips', async () => {
+    const combinationAnalysis = analysis.map((entry) => ({ ...entry }));
+    combinationAnalysis[0] = {
+      ...combinationAnalysis[0],
+      combo_synergies: [
+        { label: '甲 + 乙', family: 'HP', weight: 0.36, support: 20 },
+      ],
+      combo_tradeoffs: [
+        { label: '丙 + 丁', family: 'HP', weight: -0.18, support: 10 },
+      ],
+    };
+
+    render(
+      <AnalysisGrid
+        sets={sets}
+        analysis={combinationAnalysis}
+        selectedIndex={null}
+        onSelectSet={vi.fn()}
+        roundType="hero"
+      />
+    );
+
+    expect(screen.queryByText('单项加分:')).not.toBeInTheDocument();
+    expect(screen.getByText('关键组合依据（已计入评分）')).toBeInTheDocument();
+    expect(screen.queryByText('+3.6')).not.toBeInTheDocument();
+    expect(screen.queryByText('−1.8')).not.toBeInTheDocument();
+
+    const bars = screen.getAllByTestId('combination-impact-bar');
+    expect(bars[0]).toHaveAttribute('data-direction', 'positive');
+    expect(bars[1]).toHaveAttribute('data-direction', 'negative');
+
+    fireEvent.mouseOver(screen.getByRole('img', { name: '甲 + 乙，正向组合影响' }));
+    await waitFor(() => expect(screen.getByRole('tooltip')).toHaveTextContent('+3.6'));
   });
 });

--- a/web/src/components/game/__tests__/AnalysisGrid.test.tsx
+++ b/web/src/components/game/__tests__/AnalysisGrid.test.tsx
@@ -179,7 +179,8 @@ describe('AnalysisGrid player preference display', () => {
     );
 
     expect(screen.queryByText('单项加分:')).not.toBeInTheDocument();
-    expect(screen.getByText('关键组合依据（已计入评分）')).toBeInTheDocument();
+    expect(screen.queryByText('关键组合依据（已计入评分）')).not.toBeInTheDocument();
+    expect(screen.getByTestId('combination-evidence')).toBeInTheDocument();
     expect(screen.getByText('+4.5')).toBeInTheDocument();
     expect(screen.getByText('+3.6')).toBeInTheDocument();
     expect(screen.getByText('−1.8')).toBeInTheDocument();

--- a/web/src/components/game/__tests__/AnalysisGrid.test.tsx
+++ b/web/src/components/game/__tests__/AnalysisGrid.test.tsx
@@ -155,12 +155,13 @@ describe('AnalysisGrid player preference display', () => {
     expect(screen.queryByText(/T[0-9]/)).not.toBeInTheDocument();
   });
 
-  test('shows combination direction and relative strength while keeping exact values in tooltips', async () => {
+  test('shows combination direction and strength with thumbs while keeping exact values in tooltips', async () => {
     const combinationAnalysis = analysis.map((entry) => ({ ...entry }));
     combinationAnalysis[0] = {
       ...combinationAnalysis[0],
       combo_synergies: [
         { label: '甲 + 乙', family: 'HP', weight: 0.36, support: 20 },
+        { label: '戊 + 己', family: 'HP', weight: 0.45, support: 15 },
       ],
       combo_tradeoffs: [
         { label: '丙 + 丁', family: 'HP', weight: -0.18, support: 10 },
@@ -179,14 +180,23 @@ describe('AnalysisGrid player preference display', () => {
 
     expect(screen.queryByText('单项加分:')).not.toBeInTheDocument();
     expect(screen.getByText('关键组合依据（已计入评分）')).toBeInTheDocument();
+    expect(screen.queryByText('+4.5')).not.toBeInTheDocument();
     expect(screen.queryByText('+3.6')).not.toBeInTheDocument();
     expect(screen.queryByText('−1.8')).not.toBeInTheDocument();
 
-    const bars = screen.getAllByTestId('combination-impact-bar');
-    expect(bars[0]).toHaveAttribute('data-direction', 'positive');
-    expect(bars[1]).toHaveAttribute('data-direction', 'negative');
+    expect(
+      screen.getByRole('img', { name: '戊 + 己，正向组合影响，强度3级' })
+    ).toHaveTextContent('👍👍👍');
+    expect(
+      screen.getByRole('img', { name: '甲 + 乙，正向组合影响，强度2级' })
+    ).toHaveTextContent('👍👍');
+    expect(
+      screen.getByRole('img', { name: '丙 + 丁，负向组合影响，强度1级' })
+    ).toHaveTextContent('👎');
 
-    fireEvent.mouseOver(screen.getByRole('img', { name: '甲 + 乙，正向组合影响' }));
+    fireEvent.mouseOver(
+      screen.getByRole('img', { name: '甲 + 乙，正向组合影响，强度2级' })
+    );
     await waitFor(() => expect(screen.getByRole('tooltip')).toHaveTextContent('+3.6'));
   });
 });

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -101,6 +101,26 @@ describe('recommendHeroSet — marginal roster-strength ranking', () => {
     const b = recommendHeroSet([['strong', 'x', 'y'], ['weak', 'x', 'y']], ['ally'], data);
     expect(a).toEqual(b);
   });
+
+  test('surfaces negative combo evidence separately from atomic tradeoffs', () => {
+    const negativeComboData = makeData({
+      weights: {
+        'H|candidate': 0.2,
+        'HP|ally|candidate': -0.6,
+      },
+      support: {
+        'H|candidate': 50,
+        'HP|ally|candidate': 20,
+      },
+      n_features: 2,
+    });
+
+    const result = recommendHeroSet([['candidate']], ['ally'], negativeComboData);
+
+    expect(result.analysis[0].combo_tradeoffs).toEqual([
+      expect.objectContaining({ family: 'HP', weight: -0.6 }),
+    ]);
+  });
 });
 
 describe('recommendSkillSet — best hero-routing', () => {

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -73,6 +73,8 @@ export interface OptionAnalysis {
    * dominant single-item H/S weights can never crowd real combos out.
    */
   combo_synergies: Contribution[];
+  /** Strongest negative combo contributions, kept separate from atomic tradeoffs. */
+  combo_tradeoffs: Contribution[];
   /** Notable negative contributions (tradeoffs) this option brings. */
   tradeoffs: Contribution[];
   /** Aggregate evidence behind the option's score. */
@@ -158,6 +160,13 @@ const displayScore = (x: number): number => roundTo(x * 10, 1);
  */
 const topComboSynergies = (contributions: Contribution[]): Contribution[] =>
   contributions.filter((c) => c.weight > 0 && c.family !== 'H' && c.family !== 'S').slice(0, 5);
+
+/** Most negative combo contributions, ordered by absolute impact. */
+const topComboTradeoffs = (contributions: Contribution[]): Contribution[] =>
+  contributions
+    .filter((c) => c.weight < 0 && c.family !== 'H' && c.family !== 'S')
+    .sort((a, b) => a.weight - b.weight)
+    .slice(0, 5);
 
 /**
  * Route a non-default skill to the current hero that maximises its
@@ -271,6 +280,7 @@ export function recommendHeroSet(
       item_scores,
       synergies: contributions.filter((c) => c.weight > 0).slice(0, 5),
       combo_synergies: topComboSynergies(contributions),
+      combo_tradeoffs: topComboTradeoffs(contributions),
       tradeoffs: contributions.filter((c) => c.weight < 0).slice(0, 3),
       evidence: ev,
     };
@@ -330,6 +340,7 @@ export function recommendSkillSet(
       item_scores,
       synergies: contributions.filter((c) => c.weight > 0).slice(0, 5),
       combo_synergies: topComboSynergies(contributions),
+      combo_tradeoffs: topComboTradeoffs(contributions),
       tradeoffs: contributions.filter((c) => c.weight < 0).slice(0, 3),
       evidence: {
         featureCount: contributions.length,

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -302,10 +302,13 @@ test.describe('Accessibility and responsive layout', () => {
     await expect(page.getByTestId('option-score-0')).toBeVisible();
     await expect(page.getByText(/火力/)).toHaveCount(0);
 
-    // Expanding reveals the compact 组合加分项 detail (or its empty-state).
+    // Expanding reveals the compact combination evidence (or its empty-state).
     await firstDetails.click();
     await expect(
-      page.getByText('组合加分项:').or(page.getByText('暂无明显加分项。')).first(),
+      page
+        .getByText('关键组合依据（已计入评分）')
+        .or(page.getByText('暂无关键组合依据。'))
+        .first(),
     ).toBeVisible();
     await expect(page.getByText('推荐理由:')).toHaveCount(0);
     await expect(page.getByText('可能减分项:')).toHaveCount(0);

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -306,7 +306,7 @@ test.describe('Accessibility and responsive layout', () => {
     await firstDetails.click();
     await expect(
       page
-        .getByText('关键组合依据（已计入评分）')
+        .getByTestId('combination-evidence')
         .or(page.getByText('暂无关键组合依据。'))
         .first(),
     ).toBeVisible();

--- a/web/tests/optionAnalysisLabels.spec.js
+++ b/web/tests/optionAnalysisLabels.spec.js
@@ -59,8 +59,8 @@ test.describe('选项分析 — hero & skill labels', () => {
       await expect(optionScore).toHaveText(/评分：[+−]\d+\.\d/);
     }
 
-    // Plain 单项加分 heading remains.
-    await expect(page.getByText('单项加分:').first()).toBeVisible();
+    // Candidate rows stay visible without a misleading additive heading.
+    await expect(page.getByText('单项加分:')).toHaveCount(0);
 
     // The standalone fire baseline panel and all fire bars are gone.
     await expect(page.getByTestId('fire-baseline-card')).toHaveCount(0);
@@ -79,7 +79,7 @@ test.describe('选项分析 — hero & skill labels', () => {
     await expect(page.getByText(/项特征/)).toHaveCount(0);
   });
 
-  test('hero round: candidate chips under 单项加分 show hero ranking', async ({ page }) => {
+  test('hero round: candidate chips show hero ranking', async ({ page }) => {
     // 4 team heroes + 9 distinct candidate heroes (3 per option set), all with metadata.
     const team = heroesWithMeta.slice(0, 4);
     const candidates = heroesWithMeta.slice(4, 13);
@@ -104,7 +104,7 @@ test.describe('选项分析 — hero & skill labels', () => {
     }
   });
 
-  test('skill round: candidate chips under 单项加分 stay as bare names', async ({ page }) => {
+  test('skill round: candidate chips stay as bare names', async ({ page }) => {
     const team = heroesWithMeta.slice(0, 4);
     const candidates = anySkills(9);
 


### PR DESCRIPTION
## Intent

Clarify the option-analysis scoring UI so players do not mistakenly add explanatory combination evidence to the displayed 评分 a second time. Remove the misleading 单项加分 heading and, following the final design decision, also remove the 关键组合依据（已计入评分） heading while retaining the compact combination rows. Show exact signed numeric combination values directly—no impact bars, emoji strength scale, or hover-only values—and include both positive and negative HP/HS/SP combination evidence. Do not change recommendation scoring or ranking behavior.

## What Changed

- Reworked the 选项分析 grid (`AnalysisGrid.tsx`) so combination evidence reads as already-counted context rather than an addable bonus: removed the misleading `单项加分:` heading and the `关键组合依据（已计入评分）` heading, kept the compact combination rows, and now render exact signed one-decimal values (`fmtSigned`, tabular-nums) with no impact bars, emoji strength scale, or hover-only values.
- The detailed-analysis disclosure now shows both positive and negative HP/HS/SP evidence together — merging `combo_synergies` and `combo_tradeoffs`, filtering to combo families, and sorting the top 5 by absolute weight — with the empty state updated to `暂无关键组合依据`.
- Added a `combo_tradeoffs` field to `OptionAnalysis` and a `topComboTradeoffs` helper in `recommendationEngine.ts`, populated for both hero and skill option sets; scoring and ranking logic is unchanged. Covered by new `AnalysisGrid` and `recommendationEngine` unit tests plus updated Playwright label/accessibility specs.

## Risk Assessment

✅ Low: Small, well-tested, display-only UI change that adds a new derived analysis field without touching scoring or ranking, and it satisfies every intent constraint.

## Testing

Set up the web workspace under Node 22 and exercised the full changed surface: the Vitest unit suite (396 tests) and Go-native typecheck both pass, and the two modified Playwright e2e specs pass 16/16. For reviewer-visible proof I drove the real app through a seeded hero round crafted to produce both signs of combination evidence, expanded the detail disclosures, and captured a screenshot — it shows candidate rows with no `单项加分:` heading, combination rows with no `关键组合依据` heading, exact signed values in green positive (+12.7, +11.7, +2.9) and red negative (−9.6, −2.5, −4.0, −3.5), and no emoji or impact bars, while the 评分 and option ranking are unchanged. All green; no issues found.

- Evidence: Rendered 选项分析 card — signed positive &amp; negative combination-evidence rows, no additive/combo headings, no emoji/bars (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYXH264G28M4S39TGDXCXPSN/option-analysis-combination-evidence.png</code>)
<details>
<summary>Evidence: Actual first-option combination rows rendered in the browser</summary>

```text
COMBO_ROWS ["祝融 + 貂蝉 +12.7","甘夫人 + 赵云 +11.7","姜维 + 张飞 −9.6","大乔 + 祝融 +2.9","姜维 + 貂蝉 −2.5"]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Node 22 (v22.17.1) + `pnpm install --frozen-lockfile` in web/ (Node 20 skips rolldown native binding)</code>
- <code>`pnpm test` (Vitest) — 396 unit tests pass, including new AnalysisGrid test (no `单项加分:`/`关键组合依据` headings, signed +4.5/+3.6/−1.8 values, no 👍/👎) and recommendationEngine `combo_tradeoffs` test</code>
- <code>`pnpm typecheck` (Go-native tsc) — clean</code>
- <code>`pnpm exec playwright test tests/optionAnalysisLabels.spec.js tests/accessibilityLayout.spec.js` — 16/16 pass</code>
- `Manual visual evidence: temporary Playwright spec seeded a hero round (team 赵云/张飞/貂蝉/大乔, option A 甘夫人/姜维/祝融) to force both positive and negative combos, expanded each 详细分析 disclosure, and screenshotted the rendered 选项分析 grid; temp spec removed afterward`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
