### PR TITLE
feat(agent): add local TypeScript agent runtime

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,7 +35,8 @@ working tree; steps 4–5 go through the `no-mistakes` gate.
 
 ## Scope tests to the changed workspace
 
-This repo is a **uv workspace + a React app**, and the workspaces are independent.
+This repo is a **uv workspace + React app + local TypeScript agent**, and the
+workspaces are independent.
 **Run only the tests for the area you changed.** A web-only change must not drag in
 the heavy PaddleOCR Python suite, and a Python change does not need the React
 tests. Match the changed paths to the smallest test set that covers them:
@@ -44,6 +45,7 @@ tests. Match the changed paths to the smallest test set that covers them:
 |---|---|
 | `web/**` (source under `web/src/`) | **Web unit tests** (Vitest): `cd web && pnpm test` — and **type-check**: `cd web && pnpm typecheck` (Go-native `tsc`) |
 | `web/**` that changes UI flow / rendered behavior | The unit tests above **and** the **e2e tests** (Playwright): `cd web && pnpm test:e2e` (first time: `pnpm exec playwright install`) |
+| `agent/**` | **Agent checks**: `cd agent && pnpm typecheck && pnpm test && pnpm build`. Tests use fake providers and consume no model tokens. Run `pnpm smoke` only for an explicit live integration check when the local provider is available. |
 | `image_extraction/**` | **Python tests**: `make test` (runs `uv run pytest image_extraction/`; needs `make sync` first if deps aren't installed — loads PaddleOCR, ~40s) |
 | `data/**` (offline builders) | **Python tests**: `make test-data` (runs the recommendation and telemetry builder suites; fast, no PaddleOCR). For recommendation changes, also run `make build-recommendation`; when evaluation logic or model configuration changes, run `make evaluate-recommendation` as well. Its ignored JSON report is evaluation-only and must not update production weights automatically. For telemetry changes, run `make build-telemetry EXPORT=<D1 SQL export>` (the empty migration is a safe local smoke input). Confirm the relevant generated artifact updates and the web app still loads. |
 | `study-battle-report/**` | No automated tests. Validate with a manual OCR run: `uv run python study-battle-report/ocr_battle_log.py [<id>] --use-cache`. |
@@ -52,8 +54,9 @@ tests. Match the changed paths to the smallest test set that covers them:
 
 Notes:
 - When a change spans more than one workspace, run each affected workspace's tests.
-- Fresh checkouts have no installed deps: web tests need
-  `pnpm install --frozen-lockfile` in `web/`; Python tests need `make sync`.
+- Fresh checkouts have no installed deps: web and agent checks each need
+  `pnpm install --frozen-lockfile` in their own directory; Python tests need
+  `make sync`.
 - The canonical commands live in the [README `Commands`](README.md#commands)
   section and the `Makefile` — prefer them over ad-hoc invocations.
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
   --yes
 ```
 
-## Layout (a uv workspace + a React app)
+## Layout (a uv workspace + React app + local TypeScript agent)
 
 - `image_extraction/` — OCR skill extraction (PaddleOCR). `skill_extraction_system.py`
   is the engine; `batch_extract_battles.py` runs it over `data/images/` and writes
@@ -319,6 +319,10 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
   - `src/types/` — hand-written domain types (`domain.ts`, `recommendation.ts`, `game.ts`) for
     `database.json`/`recommendation_data.json` and the game state/reducer.
   - `src/data.ts` — the central typed boundary that imports and casts the bundled JSON once.
+- `agent/` — local TypeScript HTTP/CLI runtime for model-backed experiments.
+  It uses an OpenAI-compatible provider boundary, is never required by the
+  public static site, and will host the LangGraph team-completion workflow in
+  later milestones.
 - `data/import_yanwu_workbook.py` — strict, deterministic five-sheet workbook
   importer. It defaults to a no-write dry run and requires `--apply` to update
   `web/public/game-data/database.json`; the source workbook itself stays
@@ -352,6 +356,9 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
 - `make web` — start the Vite dev server (port 3000).
 - Web unit tests: `cd web && pnpm test` (Vitest). Type-check: `cd web && pnpm typecheck`
   (Go-native `tsc`). E2e: `cd web && pnpm test:e2e` (Playwright). Build: `cd web && pnpm build`.
+- Local agent: `cd agent && pnpm start`. Token-free checks:
+  `pnpm typecheck && pnpm test && pnpm build`. Explicit live model check:
+  `pnpm smoke`.
 - Python runs under **uv** (Python 3.12): `uv run python <script>`. `make sync` installs deps.
 
 ## Data conventions (recommendation_data.json)

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -1,0 +1,11 @@
+# Local Sanmou agent server. Keep it loopback-only.
+SANMOU_AGENT_HOST=127.0.0.1
+SANMOU_AGENT_PORT=8790
+
+# OpenAI-compatible model provider. The local ai-gateway-provider exposes /v1.
+AI_BASE_URL=http://127.0.0.1:8787/v1
+AI_MODEL=gpt-5.6-sol
+AI_TIMEOUT_MS=60000
+
+# Optional for other OpenAI-compatible providers. Not needed by ai-gateway-provider.
+# AI_API_KEY=

--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -1,0 +1,4 @@
+.env
+node_modules/
+dist/
+coverage/

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,95 @@
+# Sanmou Agent
+
+Local TypeScript service for Sanmou's future LangGraph workflows. This first
+milestone establishes the model boundary and HTTP runtime; it deliberately does
+not contain team-building logic or LangGraph yet.
+
+The agent is open-source application code. It talks to any OpenAI-compatible
+model provider configured through environment variables. For the maintainer's
+local setup, that provider is the separate, untracked Atlassian
+`ai-gateway-provider` service.
+
+## Runtime architecture
+
+```text
+CLI or local HTTP caller
+          |
+          v
+Sanmou Agent (127.0.0.1:8790)
+          |
+          v
+OpenAI-compatible provider (127.0.0.1:8787/v1)
+```
+
+The public Sanmou website does not start this service and consumes no model
+tokens.
+
+## Setup
+
+```bash
+cd agent
+pnpm install --frozen-lockfile
+cp .env.example .env
+```
+
+With `atlas slauth server --port 5000` and `ai-gateway-provider` already
+running, verify the model connection directly from the agent client:
+
+```bash
+pnpm smoke
+```
+
+The default model is `gpt-5.6-sol`. Change `AI_MODEL` in `.env` to compare
+another model.
+
+## Run the local HTTP server
+
+```bash
+pnpm start
+```
+
+Check liveness:
+
+```bash
+curl http://127.0.0.1:8790/health/live
+```
+
+Send a chat request through the agent and its configured provider:
+
+```bash
+curl --silent --show-error --fail-with-body \
+  http://127.0.0.1:8790/v1/chat \
+  -H 'content-type: application/json' \
+  -d '{
+    "messages": [
+      {"role": "user", "content": "Reply with exactly: agent-http-ok"}
+    ],
+    "maxCompletionTokens": 64
+  }'
+```
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SANMOU_AGENT_HOST` | `127.0.0.1` | Local server bind address |
+| `SANMOU_AGENT_PORT` | `8790` | Local server port |
+| `AI_BASE_URL` | `http://127.0.0.1:8787/v1` | OpenAI-compatible provider base URL |
+| `AI_MODEL` | `gpt-5.6-sol` | Default model ID |
+| `AI_TIMEOUT_MS` | `60000` | Provider request timeout |
+| `AI_API_KEY` | unset | Optional bearer token for other providers |
+
+Do not put provider credentials in the React app or a `VITE_*` variable. Keep
+them in this local server's ignored `.env` file.
+
+## Development checks
+
+```bash
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+Tests use fake model/provider implementations and consume no tokens. `pnpm
+smoke` is the explicit live integration check and does consume a small number
+of tokens.

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@sanmou/agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.16.0",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "tsx src/server.ts",
+    "smoke": "tsx src/cli.ts smoke",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "tsx": "^4.21.0",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/agent/pnpm-lock.yaml
+++ b/agent/pnpm-lock.yaml
@@ -1,0 +1,1211 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.23.11
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.2)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.11))
+
+packages:
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  tsx@4.23.11:
+    resolution: {integrity: sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@oxc-project/types@0.143.0': {}
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@26.1.2':
+    dependencies:
+      undici-types: 8.3.0
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.11))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.11)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  es-module-lexer@2.3.1: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.18: {}
+
+  obug@2.1.4: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rolldown@1.2.3:
+    dependencies:
+      '@oxc-project/types': 0.143.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
+
+  tsx@4.23.11:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
+
+  undici-types@8.3.0: {}
+
+  vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.11):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.2
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      tsx: 4.23.11
+
+  vitest@4.1.10(@types/node@26.1.2)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.11)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.11))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.11)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.2
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zod@4.4.3: {}

--- a/agent/pnpm-workspace.yaml
+++ b/agent/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/agent/src/cli.ts
+++ b/agent/src/cli.ts
@@ -1,0 +1,49 @@
+import { loadLocalEnvironment, readAgentConfig } from './config.js';
+import { ChatModelError } from './model.js';
+import { OpenAICompatibleChatModel } from './openAiCompatibleChatModel.js';
+
+function printUsage(): void {
+  console.log('Usage: pnpm smoke');
+  console.log('Runs one synthetic completion through the configured model provider.');
+}
+
+async function runSmoke(): Promise<void> {
+  loadLocalEnvironment();
+  const config = readAgentConfig();
+  const model = new OpenAICompatibleChatModel(config.model);
+  const result = await model.complete({
+    messages: [{ role: 'user', content: 'Reply with exactly: agent-smoke-ok' }],
+    maxCompletionTokens: 64,
+  });
+  console.log(
+    JSON.stringify(
+      {
+        model: result.model,
+        content: result.content,
+        usage: result.usage,
+      },
+      null,
+      2
+    )
+  );
+}
+
+async function main(): Promise<void> {
+  const command = process.argv[2];
+  if (command !== 'smoke') {
+    printUsage();
+    process.exitCode = command === undefined ? 0 : 1;
+    return;
+  }
+  await runSmoke();
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof ChatModelError) {
+    console.error(`Model request failed: ${error.message}`);
+    if (error.statusCode !== null) console.error(`Upstream HTTP status: ${error.statusCode}`);
+  } else {
+    console.error(error instanceof Error ? error.message : String(error));
+  }
+  process.exitCode = 1;
+});

--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -1,0 +1,48 @@
+import { loadEnvFile } from 'node:process';
+import { resolve } from 'node:path';
+import { z } from 'zod';
+
+const environmentSchema = z.object({
+  SANMOU_AGENT_HOST: z.string().min(1).default('127.0.0.1'),
+  SANMOU_AGENT_PORT: z.coerce.number().int().min(1).max(65_535).default(8790),
+  AI_BASE_URL: z.url().default('http://127.0.0.1:8787/v1'),
+  AI_MODEL: z.string().min(1).default('gpt-5.6-sol'),
+  AI_TIMEOUT_MS: z.coerce.number().int().min(1).max(300_000).default(60_000),
+  AI_API_KEY: z.string().min(1).optional(),
+});
+
+export interface AgentConfig {
+  host: string;
+  port: number;
+  model: {
+    baseUrl: string;
+    model: string;
+    timeoutMs: number;
+    apiKey?: string;
+  };
+}
+
+export function loadLocalEnvironment(path = resolve(process.cwd(), '.env')): void {
+  try {
+    loadEnvFile(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+
+export function readAgentConfig(
+  environment: NodeJS.ProcessEnv = process.env
+): AgentConfig {
+  const parsed = environmentSchema.parse(environment);
+  const apiKey = parsed.AI_API_KEY;
+  return {
+    host: parsed.SANMOU_AGENT_HOST,
+    port: parsed.SANMOU_AGENT_PORT,
+    model: {
+      baseUrl: parsed.AI_BASE_URL.replace(/\/+$/, ''),
+      model: parsed.AI_MODEL,
+      timeoutMs: parsed.AI_TIMEOUT_MS,
+      ...(apiKey === undefined ? {} : { apiKey }),
+    },
+  };
+}

--- a/agent/src/httpSchemas.ts
+++ b/agent/src/httpSchemas.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+const chatMessageSchema = z.object({
+  role: z.enum(['developer', 'system', 'user', 'assistant']),
+  content: z.string().min(1),
+});
+
+export const agentChatRequestSchema = z
+  .object({
+    messages: z.array(chatMessageSchema).min(1),
+    model: z.string().min(1).optional(),
+    maxCompletionTokens: z.number().int().min(1).max(100_000).optional(),
+    temperature: z.number().min(-2).max(2).optional(),
+  })
+  .strict();

--- a/agent/src/httpServer.ts
+++ b/agent/src/httpServer.ts
@@ -1,0 +1,122 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { ZodError } from 'zod';
+import { agentChatRequestSchema } from './httpSchemas.js';
+import { ChatModelError, type ChatModel } from './model.js';
+
+const MAX_BODY_BYTES = 256 * 1024;
+
+export interface AgentHttpServerOptions {
+  model: ChatModel;
+  modelName: string;
+}
+
+class RequestBodyError extends Error {
+  readonly statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+function writeJson(response: ServerResponse, statusCode: number, body: unknown): void {
+  response.writeHead(statusCode, { 'content-type': 'application/json; charset=utf-8' });
+  response.end(JSON.stringify(body));
+}
+
+function writeError(
+  response: ServerResponse,
+  statusCode: number,
+  message: string,
+  type: string,
+  details?: unknown
+): void {
+  writeJson(response, statusCode, {
+    error: {
+      message,
+      type,
+      ...(details === undefined ? {} : { details }),
+    },
+  });
+}
+
+async function readJson(request: IncomingMessage): Promise<unknown> {
+  const contentType = request.headers['content-type'] ?? '';
+  if (!contentType.toLowerCase().startsWith('application/json')) {
+    throw new RequestBodyError(415, 'Content-Type must be application/json');
+  }
+
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > MAX_BODY_BYTES) {
+      throw new RequestBodyError(413, 'Request body is too large');
+    }
+    chunks.push(buffer);
+  }
+
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+  } catch {
+    throw new RequestBodyError(400, 'Request body must contain valid JSON');
+  }
+}
+
+async function handleRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: AgentHttpServerOptions
+): Promise<void> {
+  const pathname = new URL(request.url ?? '/', 'http://localhost').pathname;
+
+  if (request.method === 'GET' && pathname === '/health/live') {
+    writeJson(response, 200, { status: 'ok' });
+    return;
+  }
+  if (request.method === 'GET' && pathname === '/health/ready') {
+    writeJson(response, 200, { status: 'ready', model: options.modelName });
+    return;
+  }
+  if (request.method !== 'POST' || pathname !== '/v1/chat') {
+    writeError(response, 404, 'Route not found', 'not_found');
+    return;
+  }
+
+  try {
+    const body = await readJson(request);
+    const parsed = agentChatRequestSchema.parse(body);
+    const completion = await options.model.complete({
+      messages: parsed.messages,
+      ...(parsed.model === undefined ? {} : { model: parsed.model }),
+      ...(parsed.maxCompletionTokens === undefined
+        ? {}
+        : { maxCompletionTokens: parsed.maxCompletionTokens }),
+      ...(parsed.temperature === undefined ? {} : { temperature: parsed.temperature }),
+    });
+    writeJson(response, 200, completion);
+  } catch (error) {
+    if (error instanceof RequestBodyError) {
+      writeError(response, error.statusCode, error.message, 'invalid_request');
+      return;
+    }
+    if (error instanceof ZodError) {
+      writeError(response, 422, 'Request body does not match the chat contract', 'validation_error', error.issues);
+      return;
+    }
+    if (error instanceof ChatModelError) {
+      writeError(response, 502, error.message, 'model_provider_error', {
+        upstreamStatus: error.statusCode,
+      });
+      return;
+    }
+    writeError(response, 500, 'Unexpected agent server error', 'internal_error');
+  }
+}
+
+export function createAgentHttpServer(options: AgentHttpServerOptions): Server {
+  return createServer((request, response) => {
+    void handleRequest(request, response, options);
+  });
+}

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,0 +1,15 @@
+export { readAgentConfig, type AgentConfig } from './config.js';
+export { createAgentHttpServer, type AgentHttpServerOptions } from './httpServer.js';
+export {
+  ChatModelError,
+  type ChatCompletion,
+  type ChatCompletionRequest,
+  type ChatMessage,
+  type ChatModel,
+  type ChatRole,
+  type TokenUsage,
+} from './model.js';
+export {
+  OpenAICompatibleChatModel,
+  type OpenAICompatibleChatModelOptions,
+} from './openAiCompatibleChatModel.js';

--- a/agent/src/model.ts
+++ b/agent/src/model.ts
@@ -1,0 +1,43 @@
+export type ChatRole = 'developer' | 'system' | 'user' | 'assistant';
+
+export interface ChatMessage {
+  role: ChatRole;
+  content: string;
+}
+
+export interface ChatCompletionRequest {
+  messages: ChatMessage[];
+  model?: string;
+  maxCompletionTokens?: number;
+  temperature?: number;
+}
+
+export interface TokenUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+export interface ChatCompletion {
+  id: string;
+  model: string;
+  content: string;
+  finishReason: string | null;
+  usage: TokenUsage | null;
+}
+
+export interface ChatModel {
+  complete(request: ChatCompletionRequest): Promise<ChatCompletion>;
+}
+
+export class ChatModelError extends Error {
+  readonly statusCode: number | null;
+  readonly details: unknown;
+
+  constructor(message: string, options: { statusCode?: number; details?: unknown } = {}) {
+    super(message);
+    this.name = 'ChatModelError';
+    this.statusCode = options.statusCode ?? null;
+    this.details = options.details;
+  }
+}

--- a/agent/src/openAiCompatibleChatModel.ts
+++ b/agent/src/openAiCompatibleChatModel.ts
@@ -1,0 +1,158 @@
+import { z } from 'zod';
+import {
+  ChatModelError,
+  type ChatCompletion,
+  type ChatCompletionRequest,
+  type ChatModel,
+} from './model.js';
+
+const upstreamResponseSchema = z.object({
+  id: z.string().default(''),
+  model: z.string().default(''),
+  choices: z
+    .array(
+      z.object({
+        message: z.object({
+          content: z.string().nullable(),
+        }),
+        finish_reason: z.string().nullable().optional(),
+      })
+    )
+    .min(1),
+  usage: z
+    .object({
+      prompt_tokens: z.number().int().nonnegative(),
+      completion_tokens: z.number().int().nonnegative(),
+      total_tokens: z.number().int().nonnegative(),
+    })
+    .nullable()
+    .optional(),
+});
+
+export interface OpenAICompatibleChatModelOptions {
+  baseUrl: string;
+  model: string;
+  timeoutMs: number;
+  apiKey?: string;
+  fetchImplementation?: typeof fetch;
+}
+
+function errorMessage(body: unknown, status: number): string {
+  if (
+    body !== null &&
+    typeof body === 'object' &&
+    'error' in body &&
+    body.error !== null &&
+    typeof body.error === 'object' &&
+    'message' in body.error &&
+    typeof body.error.message === 'string'
+  ) {
+    return body.error.message;
+  }
+  return `Model provider returned HTTP ${status}`;
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.length === 0) return {};
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new ChatModelError('Model provider returned a non-JSON response', {
+      statusCode: response.status,
+      details: { cause: error instanceof Error ? error.message : String(error) },
+    });
+  }
+}
+
+export class OpenAICompatibleChatModel implements ChatModel {
+  private readonly endpoint: URL;
+  private readonly defaultModel: string;
+  private readonly timeoutMs: number;
+  private readonly apiKey: string | undefined;
+  private readonly fetchImplementation: typeof fetch;
+
+  constructor(options: OpenAICompatibleChatModelOptions) {
+    const baseUrl = options.baseUrl.endsWith('/') ? options.baseUrl : `${options.baseUrl}/`;
+    this.endpoint = new URL('chat/completions', baseUrl);
+    this.defaultModel = options.model;
+    this.timeoutMs = options.timeoutMs;
+    this.apiKey = options.apiKey;
+    this.fetchImplementation = options.fetchImplementation ?? fetch;
+  }
+
+  async complete(request: ChatCompletionRequest): Promise<ChatCompletion> {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+    };
+    if (this.apiKey !== undefined) headers.authorization = `Bearer ${this.apiKey}`;
+
+    let response: Response;
+    try {
+      response = await this.fetchImplementation(this.endpoint, {
+        method: 'POST',
+        headers,
+        signal: AbortSignal.timeout(this.timeoutMs),
+        body: JSON.stringify({
+          model: request.model ?? this.defaultModel,
+          messages: request.messages,
+          ...(request.maxCompletionTokens === undefined
+            ? {}
+            : { max_completion_tokens: request.maxCompletionTokens }),
+          ...(request.temperature === undefined
+            ? {}
+            : { temperature: request.temperature }),
+        }),
+      });
+    } catch (error) {
+      throw new ChatModelError(
+        error instanceof DOMException && error.name === 'TimeoutError'
+          ? `Model provider timed out after ${this.timeoutMs}ms`
+          : `Could not reach model provider: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    const body = await parseJsonResponse(response);
+    if (!response.ok) {
+      throw new ChatModelError(errorMessage(body, response.status), {
+        statusCode: response.status,
+        details: body,
+      });
+    }
+
+    const parsed = upstreamResponseSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new ChatModelError('Model provider returned an unexpected response shape', {
+        statusCode: response.status,
+        details: parsed.error.issues,
+      });
+    }
+    const choice = parsed.data.choices[0];
+    if (choice === undefined) {
+      throw new ChatModelError('Model provider returned no completion choices', {
+        statusCode: response.status,
+      });
+    }
+    const content = choice.message.content;
+    if (content === null) {
+      throw new ChatModelError('Model provider returned no text content', {
+        statusCode: response.status,
+      });
+    }
+    const usage = parsed.data.usage;
+    return {
+      id: parsed.data.id,
+      model: parsed.data.model,
+      content,
+      finishReason: choice.finish_reason ?? null,
+      usage:
+        usage === undefined || usage === null
+          ? null
+          : {
+              promptTokens: usage.prompt_tokens,
+              completionTokens: usage.completion_tokens,
+              totalTokens: usage.total_tokens,
+            },
+    };
+  }
+}

