### PR TITLE
test(web): consolidate deterministic recommendation-option coverage

### DIFF
--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -470,7 +470,7 @@ describe('recommendTeams — global formation optimization', () => {
     expect(r).not.toHaveProperty('totalScore');
   });
 
-  test('options use distinct canonical hero partitions (no team-order variants)', () => {
+  test('options use distinct canonical hero partitions in deterministic order', () => {
     const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
     const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
     const data = makeData({
@@ -486,6 +486,13 @@ describe('recommendTeams — global formation optimization', () => {
         .sort()
         .join('||');
     const keys = r.options.map(canonKey);
+    // One fixed-output assertion covers deterministic option selection without
+    // repeating the expensive full formation search in the same test.
+    expect(keys).toEqual([
+      'h0|h1|h2||h3|h4|h5||h6|h7|h8',
+      'h0|h1|h3||h2|h4|h6||h5|h7|h8',
+      'h0|h1|h4||h2|h3|h7||h5|h6|h8',
+    ]);
     // Every option is a distinct canonical partition.
     expect(new Set(keys).size).toBe(keys.length);
     // With 9 heroes and non-degenerate weights, three distinct options exist.
@@ -500,19 +507,6 @@ describe('recommendTeams — global formation optimization', () => {
         .reduce((sum, score) => sum + score, 0)
     );
     expect(Math.max(...topTwo) - Math.min(...topTwo)).toBeLessThanOrEqual(2.6);
-  });
-
-  test('options are deterministic across repeated calls (no randomness)', () => {
-    const heroes = Array.from({ length: 9 }, (_, i) => `h${i}`);
-    const skills = Array.from({ length: 18 }, (_, i) => `s${i}`);
-    const data = makeData({
-      weights: { 'H|h0': 1.0, 'H|h1': 0.5, 'HP|h0|h1': 0.8, 'HS|h0|s0': 0.4 },
-      support: { 'H|h0': 50, 'H|h1': 50, 'HP|h0|h1': 30, 'HS|h0|s0': 20 },
-      n_features: 4,
-    });
-    const a = recommendTeams(heroes, skills, data, data.catalog);
-    const b = recommendTeams(heroes, skills, data, data.catalog);
-    expect(a.options).toEqual(b.options);
   });
 
   test('all options derive from the already-evaluated capped partition set (no extra enumeration)', () => {


### PR DESCRIPTION
## Intent

Fix the scheduled Update web battle data workflow failure caused by the deterministic recommendation-options test exceeding Vitest's default 5-second timeout. Simplify the tests instead of raising any timeout: consolidate deterministic output coverage into the existing canonical-partition integration test, assert one fixed canonical option order, retain distinctness and top-two strength-band coverage, and remove the separate test's two redundant full optimizer runs. Keep this tests-only with no production behavior or timeout-configuration change, validate the web workspace, and create a pull request through no-mistakes.

## What Changed

- Folded the deterministic recommendation-options output coverage into the existing canonical-partition integration test in `web/src/services/__tests__/recommendationEngine.test.ts`, asserting one fixed canonical option order while retaining distinct-partition and top-two strength-band coverage.
- Removed the separate deterministic-across-repeated-calls test and its two redundant full optimizer runs, which were pushing the suite past Vitest's default 5s timeout and failing the scheduled web-battle-data workflow (net 8 additions, 14 deletions).
- Kept the change tests-only — no production logic or timeout-configuration change; the web unit suite (405/405) and `pnpm typecheck` pass.

## Risk Assessment

✅ Low: Tests-only refactor that consolidates deterministic-output coverage into one integration test with a fixed canonical-order assertion, removing two redundant optimizer runs, with no production or timeout-config changes.

## Testing

Ran the smallest relevant evidence-producing tests for this web-only, tests-only change. The consolidated canonical-partition test passes in ~0.6s (down from a two-optimizer-run pattern that could exceed Vitest's 5s default and failed the scheduled workflow), asserting the fixed option order, distinctness, and the top-two strength band; the redundant separate deterministic test is gone (grep = 0). The full web unit suite (405/405) and typecheck both pass, and the diff confirms no production or timeout-configuration change. No UI/rendered surface is involved — this is a test simplification, so evidence is the CLI test transcript rather than a screenshot. No PR was created by me: PR creation is the no-mistakes gate's own step following this validation.

<details>
<summary>Evidence: Consolidated deterministic test passes in ~0.6s; removed test absent</summary>

<code>✓ ...options use distinct canonical hero partitions in deterministic order 589ms&#10;Test Files 1 passed (1)&#10;Tests 1 passed | 53 skipped (54)&#10;Duration 1.16s&#10;--- confirm removed test name absent from source ---&#10;occurrences of removed test: 0</code>

```text
 ✓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > options use distinct canonical hero partitions in deterministic order 589ms
 Test Files  1 passed (1)
      Tests  1 passed | 53 skipped (54)
   Duration  1.16s (transform 88ms, setup 49ms, import 97ms, tests 590ms, environment 340ms)
--- confirm removed test name absent from source ---
occurrences of removed test: 0
```
</details>
<details>
<summary>Evidence: Full web unit suite + typecheck</summary>

```text
pnpm typecheck: tsc --noEmit (clean)
pnpm test: Test Files 35 passed (35) / Tests 405 passed (405) / Duration 17.64s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; pnpm install --frozen-lockfile` (Node 22.17.1 — pnpm 11 requires node:sqlite)</code>
- <code>`pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts --reporter=verbose` — 54/54 pass; consolidated test &#39;options use distinct canonical hero partitions in deterministic order&#39; runs in 546–589ms (&lt;5s default timeout)</code>
- <code>`pnpm typecheck` (tsc --noEmit) — clean</code>
- <code>`pnpm test` — full web unit suite, 405/405 across 35 files</code>
- <code>`grep -c &#39;deterministic across repeated calls&#39;` on the test file — 0 occurrences, confirming the redundant test was removed</code>
- <code>`git diff HEAD~1 HEAD` — confirmed only the test file changed (no production or vitest-timeout config change)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
