### PR TITLE
fix(team-builder): keep warehouse cards contained at short viewport heights

### DIFF
--- a/web/src/components/teamBuilder/FormationWorkbench.tsx
+++ b/web/src/components/teamBuilder/FormationWorkbench.tsx
@@ -775,6 +775,7 @@ const Repository = ({
             ? alpha('#456c5f', 0.1)
             : alpha('#fffdf7', 0.64),
         minHeight: 104,
+        flexShrink: 0,
       }}
     >
       <Stack

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -68,6 +68,11 @@ const smallPoolProgress = progressFor({
   supportSkills: [supportSkill],
 });
 
+const crowdedHeroPoolProgress = progressFor({
+  heroes: heroNames.slice(0, 12),
+  skills: smallSkills,
+});
+
 const completePoolProgress = progressFor({
   heroes: completeHeroes,
   skills: completeSkills,
@@ -646,6 +651,47 @@ test.describe('Team Builder best default', () => {
     expect(
       headerBox.x + headerBox.width - (actionsBox.x + actionsBox.width)
     ).toBeLessThanOrEqual(24);
+  });
+});
+
+test.describe('Team Builder desktop warehouse', () => {
+  test.use({ viewport: { width: 1280, height: 664 } });
+
+  test('keeps hero cards inside their repository at short viewport heights', async ({
+    page,
+  }) => {
+    await seedStoredProgress(page, crowdedHeroPoolProgress);
+    await openBuilder(page);
+
+    const heroRepository = page.getByRole('region', { name: '武将仓库' });
+    const skillRepository = page.getByRole('region', { name: '战法仓库' });
+    const heroButtons = heroRepository.getByRole('button', {
+      name: /^选择武将 /,
+    });
+    await expect(heroButtons).toHaveCount(12);
+
+    const [heroRepositoryBox, skillRepositoryBox, lastHeroBottom] =
+      await Promise.all([
+        heroRepository.boundingBox(),
+        skillRepository.boundingBox(),
+        heroButtons.evaluateAll((buttons) =>
+          Math.max(
+            ...buttons.map(
+              (button) =>
+                button.parentElement?.getBoundingClientRect().bottom ?? 0
+            )
+          )
+        ),
+      ]);
+
+    expect(heroRepositoryBox).not.toBeNull();
+    expect(skillRepositoryBox).not.toBeNull();
+    expect(lastHeroBottom).toBeLessThanOrEqual(
+      heroRepositoryBox.y + heroRepositoryBox.height + 1
+    );
+    expect(skillRepositoryBox.y).toBeGreaterThanOrEqual(
+      heroRepositoryBox.y + heroRepositoryBox.height
+    );
   });
 });
 


### PR DESCRIPTION
## Intent

Fix the /team-builder right-panel hero cards overlapping the warehouse edge and the skill warehouse at short desktop viewport heights. Preserve the existing sticky, height-capped sidebar and its internal scrolling, but keep each hero and skill warehouse section at its natural content height so cards remain contained. Add Playwright regression coverage at 1280x664 that verifies hero cards stay inside the hero warehouse and the skill warehouse starts after it. Keep the change focused on this UI layout defect and its test.

## What Changed

- Added `flexShrink: 0` to the `Repository` container in `FormationWorkbench.tsx` so the hero and skill warehouse sections hold their natural content height inside the sticky, height-capped sidebar instead of being compressed — preventing hero cards from overflowing their section and overlapping the skill warehouse at short desktop viewport heights.
- Added a Playwright regression test (`buildATeam.spec.js`) at 1280x664 with a crowded 12-hero pool that asserts every hero card stays within the 武将仓库 bounds and that the 战法仓库 starts after it.

## Risk Assessment

✅ Low: A one-line CSS `flexShrink: 0` addition correctly fixes the flex-child shrink overflow while preserving the sticky, height-capped, internally-scrolling sidebar, and the accompanying 1280×664 Playwright test accurately asserts card containment and warehouse ordering.

## Testing

Reviewed the diff (a one-line `flexShrink: 0` on the warehouse `Repository` box plus a new 1280x664 Playwright test) and exercised it end-to-end with Node 22. The new regression test passes with the fix and, when I temporarily reverted the fix, fails exactly as intended (hero cards overflow the hero warehouse by ~25px into the skill warehouse), proving it guards the defect. The full team-builder e2e spec (14 tests including mobile/desktop layout), `pnpm typecheck`, and the 405 Vitest unit tests all pass. I also captured reviewer-visible before/after screenshots at the 1280x664 viewport: the "before" clearly shows the last row of hero cards (刘禅/华佗) spilling past the 武将仓库 box and overlapping the 战法仓库 header, and the "after" shows the box fully containing all 12 cards with 战法仓库 starting cleanly below it. Worktree left clean; the temporary evidence spec and test-results were removed.

- Evidence: Team Builder warehouse at 1280x664 — BEFORE fix (hero cards 刘禅/华佗 overflow the 武将仓库 box and overlap the 战法仓库 header) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KZDJ3793VZ1KC1KAZXQ6QDFJ/warehouse-boundary-before.png</code>)
- Evidence: Team Builder warehouse at 1280x664 — AFTER fix (武将仓库 contains all 12 cards; 战法仓库 starts cleanly below) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KZDJ3793VZ1KC1KAZXQ6QDFJ/warehouse-boundary-after.png</code>)
<details>
<summary>Evidence: Measured overlap delta at 1280x664 (before vs after)</summary>

```text
before: heroWarehouseBottom=491.4 lastHeroCardBottom=516.5 skillWarehouseTop=499.4 overlapPx=25.1
after: heroWarehouseBottom=487.5 lastHeroCardBottom=476.5 skillWarehouseTop=495.5 overlapPx=-11.0
```
</details>
<details>
<summary>Evidence: New regression test fails without the fix (proves it guards the defect)</summary>

```text
expect(lastHeroBottom).toBeLessThanOrEqual(...)
Expected: <= 876.796875
Received: 900.859375
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm exec playwright test buildATeam.spec.js -g &#34;keeps hero cards inside their repository&#34;` (new 1280x664 regression test — passes with fix)</code>
- <code>Reverted `flexShrink: 0` and re-ran the same test to confirm it catches the defect (failed: last hero card bottom 900.9 &gt; warehouse bottom 876.8)</code>
- <code>`pnpm exec playwright test buildATeam.spec.js` (all 14 team-builder e2e tests, incl. mobile/desktop layout, pass)</code>
- <code>`pnpm typecheck` (Go-native tsc, clean)</code>
- <code>`pnpm test` (Vitest: 405 unit tests pass across 35 files)</code>
- `Captured before/after screenshots at 1280x664 via a temporary evidence spec (since removed): measured hero-card overlap of +25.1px into the skill warehouse without the fix vs -11px (contained) with it`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