--- a/agent/src/openAiCompatibleChatModel.ts
+++ b/agent/src/openAiCompatibleChatModel.ts
@@ -4,6 +4,7 @@ import {
   type ChatCompletion,
   type ChatCompletionRequest,
   type ChatModel,
+  type TokenUsage,
 } from './model.js';
 
 const upstreamResponseSchema = z.object({
@@ -19,15 +20,28 @@ const upstreamResponseSchema = z.object({
       })
     )
     .min(1),
-  usage: z
-    .object({
-      prompt_tokens: z.number().int().nonnegative(),
-      completion_tokens: z.number().int().nonnegative(),
-      total_tokens: z.number().int().nonnegative(),
-    })
-    .nullable()
-    .optional(),
+  usage: z.unknown().optional(),
 });
+
+function isNonnegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function normalizeUsage(raw: unknown): TokenUsage | null {
+  if (raw === null || typeof raw !== 'object') return null;
+  const record = raw as Record<string, unknown>;
+  const promptTokens = record.prompt_tokens;
+  const completionTokens = record.completion_tokens;
+  const totalTokens = record.total_tokens;
+  if (
+    isNonnegativeInteger(promptTokens) &&
+    isNonnegativeInteger(completionTokens) &&
+    isNonnegativeInteger(totalTokens)
+  ) {
+    return { promptTokens, completionTokens, totalTokens };
+  }
+  return null;
+}
 
 export interface OpenAICompatibleChatModelOptions {
   baseUrl: string;
@@ -139,20 +153,12 @@ export class OpenAICompatibleChatModel implements ChatModel {
         statusCode: response.status,
       });
     }
