### PR TITLE
fix(web): dedupe hero team directions in KnownStrongTeams

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -193,8 +193,10 @@ selected skills.
   keeps live per-team model scores, uses matched formations from
   `database.json`, and supports drag/drop plus tap-to-place on mobile.
 - **KnownStrongTeams**: Filters the imported strong/championship library against
-  the acquired pool and the current offers. Hero rounds keep cards concise;
-  skill rounds reveal the source formation and both per-hero skill slots.
+  the acquired pool and the current offers. Hero rounds keep cards concise and
+  collapse same-roster build variants (whose skill differences are hidden) into a
+  single direction so distinct rosters fill the remaining slots; skill rounds keep
+  those variants and reveal the source formation and both per-hero skill slots.
 
 ### 演武攻略
 

--- a/web/src/components/game/KnownStrongTeams.tsx
+++ b/web/src/components/game/KnownStrongTeams.tsx
@@ -225,23 +225,40 @@ const MemberCard = ({
 const HERO_SHORTLIST_LIMIT = 6;
 const SKILL_SHORTLIST_LIMIT = 4;
 
+const distinctHeroRosters = (
+  entries: RelevantTeamComp[]
+): RelevantTeamComp[] => {
+  const seenRosters = new Set<string>();
+  return entries.filter(({ comp }) => {
+    const rosterKey = comp.members
+      .map((member) => member.hero)
+      .sort()
+      .join('|');
+    if (seenRosters.has(rosterKey)) return false;
+    seenRosters.add(rosterKey);
+    return true;
+  });
+};
+
 const heroRoundShortlist = (
   relevant: RelevantTeamComp[],
   candidateHeroes: string[]
 ): RelevantTeamComp[] => {
   if (candidateHeroes.length === 0) {
-    return relevant.slice(0, HERO_SHORTLIST_LIMIT);
+    return distinctHeroRosters(relevant).slice(0, HERO_SHORTLIST_LIMIT);
   }
 
   const candidateSet = new Set(candidateHeroes);
   const representedCandidates = new Set<string>();
   const selectedIds = new Set<string>();
   const shortlist: RelevantTeamComp[] = [];
-  const actionable = [...relevant].sort(
-    (left, right) =>
-      right.selectedCount - left.selectedCount ||
-      right.candidateCount - left.candidateCount ||
-      compareKnownTeamStrength(left, right)
+  const actionable = distinctHeroRosters(
+    [...relevant].sort(
+      (left, right) =>
+        right.selectedCount - left.selectedCount ||
+        right.candidateCount - left.candidateCount ||
+        compareKnownTeamStrength(left, right)
+    )
   );
 
   // Prefer strong entries that introduce a different offered hero, so the
@@ -288,9 +305,11 @@ const skillRoundShortlist = (
 /**
  * 本轮阵容方向 — a small, actionable guide-backed shortlist.
  *
- * Hero rounds diversify across offered heroes and show no skills. Skill rounds
- * only show teams where an offered skill fills a recommended slot. The full
- * catalogue remains on the Yanwu guide page.
+ * Hero rounds diversify across offered heroes, hide skills, and collapse build
+ * variants that share one roster. Skill rounds keep those variants because
+ * their different skill plans are visible, but only show teams where an offered
+ * skill fills a recommended slot. The full catalogue remains on the Yanwu guide
+ * page.
  */
 export interface KnownStrongTeamsProps {
   selectedHeroes?: string[];

--- a/web/src/components/game/__tests__/KnownStrongTeams.test.tsx
+++ b/web/src/components/game/__tests__/KnownStrongTeams.test.tsx
@@ -256,4 +256,58 @@ describe('KnownStrongTeams', () => {
     );
     expect(screen.getAllByTestId('known-team-card')).toHaveLength(4);
   });
+
+  test('collapses same-roster build variants only when their skills are hidden', () => {
+    const championshipVariant: TeamComp = {
+      ...championshipTeam,
+      id: 'championship-2',
+      members: championshipTeam.members.map((member, memberIndex) => ({
+        ...member,
+        skillSlots:
+          memberIndex === 0
+            ? [['胜敌益强'], ['及锋而试']]
+            : member.skillSlots,
+      })) as TeamComp['members'],
+    };
+    const variantEntries = [
+      relevant[0],
+      {
+        ...relevant[0],
+        comp: championshipVariant,
+      },
+      {
+        ...relevant[1],
+        selectedCount: 1,
+        candidateSkillCount: 1,
+      },
+    ];
+    promptMocks.selectRelevantTeamComps.mockReturnValue(variantEntries);
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <KnownStrongTeams
+          selectedHeroes={['司马懿', '孙权']}
+          candidateHeroes={['曹操', '陆逊']}
+          roundType="hero"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByTestId('known-team-card')).toHaveLength(2);
+    expect(screen.getByText('推荐 2 组')).toBeInTheDocument();
+    unmount();
+
+    render(
+      <MemoryRouter>
+        <KnownStrongTeams
+          selectedHeroes={['司马懿', '孙权']}
+          candidateSkills={['潜龙在渊']}
+          roundType="skill"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByTestId('known-team-card')).toHaveLength(3);
+    expect(screen.getByText('推荐 3 组')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Intent

Fix the web bug in 本轮阵容方向 where hero rounds repeat the same three-hero roster because database.json contains legitimate build variants with different skill loadouts. Keep database.json and the full Yanwu guide unchanged because those variants are valid source data. In hero rounds only, where skills are hidden, collapse same-roster variants to one visible direction and let distinct rosters use the remaining shortlist slots; preserve all variants in skill rounds where their skill differences are visible and useful. Add regression coverage for both behaviors, validate the web workspace, and create a pull request.

## What Changed

- In `KnownStrongTeams.tsx`, hero rounds (where skills are hidden) now collapse `database.json` build variants that share the same three-hero roster into a single visible 本轮阵容方向, letting distinct rosters fill the remaining shortlist slots instead of repeating one roster.
- Skill rounds are left untouched, preserving every build variant so their differing skill loadouts stay visible; `database.json` and the Yanwu guide data are unchanged.
- Added `KnownStrongTeams.test.tsx` regression coverage asserting variants collapse only in hero rounds and remain distinct in skill rounds, and documented the round-specific dedupe behavior in `web/README.md`.

## Risk Assessment

✅ Low: The change is a small, well-bounded UI helper that dedupes hero-round rosters exactly per the stated intent, leaves skill rounds and source data untouched, and adds direct regression coverage for both behaviors.

## Testing

Ran the web workspace's full Vitest unit suite (397 tests, Node 22) — all pass, including the added regression test that pins hero-round collapse (2 cards) and skill-round preservation (3 cards) — and a clean `pnpm typecheck`. For reviewer-visible proof of the actual UI, I rendered the real component with a bug-shaped input (two same-roster 司马懿·曹操·满宠 variants with different skills plus a distinct 孙权·陆逊·陆抗 roster) and captured a Playwright screenshot: the hero round shows 推荐 2 组 with the variants collapsed to one direction and skills hidden, while the skill round shows 推荐 3 组 with both variants retained and their distinct 战法 visible — exactly the intended behavior. The diff only touches the component and its test, so database.json and the Yanwu guide remain unchanged.

- Evidence: Hero vs skill round rendering — variants collapse in hero round (推荐 2 组), preserved in skill round (推荐 3 组) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KYXZFDYX46KHHADG8KK7DKS4/known-strong-teams-rounds.png</code>)
<details>
<summary>Evidence: Rendered HTML source of both panels</summary>

```text
<!DOCTYPE html>
<html><head><meta name="emotion-insertion-point" content=""><style data-emotion="css" data-s="">.css-7mj0f2-MuiPaper-root{background-color:#fff;color:rgba(0, 0, 0, 0.87);-webkit-transition:box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;transition:box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;border-radius:4px;box-shadow:var(--Paper-shadow);background-image:var(--Paper-overlay);margin-bottom:24px;overflow:hidden;}</style><style data-emotion="css" data-s="">@media (min-width:0px){.css-7mj0f2-MuiPaper-root{padding:16px;}}</style><style data-emotion="css" data-s="">@media (min-width:600px){.css-7mj0f2-MuiPaper-root{padding:24px;}}</style><style data-emotion="css" data-s="">.css-1wz3ek4{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;gap:8px;margin-bottom:18px;}</style><style data-emotion="css" data-s="">@media (min-width:0px){.css-1wz3ek4{-webkit-align-items:flex-start;-webkit-box-align:flex-start;-ms-flex-align:flex-start;align-items:flex-start;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}}</style><style data-emotion="css" data-s="">@media (min-width:600px){.css-1wz3ek4{-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;-webkit-flex-direction:row;-ms-flex-direction:row;flex-direction:row;}}</style><style data-emotion="css" data-s="">.css-0{}</style><style data-emotion="css" data-s="">.css-11t88x6-MuiTypography-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:400;font-size:0.75rem;line-height:2.66;letter-spacing:0.08333em;text-transform:uppercase;color:#d32f2f;}</style><style data-emotion="css" data-s="">.css-1miy0lu-MuiTypography-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:500;font-size:1.25rem;line-height:1.6;letter-spacing:0.0075em;}</style><style data-emotion="css" data-s="">.css-n0ucam{}</style><style data-emotion="css" data-s="">@media (min-width:0px){.css-n0ucam{text-align:left;}}</style><style data-emotion="css" data-s="">@media (min-width:600px){.css-n0ucam{text-align:right;}}</style><style data-emotion="css" data-s="">.css-3tryrp-MuiTypography-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:400;font-size:0.875rem;line-height:1.43;letter-spacing:0.01071em;color:rgba(0, 0, 0, 0.6);white-space:nowrap;}</style><style data-emotion="css" data-s="">.css-lvnrwm-MuiLink-root{-webkit-text-decoration:none;text-decoration:none;display:inline-block;margin-top:2.8px;}</style><style data-emotion="css" data-s="">.css-lvnrwm-MuiLink-root:hover{-webkit-text-decoration:underline;text-decoration:underline;}</style><style data-emotion="css" data-s="">.css-1q4vht9-MuiTypography-root-MuiLink-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:400;font-size:0.75rem;line-height:1.66;letter-spacing:0.03333em;color:#1976d2;-webkit-text-decoration:none;text-decoration:none;display:inline-block;margin-top:2.8px;}</style><style data-emotion="css" data-s="">.css-1q4vht9-MuiTypography-root-MuiLink-root:hover{-webkit-text-decoration:underline;text-decoration:underline;}</style><style data-emotion="css" data-s="">.css-1qxtbqe{list-style:none;margin:0px;padding:0px;display:grid;gap:10px;}</style><style data-emotion="css" data-s="">@media (min-width:0px){.css-1qxtbqe{grid-template-columns:minmax(0, 1fr);}}</style><style data-emotion="css" data-s="">@media (min-width:1536px){.css-1qxtbqe{grid-template-columns:repeat(2, minmax(0, 1fr));}}</style><style data-emotion="css" data-s="">.css-zev2rh{display:grid;border:1px solid;border-color:rgba(0, 0, 0, 0.12);background-color:rgba(251,248,239,0.72);box-shadow:none;}</style><style data-emotion="css" data-s="">@media (min-width:0px){.css-zev2rh{grid-template-columns:62px minmax(0, 1fr);}}</style><style data-emotion="css" data-s="">@media (min-width:600px){.css-zev2rh{grid-template-columns:76px minmax(0, 1fr);}}</style><style data-emotion="css" data-s="">.css-1dnm5ei{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-box-pack:center;-ms-flex-pack:center;-webkit-justify-content:center;justify-content:center;background-color:#e7dfcc;color:rgba(0, 0, 0, 0.87);border-right:1px solid;border-color:rgba(0, 0, 0, 0.12);padding-left:4.8px;padding-right:4.8px;padding-top:8px;padding-bottom:8px;text-align:center;}</style><style data-emotion="css" data-s="">.css-197qu69-MuiTypography-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:400;font-size:1rem;line-height:1.5;letter-spacing:0.00938em;font-family:Georgia,serif;font-weight:800;font-size:19px;line-height:1.15;}</style><style data-emotion="css" data-s="">.css-c9ypkc-MuiTypography-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:400;font-size:0.75rem;line-height:1.66;letter-spacing:0.03333em;opacity:0.78;font-size:10px;line-height:1.2;margin-top:2px;}</style><style data-emotion="css" data-s="">.css-31l7gp{min-width:0;}</style><style data-emotion="css" data-s="">.css-x1lk20{padding-left:8px;padding-right:8px;padding-top:5.2px;padding-bottom:5.2px;border-bottom:1px solid;border-color:rgba(0, 0, 0, 0.12);}</style><style data-emotion="css" data-s="">.css-1baypqb-MuiTypography-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:400;font-size:0.75rem;line-height:1.66;letter-spacing:0.03333em;color:rgba(0, 0, 0, 0.6);font-weight:750;}</style><style data-emotion="css" data-s="">.css-u6zhab{display:grid;grid-template-columns:repeat(3, minmax(0, 1fr));gap:6px;padding:6px;}</style><style data-emotion="css" data-s="">.css-smryt2{min-width:0;padding-left:8.8px;padding-right:8.8px;padding-top:7.2px;padding-bottom:7.2px;border-top:3px solid;border-color:#1976d2;background-color:rgba(69,108,95,0.10);}</style><style data-emotion="css" data-s="">.css-1fm6lu4-MuiTypography-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:400;font-size:0.875rem;line-height:1.43;letter-spacing:0.01071em;font-weight:750;line-height:1.3;overflow-wrap:anywhere;}</style><style data-emotion="css" data-s="">.css-s45hww-MuiTypography-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:400;font-size:0.75rem;line-height:1.66;letter-spacing:0.03333em;color:rgba(0, 0, 0, 0.6);display:block;margin-top:2.8px;letter-spacing:0.04em;}</style><style data-emotion="css" data-s="">.css-1f2m1jc{min-width:0;padding-left:8.8px;padding-right:8.8px;padding-top:7.2px;padding-bottom:7.2px;border-top:3px solid;border-color:#d32f2f;background-color:rgba(168,57,47,0.07);}</style><style data-emotion="css" data-s="">.css-x8na1j-MuiTypography-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:400;font-size:0.75rem;line-height:1.66;letter-spacing:0.03333em;color:#c62828;display:block;margin-top:2.8px;letter-spacing:0.04em;}</style><style data-emotion="css" data-s="">.css-443dxl{min-width:0;padding-left:8.8px;padding-right:8.8px;padding-top:7.2px;padding-bottom:7.2px;border-top:3px solid;border-color:rgba(0, 0, 0, 0.12);border-style:dashed;background-color:rgba(29,36,33,0.035);color:rgba(0, 0, 0, 0.6);}</style><style data-emotion="css" data-s="">.css-3wwm8g-MuiTypography-root{margin:0;font-family:"Roboto","Helvetica","Arial",sans-serif;font-weight:400;font-size:0.875rem;line-height:1.43;letter-spacing:0.01071em;font-weight:550;line-height:1.3;overflow-wrap:anywhere;}</style><style data-emotion="css" data-s="">.css-sb637v{display:grid;border:1px solid;border-color:#b89543;background-color:rgba(181,137,48,0.07);box-shadow:inset 3px 0 0 rgba(181,137,48,0.55);}</style><style data-emotion="css" data-s="">@media (min-width:0px){.css-sb637v{grid-template-columns:62px minmax(0, 1fr);}}</style><style data-emotion="css" data-s="">@media (min-width:600px){.css-sb637v{grid-template-columns:76px minmax(0, 1fr);}}</style><style data-emotion="css" data-s="">.css-47hk17{dis

... [18498 bytes truncated] ...

v class="MuiBox-root css-31l7gp"><div class="MuiBox-root css-443dxl" aria-label="曹操：尚未获得"><p class="MuiTypography-root MuiTypography-body2 css-3wwm8g-MuiTypography-root">曹操</p><span class="MuiTypography-root MuiTypography-caption css-s45hww-MuiTypography-root" data-testid="known-team-hero-status">尚未获得</span></div><div class="MuiBox-root css-xvir1"><div class="MuiBox-root css-1nfme9z" data-testid="known-team-skill-slot"><span class="MuiTypography-root MuiTypography-caption css-1x0vu9r-MuiTypography-root">战法位1</span><div class="MuiBox-root css-w9mang"><span class="MuiBox-root css-31l7gp" aria-label="披坚执锐：尚未获得"><span class="MuiTypography-root MuiTypography-caption css-ydu5ta-MuiTypography-root" data-testid="known-team-skill-status">披坚执锐</span><span class="MuiTypography-root MuiTypography-caption css-1y10l38-MuiTypography-root">尚未获得</span></span></div></div><div class="MuiBox-root css-1nfme9z" data-testid="known-team-skill-slot"><span class="MuiTypography-root MuiTypography-caption css-1x0vu9r-MuiTypography-root">战法位2</span><div class="MuiBox-root css-w9mang"><span class="MuiBox-root css-31l7gp" aria-label="百战不殆：尚未获得"><span class="MuiTypography-root MuiTypography-caption css-ydu5ta-MuiTypography-root" data-testid="known-team-skill-status">百战不殆</span><span class="MuiTypography-root MuiTypography-caption css-1y10l38-MuiTypography-root">尚未获得</span></span></div></div></div></div><div class="MuiBox-root css-31l7gp"><div class="MuiBox-root css-443dxl" aria-label="满宠：尚未获得"><p class="MuiTypography-root MuiTypography-body2 css-3wwm8g-MuiTypography-root">满宠</p><span class="MuiTypography-root MuiTypography-caption css-s45hww-MuiTypography-root" data-testid="known-team-hero-status">尚未获得</span></div><div class="MuiBox-root css-xvir1"><div class="MuiBox-root css-1nfme9z" data-testid="known-team-skill-slot"><span class="MuiTypography-root MuiTypography-caption css-1x0vu9r-MuiTypography-root">战法位1</span><div class="MuiBox-root css-w9mang"><span class="MuiBox-root css-31l7gp" aria-label="蓄势待发：尚未获得"><span class="MuiTypography-root MuiTypography-caption css-ydu5ta-MuiTypography-root" data-testid="known-team-skill-status">蓄势待发</span><span class="MuiTypography-root MuiTypography-caption css-1y10l38-MuiTypography-root">尚未获得</span></span></div></div><div class="MuiBox-root css-1nfme9z" data-testid="known-team-skill-slot"><span class="MuiTypography-root MuiTypography-caption css-1x0vu9r-MuiTypography-root">战法位2</span><div class="MuiBox-root css-w9mang"><span class="MuiBox-root css-31l7gp" aria-label="青囊急救：尚未获得"><span class="MuiTypography-root MuiTypography-caption css-ydu5ta-MuiTypography-root" data-testid="known-team-skill-status">青囊急救</span><span class="MuiTypography-root MuiTypography-caption css-1y10l38-MuiTypography-root">尚未获得</span></span></div></div></div></div></div></div></li><li class="MuiBox-root css-zev2rh" data-testid="known-team-card" aria-label="S级阵容，阵型箕形阵，孙权、陆逊、陆抗"><div class="MuiBox-root css-1dnm5ei"><p class="MuiTypography-root MuiTypography-body1 css-197qu69-MuiTypography-root" data-testid="team-ranking">S</p><span class="MuiTypography-root MuiTypography-caption css-c9ypkc-MuiTypography-root">强度</span></div><div class="MuiBox-root css-31l7gp"><div class="MuiBox-root css-x1lk20"><span class="MuiTypography-root MuiTypography-caption css-1baypqb-MuiTypography-root">阵型 · 箕形阵</span></div><div class="MuiBox-root css-2d72lb"><div class="MuiBox-root css-31l7gp"><div class="MuiBox-root css-smryt2" aria-label="孙权：已获得"><p class="MuiTypography-root MuiTypography-body2 css-1fm6lu4-MuiTypography-root">孙权</p><span class="MuiTypography-root MuiTypography-caption css-s45hww-MuiTypography-root" data-testid="known-team-hero-status">已获得</span></div><div class="MuiBox-root css-xvir1"><div class="MuiBox-root css-1nfme9z" data-testid="known-team-skill-slot"><span class="MuiTypography-root MuiTypography-caption css-1x0vu9r-MuiTypography-root">战法位1</span><div class="MuiBox-root css-w9mang"><span class="MuiBox-root css-31l7gp" aria-label="指点乾坤：尚未获得"><span class="MuiTypography-root MuiTypography-caption css-ydu5ta-MuiTypography-root" data-testid="known-team-skill-status">指点乾坤</span><span class="MuiTypography-root MuiTypography-caption css-1y10l38-MuiTypography-root">尚未获得</span></span></div></div><div class="MuiBox-root css-1nfme9z" data-testid="known-team-skill-slot"><span class="MuiTypography-root MuiTypography-caption css-1x0vu9r-MuiTypography-root">战法位2</span><div class="MuiBox-root css-w9mang"><span class="MuiBox-root css-31l7gp" aria-label="烈火焚营：尚未获得"><span class="MuiTypography-root MuiTypography-caption css-ydu5ta-MuiTypography-root" data-testid="known-team-skill-status">烈火焚营</span><span class="MuiTypography-root MuiTypography-caption css-1y10l38-MuiTypography-root">尚未获得</span></span></div></div></div></div><div class="MuiBox-root css-31l7gp"><div class="MuiBox-root css-443dxl" aria-label="陆逊：尚未获得"><p class="MuiTypography-root MuiTypography-body2 css-3wwm8g-MuiTypography-root">陆逊</p><span class="MuiTypography-root MuiTypography-caption css-s45hww-MuiTypography-root" data-testid="known-team-hero-status">尚未获得</span></div><div class="MuiBox-root css-xvir1"><div class="MuiBox-root css-1nfme9z" data-testid="known-team-skill-slot"><span class="MuiTypography-root MuiTypography-caption css-1x0vu9r-MuiTypography-root">战法位1</span><div class="MuiBox-root css-w9mang"><span class="MuiBox-root css-31l7gp" aria-label="风助火势：尚未获得"><span class="MuiTypography-root MuiTypography-caption css-ydu5ta-MuiTypography-root" data-testid="known-team-skill-status">风助火势</span><span class="MuiTypography-root MuiTypography-caption css-1y10l38-MuiTypography-root">尚未获得</span></span></div></div><div class="MuiBox-root css-1nfme9z" data-testid="known-team-skill-slot"><span class="MuiTypography-root MuiTypography-caption css-1x0vu9r-MuiTypography-root">战法位2</span><div class="MuiBox-root css-w9mang"><span class="MuiBox-root css-31l7gp" aria-label="明其虚实：尚未获得"><span class="MuiTypography-root MuiTypography-caption css-ydu5ta-MuiTypography-root" data-testid="known-team-skill-status">明其虚实</span><span class="MuiTypography-root MuiTypography-caption css-1y10l38-MuiTypography-root">尚未获得</span></span></div></div></div></div><div class="MuiBox-root css-31l7gp"><div class="MuiBox-root css-443dxl" aria-label="陆抗：尚未获得"><p class="MuiTypography-root MuiTypography-body2 css-3wwm8g-MuiTypography-root">陆抗</p><span class="MuiTypography-root MuiTypography-caption css-s45hww-MuiTypography-root" data-testid="known-team-hero-status">尚未获得</span></div><div class="MuiBox-root css-xvir1"><div class="MuiBox-root css-1nfme9z" data-testid="known-team-skill-slot"><span class="MuiTypography-root MuiTypography-caption css-1x0vu9r-MuiTypography-root">战法位1</span><div class="MuiBox-root css-w9mang"><span class="MuiBox-root css-31l7gp" aria-label="折冲御侮：尚未获得"><span class="MuiTypography-root MuiTypography-caption css-ydu5ta-MuiTypography-root" data-testid="known-team-skill-status">折冲御侮</span><span class="MuiTypography-root MuiTypography-caption css-1y10l38-MuiTypography-root">尚未获得</span></span></div></div><div class="MuiBox-root css-1nfme9z" data-testid="known-team-skill-slot"><span class="MuiTypography-root MuiTypography-caption css-1x0vu9r-MuiTypography-root">战法位2</span><div class="MuiBox-root css-w9mang"><span class="MuiBox-root css-31l7gp" aria-label="御敌临前：尚未获得"><span class="MuiTypography-root MuiTypography-caption css-ydu5ta-MuiTypography-root" data-testid="known-team-skill-status">御敌临前</span><span class="MuiTypography-root MuiTypography-caption css-1y10l38-MuiTypography-root">尚未获得</span></span></div></div></div></div></div></div></li></ol></div></div></div></body></html>
```
</details>
<details>
<summary>Evidence: Playwright card-count assertions from the rendered surface</summary>

```text
HERO_CARDS=2
SKILL_CARDS=3
HERO_HEADER=推荐 2 组
SKILL_HEADER=推荐 3 组
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm test` (Vitest, Node 22) — full web unit suite, 397 tests pass including the new `collapses same-roster build variants only when their skills are hidden` regression test</code>
- <code>`pnpm typecheck` (Go-native tsc) — clean</code>
- `Rendered the real KnownStrongTeams component with two same-roster build variants + one distinct roster, then screenshotted both round types via Playwright chromium: hero round = 2 cards / 推荐 2 组 (variants collapsed), skill round = 3 cards / 推荐 3 组 (variants preserved)`
- `Confirmed the diff touches only KnownStrongTeams.tsx and its test file, leaving database.json/guide data unchanged`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