-    const usage = parsed.data.usage;
     return {
       id: parsed.data.id,
       model: parsed.data.model,
       content,
       finishReason: choice.finish_reason ?? null,
-      usage:
-        usage === undefined || usage === null
-          ? null
-          : {
-              promptTokens: usage.prompt_tokens,
-              completionTokens: usage.completion_tokens,
-              totalTokens: usage.total_tokens,
-            },
+      usage: normalizeUsage(parsed.data.usage),
     };
   }
 }

--- a/agent/src/server.ts
+++ b/agent/src/server.ts
@@ -1,0 +1,26 @@
+import { createAgentHttpServer } from './httpServer.js';
+import { loadLocalEnvironment, readAgentConfig } from './config.js';
+import { OpenAICompatibleChatModel } from './openAiCompatibleChatModel.js';
+
+loadLocalEnvironment();
+const config = readAgentConfig();
+const model = new OpenAICompatibleChatModel(config.model);
+const server = createAgentHttpServer({ model, modelName: config.model.model });
+
+server.listen(config.port, config.host, () => {
+  console.log(`Sanmou agent listening on http://${config.host}:${config.port}`);
+  console.log(`Model: ${config.model.model}`);
+});
+
+function shutdown(signal: string): void {
+  console.log(`Received ${signal}; shutting down`);
+  server.close((error) => {
+    if (error) {
+      console.error(error);
+      process.exitCode = 1;
+    }
+  });
+}
+
+process.once('SIGINT', () => shutdown('SIGINT'));
+process.once('SIGTERM', () => shutdown('SIGTERM'));

--- a/agent/tests/config.test.ts
+++ b/agent/tests/config.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { readAgentConfig } from '../src/config.js';
+
+describe('readAgentConfig', () => {
+  it('uses local-only defaults', () => {
+    const config = readAgentConfig({});
+
+    expect(config).toEqual({
+      host: '127.0.0.1',
+      port: 8790,
+      model: {
+        baseUrl: 'http://127.0.0.1:8787/v1',
+        model: 'gpt-5.6-sol',
+        timeoutMs: 60_000,
+      },
+    });
+  });
+
+  it('normalizes configuration values', () => {
+    const config = readAgentConfig({
+      SANMOU_AGENT_HOST: 'localhost',
+      SANMOU_AGENT_PORT: '9000',
+      AI_BASE_URL: 'http://localhost:9001/v1/',
+      AI_MODEL: 'test-model',
+      AI_TIMEOUT_MS: '1234',
+      AI_API_KEY: 'secret',
+    });
+
+    expect(config).toEqual({
+      host: 'localhost',
+      port: 9000,
+      model: {
+        baseUrl: 'http://localhost:9001/v1',
+        model: 'test-model',
+        timeoutMs: 1234,
+        apiKey: 'secret',
+      },
+    });
+  });
+});

--- a/agent/tests/httpServer.test.ts
+++ b/agent/tests/httpServer.test.ts
@@ -1,0 +1,103 @@
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createAgentHttpServer } from '../src/httpServer.js';
+import type { ChatCompletionRequest, ChatModel } from '../src/model.js';
+
+class FakeChatModel implements ChatModel {
+  readonly requests: ChatCompletionRequest[] = [];
+
+  async complete(request: ChatCompletionRequest) {
+    this.requests.push(request);
+    return {
+      id: 'fake-1',
+      model: 'fake-model',
+      content: 'fake-response',
+      finishReason: 'stop',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    };
+  }
+}
+
+const openServers: Server[] = [];
+
+async function startServer(model: ChatModel): Promise<{ server: Server; baseUrl: string }> {
+  const server = createAgentHttpServer({ model, modelName: 'fake-model' });
+  openServers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    openServers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve()))
+        )
+    )
+  );
+});
+
+describe('agent HTTP server', () => {
+  it('reports liveness and readiness without a model request', async () => {
+    const model = new FakeChatModel();
+    const { baseUrl } = await startServer(model);
+
+    const live = await fetch(`${baseUrl}/health/live`);
+    const ready = await fetch(`${baseUrl}/health/ready`);
+
+    expect(live.status).toBe(200);
+    expect(await live.json()).toEqual({ status: 'ok' });
+    expect(ready.status).toBe(200);
+    expect(await ready.json()).toEqual({ status: 'ready', model: 'fake-model' });
+    expect(model.requests).toEqual([]);
+  });
+
+  it('validates and forwards a chat request', async () => {
+    const model = new FakeChatModel();
+    const { baseUrl } = await startServer(model);
+
+    const response = await fetch(`${baseUrl}/v1/chat`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: 'hello' }],
+        maxCompletionTokens: 64,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      model: 'fake-model',
+      content: 'fake-response',
+    });
+    expect(model.requests).toEqual([
+      {
+        messages: [{ role: 'user', content: 'hello' }],
+        maxCompletionTokens: 64,
+      },
+    ]);
+  });
+
+  it('rejects an invalid request without calling the model', async () => {
+    const model = new FakeChatModel();
+    const { baseUrl } = await startServer(model);
+
+    const response = await fetch(`${baseUrl}/v1/chat`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ messages: [] }),
+    });
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toMatchObject({
+      error: { type: 'validation_error' },
+    });
+    expect(model.requests).toEqual([]);
+  });
+});

--- a/agent/tests/openAiCompatibleChatModel.test.ts
+++ b/agent/tests/openAiCompatibleChatModel.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { OpenAICompatibleChatModel } from '../src/openAiCompatibleChatModel.js';
+
+describe('OpenAICompatibleChatModel', () => {
+  it('maps the generic request and normalizes the completion', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () =>
+      new Response(
+        JSON.stringify({
+          id: 'completion-1',
+          model: 'resolved-model',
+          choices: [
+            {
+              message: { content: 'hello' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 4,
+            completion_tokens: 2,
+            total_tokens: 6,
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    const model = new OpenAICompatibleChatModel({
+      baseUrl: 'http://provider.test/v1',
+      model: 'default-model',
+      timeoutMs: 1000,
+      apiKey: 'test-key',
+      fetchImplementation,
+    });
+
+    const completion = await model.complete({
+      messages: [{ role: 'user', content: 'hi' }],
+      maxCompletionTokens: 50,
+      temperature: 0,
+    });
+
+    expect(completion).toEqual({
+      id: 'completion-1',
+      model: 'resolved-model',
+      content: 'hello',
+      finishReason: 'stop',
+      usage: {
+        promptTokens: 4,
+        completionTokens: 2,
+        totalTokens: 6,
+      },
+    });
+    expect(fetchImplementation).toHaveBeenCalledOnce();
+    const [url, init] = fetchImplementation.mock.calls[0]!;
+    expect(String(url)).toBe('http://provider.test/v1/chat/completions');
+    expect(init?.headers).toEqual({
+      authorization: 'Bearer test-key',
+      'content-type': 'application/json',
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      model: 'default-model',
+      messages: [{ role: 'user', content: 'hi' }],
+      max_completion_tokens: 50,
+      temperature: 0,
+    });
+  });
+
+  it('preserves a provider error message and status', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () =>
+      new Response(
+        JSON.stringify({ error: { message: 'rate limited', type: 'rate_limit' } }),
+        { status: 429, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    const model = new OpenAICompatibleChatModel({
+      baseUrl: 'http://provider.test/v1',
+      model: 'test-model',
+      timeoutMs: 1000,
+      fetchImplementation,
+    });
+
+    await expect(
+      model.complete({ messages: [{ role: 'user', content: 'hi' }] })
+    ).rejects.toMatchObject({
+      message: 'rate limited',
+      statusCode: 429,
+    });
+  });
+});

--- a/agent/tests/openAiCompatibleChatModel.test.ts
+++ b/agent/tests/openAiCompatibleChatModel.test.ts
@@ -63,6 +63,94 @@ describe('OpenAICompatibleChatModel', () => {
     });
   });
 
+  it('keeps a valid completion when upstream usage is missing', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () =>
+      new Response(
+        JSON.stringify({
+          id: 'completion-2',
+          model: 'resolved-model',
+          choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    const model = new OpenAICompatibleChatModel({
+      baseUrl: 'http://provider.test/v1',
+      model: 'default-model',
+      timeoutMs: 1000,
+      fetchImplementation,
+    });
+
+    const completion = await model.complete({
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    expect(completion).toEqual({
+      id: 'completion-2',
+      model: 'resolved-model',
+      content: 'hello',
+      finishReason: 'stop',
+      usage: null,
+    });
+  });
+
+  it('drops partial or non-integer usage without inventing counts', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () =>
+      new Response(
+        JSON.stringify({
+          id: 'completion-3',
+          model: 'resolved-model',
+          choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 4, completion_tokens: 2.5 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    const model = new OpenAICompatibleChatModel({
+      baseUrl: 'http://provider.test/v1',
+      model: 'default-model',
+      timeoutMs: 1000,
+      fetchImplementation,
+    });
+
+    const completion = await model.complete({
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    expect(completion.content).toBe('hello');
+    expect(completion.usage).toBeNull();
+  });
+
+  it('normalizes complete valid usage', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () =>
+      new Response(
+        JSON.stringify({
+          id: 'completion-4',
+          model: 'resolved-model',
+          choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 7, completion_tokens: 3, total_tokens: 10 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    const model = new OpenAICompatibleChatModel({
+      baseUrl: 'http://provider.test/v1',
+      model: 'default-model',
+      timeoutMs: 1000,
+      fetchImplementation,
+    });
+
+    const completion = await model.complete({
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    expect(completion.usage).toEqual({
+      promptTokens: 7,
+      completionTokens: 3,
+      totalTokens: 10,
+    });
+  });
+
   it('preserves a provider error message and status', async () => {
     const fetchImplementation = vi.fn<typeof fetch>(async () =>
       new Response(

--- a/agent/tsconfig.build.json
+++ b/agent/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests/**/*.ts"]
+}

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Intent

Build the first local Sanmou agent milestone as an independent TypeScript workspace with a reusable OpenAI-compatible model client, loopback-only HTTP server, CLI smoke command, environment configuration, and token-free fake-provider tests. Keep the public React website unchanged and free of model calls, keep Atlassian AI Gateway details in the separate local provider, use gpt-5.6-sol as the verified frontier model, and explicitly verify both CLI and HTTP paths against the already-running local ai-gateway-provider.

## What Changed

- Adds a new standalone `agent/` TypeScript workspace: a reusable OpenAI-compatible chat model client (`openAiCompatibleChatModel.ts`), a loopback-only HTTP server exposing `/health/live`, `/health/ready`, and `POST /v1/chat`, a CLI smoke command, and environment-driven configuration that keeps Atlassian AI Gateway details in the local provider and defaults to the `gpt-5.6-sol` model.
- Ships token-free fake-provider tests across config, HTTP server, and the model client, plus build/typecheck tooling (`tsconfig`, `pnpm-workspace`), and hardens the upstream response schema to tolerate partial/missing `usage` fields so valid completions are never dropped.
- Documents the new workspace in `README.md` and `DEVELOPMENT.md`, including scoped agent checks and that the public React site remains unchanged with no model calls.

## Risk Assessment

✅ Low: The only change since the prior round is a tightly-scoped, well-tested fix that relaxes upstream usage parsing to keep valid completions while normalizing only valid nonnegative-integer counts, exactly per the accepted instruction, with no new issues.

## Testing

Ran the agent workspace's token-free checks (typecheck, 10 fake-provider Vitest tests, build) which all pass, then demonstrated the milestone end-to-end against the already-running local ai-gateway-provider: the CLI `pnpm smoke` returned a real `gpt-5.6-sol` completion (`agent-smoke-ok`), and the loopback HTTP server served `/health/live`, `/health/ready` (reporting `gpt-5.6-sol`), a live `POST /v1/chat` completion (`agent-http-ok`), and a 422 rejection for an invalid body with no model call. Verified the diff touches only `agent/` and two docs, leaving the React site unchanged and free of model calls. All checks passed with no findings; transient `dist/` build output was cleaned up.

<details>
<summary>Evidence: CLI smoke transcript (live gpt-5.6-sol)</summary>

<code>{&#10;&#34;model&#34;: &#34;gpt-5.6-sol&#34;,&#10;&#34;content&#34;: &#34;agent-smoke-ok&#34;,&#10;&#34;usage&#34;: { &#34;promptTokens&#34;: 14, &#34;completionTokens&#34;: 7, &#34;totalTokens&#34;: 21 }&#10;}</code>

```text
### pnpm smoke (CLI path -> live ai-gateway-provider @127.0.0.1:8787/v1)
$ tsx src/cli.ts smoke
{
  "model": "gpt-5.6-sol",
  "content": "agent-smoke-ok",
  "usage": {
    "promptTokens": 14,
    "completionTokens": 7,
    "totalTokens": 21
  }
}
```
</details>
<details>
<summary>Evidence: HTTP server transcript (health + live /v1/chat + 422 validation)</summary>

<code>GET /health/live -&gt; {&#34;status&#34;:&#34;ok&#34;}&#10;GET /health/ready -&gt; {&#34;status&#34;:&#34;ready&#34;,&#34;model&#34;:&#34;gpt-5.6-sol&#34;}&#10;POST /v1/chat -&gt; {&#34;id&#34;:&#34;chatcmpl-...&#34;,&#34;model&#34;:&#34;gpt-5.6-sol&#34;,&#34;content&#34;:&#34;agent-http-ok&#34;,&#34;finishReason&#34;:&#34;stop&#34;,&#34;usage&#34;:{...}}&#10;POST /v1/chat {messages:[]} -&gt; http_status=422</code>

```text
### GET /health/live
{"status":"ok"}

### GET /health/ready
{"status":"ready","model":"gpt-5.6-sol"}

### POST /v1/chat (live model call through provider)
{"id":"chatcmpl-EAphcCIXePXNpGkC0D5X4BVqjiYED","model":"gpt-5.6-sol","content":"agent-http-ok","finishReason":"stop","usage":{"promptTokens":13,"completionTokens":6,"totalTokens":19}}

### POST /v1/chat invalid body (empty messages) -> 422, no model call
http_status=422
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `agent/src/openAiCompatibleChatModel.ts:22` - The `usage` field in `upstreamResponseSchema` requires all three sub-fields (`prompt_tokens`, `completion_tokens`, `total_tokens`) as strictly nonnegative integers. If the provider returns a `usage` object that is present but missing a field or reports a value that isn&#39;t a nonnegative int (some OpenAI-compatible gateways omit `total_tokens` or return partial/float usage), the entire `safeParse` fails and a valid completion with real content is discarded as &#39;unexpected response shape&#39;. Consider making the usage sub-fields optional/tolerant so a valid completion is never dropped over auxiliary accounting metadata.
- ℹ️ `agent/src/config.ts:6` - The intent requires a &#39;loopback-only HTTP server&#39;. The default bind host is `127.0.0.1` (good), but `SANMOU_AGENT_HOST` accepts any non-empty string, so the server can be bound to a non-loopback address (e.g. `0.0.0.0`) via env without any guard. The loopback constraint is only enforced by default value and documentation, not by validation. If loopback-only is a hard requirement, consider restricting/validating the host.
- ℹ️ `agent/src/httpServer.ts:78` - `GET /health/ready` unconditionally returns `{status:&#39;ready&#39;}` and echoes the model name without performing any check against the configured model provider. It reports readiness even when the upstream provider is unreachable, which can mislead callers/orchestration that rely on the readiness signal.

🔧 Fix: tolerate partial upstream usage without dropping completions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd agent &amp;&amp; pnpm typecheck` — clean</code>
- <code>`cd agent &amp;&amp; pnpm test` — 10 fake-provider tests pass across config/httpServer/openAiCompatibleChatModel, zero tokens</code>
- <code>`cd agent &amp;&amp; pnpm build` — tsc emits dist (removed after verification; gitignored)</code>
- <code>`pnpm smoke` against live ai-gateway-provider — model `gpt-5.6-sol` returned content `agent-smoke-ok` with usage</code>
- <code>`pnpm start` + `curl GET /health/live` → {status:ok}, `GET /health/ready` → {status:ready,model:gpt-5.6-sol}</code>
- <code>`curl POST /v1/chat` against live provider → content `agent-http-ok` from `gpt-5.6-sol`</code>
- <code>`curl POST /v1/chat` with empty messages → HTTP 422 (rejected before any model call)</code>
- <code>`git diff --stat base..target` — confirmed only agent/, README.md, DEVELOPMENT.md changed; no web/ source</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
