### PR TITLE
feat(agent): expose team recommendation HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,9 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
   public static site, and hosts one parent LangGraph recommendation workflow.
   Its internal hero, formation/row, and skill subgraphs fill only null values,
   preserve every already-filled value, and then run a read-only team review.
-  Already-complete inputs route directly to that review. See
+  Already-complete inputs route directly to that review. Its loopback HTTP
+  server exposes a typed team-recommendation endpoint to explicitly allowed
+  browser origins while keeping generic chat outside browser CORS. See
   [agent/README.md](agent/README.md) for the graph nodes and the
   `pnpm recommend` fixture run.
 - `data/import_yanwu_workbook.py` — strict, deterministic five-sheet workbook

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -2,6 +2,10 @@
 SANMOU_AGENT_HOST=127.0.0.1
 SANMOU_AGENT_PORT=8790
 
+# Browser origins allowed to call health and team recommendation endpoints.
+# Generic /v1/chat remains unavailable to browser CORS requests.
+SANMOU_AGENT_ALLOWED_ORIGINS=https://sanmouyanwu.com,http://localhost:3000,http://127.0.0.1:3000,http://localhost:4173,http://127.0.0.1:4173
+
 # OpenAI-compatible model provider endpoint.
 AI_BASE_URL=http://127.0.0.1:8787/v1
 AI_MODEL=gpt-5.6-sol

--- a/agent/README.md
+++ b/agent/README.md
@@ -14,7 +14,7 @@ kept outside this repository.
 ## Runtime architecture
 
 ```text
-CLI or local HTTP caller
+CLI, local HTTP caller, or enabled browser experiment
           |
           v
 Sanmou Agent (127.0.0.1:8790)
@@ -25,6 +25,12 @@ OpenAI-compatible provider (127.0.0.1:8787/v1)
 
 The public Sanmou website does not start this service and consumes no model
 tokens.
+
+The HTTP server binds only to loopback. Browser access is restricted to the
+health endpoints and `POST /v1/team-recommendations`; the generic `/v1/chat`
+endpoint remains available only to callers that do not send a browser
+`Origin`. The OpenAI-compatible provider is never called directly by the web
+app.
 
 ## Team recommendation graph
 
@@ -145,6 +151,33 @@ Check liveness:
 curl http://127.0.0.1:8790/health/live
 ```
 
+Exercise the same preflight that the production website sends:
+
+```bash
+curl --include --request OPTIONS \
+  http://127.0.0.1:8790/v1/team-recommendations \
+  -H 'origin: https://sanmouyanwu.com' \
+  -H 'access-control-request-method: POST' \
+  -H 'access-control-request-headers: content-type'
+```
+
+Review the complete fixture through the browser-facing endpoint. A partial
+fixture uses the same route and runs the required completion stages before
+review:
+
+```bash
+curl --silent --show-error --fail-with-body \
+  http://127.0.0.1:8790/v1/team-recommendations \
+  -H 'origin: https://sanmouyanwu.com' \
+  -H 'content-type: application/json' \
+  --data-binary @fixtures/complete-teams.json
+```
+
+`availableHeroes` and `availableSkills` in this request are unused pools, not
+the entire owned roster. The endpoint validates the same
+`TeamRecommendationInput` contract as the CLI and returns the same
+`TeamRecommendationResult`.
+
 Send a chat request through the agent and its configured provider:
 
 ```bash
@@ -160,12 +193,31 @@ curl --silent --show-error --fail-with-body \
   }'
 ```
 
+Do not add an `Origin` header to generic chat calls. Browser-origin requests to
+`/v1/chat` are deliberately rejected even when that origin may call team
+recommendations.
+
+## Browser access
+
+The server responds to JSON preflight requests only when `Origin` exactly
+matches `SANMOU_AGENT_ALLOWED_ORIGINS`. It never uses a wildcard, sends no CORS
+credentials, and continues to accept local curl/CLI calls that have no
+`Origin`. Keep the default loopback bind; non-loopback host values are rejected
+at startup.
+
+Chrome 142 and later also asks the user for Local Network Access permission
+when a public page calls loopback. The web integration must initiate its first
+health or recommendation request from an explicit click so ordinary visitors
+are never prompted. Desktop Chrome is the supported browser for this private
+experiment.
+
 ## Configuration
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `SANMOU_AGENT_HOST` | `127.0.0.1` | Local server bind address |
 | `SANMOU_AGENT_PORT` | `8790` | Local server port |
+| `SANMOU_AGENT_ALLOWED_ORIGINS` | production site plus local dev/preview origins | Exact browser origins allowed to call health and team recommendations |
 | `AI_BASE_URL` | `http://127.0.0.1:8787/v1` | OpenAI-compatible provider base URL |
 | `AI_MODEL` | `gpt-5.6-sol` | Default model ID |
 | `SANMOU_REASONING_EFFORT` | `high` | Effort for hero, formation/row, skill, and review reasoning nodes |

--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -3,8 +3,13 @@ import { resolve } from 'node:path';
 import { z } from 'zod';
 
 const environmentSchema = z.object({
-  SANMOU_AGENT_HOST: z.string().min(1).default('127.0.0.1'),
+  SANMOU_AGENT_HOST: z.enum(['127.0.0.1', 'localhost', '::1']).default('127.0.0.1'),
   SANMOU_AGENT_PORT: z.coerce.number().int().min(1).max(65_535).default(8790),
+  SANMOU_AGENT_ALLOWED_ORIGINS: z
+    .string()
+    .default(
+      'https://sanmouyanwu.com,http://localhost:3000,http://127.0.0.1:3000,http://localhost:4173,http://127.0.0.1:4173'
+    ),
   AI_BASE_URL: z.url().default('http://127.0.0.1:8787/v1'),
   AI_MODEL: z.string().min(1).default('gpt-5.6-sol'),
   SANMOU_REASONING_EFFORT: z.enum(['low', 'medium', 'high']).default('high'),
@@ -12,9 +17,27 @@ const environmentSchema = z.object({
   AI_API_KEY: z.string().min(1).optional(),
 });
 
+const browserOriginSchema = z
+  .url()
+  .refine((value) => ['http:', 'https:'].includes(new URL(value).protocol), {
+    message: 'Browser origins must use http or https',
+  })
+  .refine((value) => new URL(value).origin === value, {
+    message: 'Browser origins must contain only scheme, host, and optional port',
+  });
+
+function parseAllowedOrigins(value: string): string[] {
+  const origins = value
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+  return [...new Set(z.array(browserOriginSchema).min(1).parse(origins))];
+}
+
 export interface AgentConfig {
   host: string;
   port: number;
+  allowedOrigins: string[];
   model: {
     baseUrl: string;
     model: string;
@@ -40,6 +63,7 @@ export function readAgentConfig(
   return {
     host: parsed.SANMOU_AGENT_HOST,
     port: parsed.SANMOU_AGENT_PORT,
+    allowedOrigins: parseAllowedOrigins(parsed.SANMOU_AGENT_ALLOWED_ORIGINS),
     model: {
       baseUrl: parsed.AI_BASE_URL.replace(/\/+$/, ''),
       model: parsed.AI_MODEL,

--- a/agent/src/httpServer.ts
+++ b/agent/src/httpServer.ts
@@ -1,13 +1,28 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { ZodError } from 'zod';
 import { agentChatRequestSchema } from './httpSchemas.js';
-import { ChatModelError, type ChatModel } from './model.js';
+import {
+  ChatModelError,
+  type ChatModel,
+  type ReasoningEffort,
+} from './model.js';
+import type { GameKnowledge } from './team/gameData.js';
+import { runTeamRecommendation } from './team/teamRecommendationGraph.js';
+import { teamRecommendationInputSchema } from './team/teamRecommendationSchemas.js';
 
 const MAX_BODY_BYTES = 256 * 1024;
+const BROWSER_ENDPOINTS = new Set([
+  '/health/live',
+  '/health/ready',
+  '/v1/team-recommendations',
+]);
 
 export interface AgentHttpServerOptions {
   model: ChatModel;
   modelName: string;
+  knowledge: GameKnowledge;
+  reasoningEffort?: ReasoningEffort;
+  allowedOrigins: readonly string[];
 }
 
 class RequestBodyError extends Error {
@@ -40,6 +55,32 @@ function writeError(
   });
 }
 
+function prepareBrowserRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  pathname: string,
+  allowedOrigins: ReadonlySet<string>
+): boolean {
+  const origin = request.headers.origin;
+  if (origin === undefined) return true;
+  if (!BROWSER_ENDPOINTS.has(pathname) || !allowedOrigins.has(origin)) {
+    writeError(response, 403, 'Browser origin is not allowed', 'forbidden_origin');
+    return false;
+  }
+
+  response.setHeader('access-control-allow-origin', origin);
+  response.setHeader('vary', 'Origin');
+  if (request.method !== 'OPTIONS') return true;
+
+  response.writeHead(204, {
+    'access-control-allow-methods': 'GET, POST, OPTIONS',
+    'access-control-allow-headers': 'Content-Type',
+    'access-control-max-age': '600',
+  });
+  response.end();
+  return false;
+}
+
 async function readJson(request: IncomingMessage): Promise<unknown> {
   const contentType = request.headers['content-type'] ?? '';
   if (!contentType.toLowerCase().startsWith('application/json')) {
@@ -67,9 +108,11 @@ async function readJson(request: IncomingMessage): Promise<unknown> {
 async function handleRequest(
   request: IncomingMessage,
   response: ServerResponse,
-  options: AgentHttpServerOptions
+  options: AgentHttpServerOptions,
+  allowedOrigins: ReadonlySet<string>
 ): Promise<void> {
   const pathname = new URL(request.url ?? '/', 'http://localhost').pathname;
+  if (!prepareBrowserRequest(request, response, pathname, allowedOrigins)) return;
 
   if (request.method === 'GET' && pathname === '/health/live') {
     writeJson(response, 200, { status: 'ok' });
@@ -79,13 +122,29 @@ async function handleRequest(
     writeJson(response, 200, { status: 'ready', model: options.modelName });
     return;
   }
-  if (request.method !== 'POST' || pathname !== '/v1/chat') {
+  if (
+    request.method !== 'POST' ||
+    (pathname !== '/v1/chat' && pathname !== '/v1/team-recommendations')
+  ) {
     writeError(response, 404, 'Route not found', 'not_found');
     return;
   }
 
   try {
     const body = await readJson(request);
+    if (pathname === '/v1/team-recommendations') {
+      const parsed = teamRecommendationInputSchema.parse(body);
+      const result = await runTeamRecommendation(parsed, {
+        model: options.model,
+        knowledge: options.knowledge,
+        ...(options.reasoningEffort === undefined
+          ? {}
+          : { reasoningEffort: options.reasoningEffort }),
+      });
+      writeJson(response, 200, result);
+      return;
+    }
+
     const parsed = agentChatRequestSchema.parse(body);
     const completion = await options.model.complete({
       messages: parsed.messages,
@@ -105,7 +164,17 @@ async function handleRequest(
       return;
     }
     if (error instanceof ZodError) {
-      writeError(response, 422, 'Request body does not match the chat contract', 'validation_error', error.issues);
+      const contract =
+        pathname === '/v1/team-recommendations'
+          ? 'team recommendation'
+          : 'chat';
+      writeError(
+        response,
+        422,
+        `Request body does not match the ${contract} contract`,
+        'validation_error',
+        error.issues
+      );
       return;
     }
     if (error instanceof ChatModelError) {
@@ -119,7 +188,8 @@ async function handleRequest(
 }
 
 export function createAgentHttpServer(options: AgentHttpServerOptions): Server {
+  const allowedOrigins = new Set(options.allowedOrigins);
   return createServer((request, response) => {
-    void handleRequest(request, response, options);
+    void handleRequest(request, response, options, allowedOrigins);
   });
 }

--- a/agent/src/server.ts
+++ b/agent/src/server.ts
@@ -1,15 +1,24 @@
 import { createAgentHttpServer } from './httpServer.js';
 import { loadLocalEnvironment, readAgentConfig } from './config.js';
 import { OpenAICompatibleChatModel } from './openAiCompatibleChatModel.js';
+import { loadGameKnowledge } from './team/gameData.js';
 
 loadLocalEnvironment();
 const config = readAgentConfig();
 const model = new OpenAICompatibleChatModel(config.model);
-const server = createAgentHttpServer({ model, modelName: config.model.model });
+const knowledge = await loadGameKnowledge();
+const server = createAgentHttpServer({
+  model,
+  modelName: config.model.model,
+  knowledge,
+  reasoningEffort: config.reasoningEffort,
+  allowedOrigins: config.allowedOrigins,
+});
 
 server.listen(config.port, config.host, () => {
   console.log(`Sanmou agent listening on http://${config.host}:${config.port}`);
   console.log(`Model: ${config.model.model}`);
+  console.log(`Browser origins: ${config.allowedOrigins.join(', ')}`);
 });
 
 function shutdown(signal: string): void {

--- a/agent/tests/config.test.ts
+++ b/agent/tests/config.test.ts
@@ -8,6 +8,13 @@ describe('readAgentConfig', () => {
     expect(config).toEqual({
       host: '127.0.0.1',
       port: 8790,
+      allowedOrigins: [
+        'https://sanmouyanwu.com',
+        'http://localhost:3000',
+        'http://127.0.0.1:3000',
+        'http://localhost:4173',
+        'http://127.0.0.1:4173',
+      ],
       reasoningEffort: 'high',
       model: {
         baseUrl: 'http://127.0.0.1:8787/v1',
@@ -21,6 +28,8 @@ describe('readAgentConfig', () => {
     const config = readAgentConfig({
       SANMOU_AGENT_HOST: 'localhost',
       SANMOU_AGENT_PORT: '9000',
+      SANMOU_AGENT_ALLOWED_ORIGINS:
+        ' https://example.com, http://localhost:3000,https://example.com ',
       AI_BASE_URL: 'http://localhost:9001/v1/',
       AI_MODEL: 'test-model',
       SANMOU_REASONING_EFFORT: 'low',
@@ -31,6 +40,7 @@ describe('readAgentConfig', () => {
     expect(config).toEqual({
       host: 'localhost',
       port: 9000,
+      allowedOrigins: ['https://example.com', 'http://localhost:3000'],
       reasoningEffort: 'low',
       model: {
         baseUrl: 'http://localhost:9001/v1',
@@ -39,5 +49,17 @@ describe('readAgentConfig', () => {
         apiKey: 'secret',
       },
     });
+  });
+
+  it('rejects non-loopback binds and origins containing paths', () => {
+    expect(() => readAgentConfig({ SANMOU_AGENT_HOST: '0.0.0.0' })).toThrow();
+    expect(() =>
+      readAgentConfig({
+        SANMOU_AGENT_ALLOWED_ORIGINS: 'https://sanmouyanwu.com/team-builder',
+      })
+    ).toThrow('Browser origins must contain only scheme, host, and optional port');
+    expect(() =>
+      readAgentConfig({ SANMOU_AGENT_ALLOWED_ORIGINS: 'ftp://localhost' })
+    ).toThrow('Browser origins must use http or https');
   });
 });

--- a/agent/tests/httpServer.test.ts
+++ b/agent/tests/httpServer.test.ts
@@ -3,16 +3,29 @@ import type { Server } from 'node:http';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createAgentHttpServer } from '../src/httpServer.js';
 import type { ChatCompletionRequest, ChatModel } from '../src/model.js';
+import type { TeamRecommendationInput } from '../src/team/teamRecommendationSchemas.js';
+import {
+  completeReviewTeams,
+  skillTestKnowledge,
+  validReviewDecision,
+} from './teamFixtures.js';
+
+const BROWSER_ORIGIN = 'https://sanmouyanwu.com';
 
 class FakeChatModel implements ChatModel {
   readonly requests: ChatCompletionRequest[] = [];
 
+  constructor(private readonly content: string | string[] = 'fake-response') {}
+
   async complete(request: ChatCompletionRequest) {
+    const responseIndex = this.requests.length;
     this.requests.push(request);
     return {
       id: 'fake-1',
       model: 'fake-model',
-      content: 'fake-response',
+      content: Array.isArray(this.content)
+        ? this.content[responseIndex] ?? this.content.at(-1) ?? ''
+        : this.content,
       finishReason: 'stop',
       usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
     };
@@ -22,7 +35,13 @@ class FakeChatModel implements ChatModel {
 const openServers: Server[] = [];
 
 async function startServer(model: ChatModel): Promise<{ server: Server; baseUrl: string }> {
-  const server = createAgentHttpServer({ model, modelName: 'fake-model' });
+  const server = createAgentHttpServer({
+    model,
+    modelName: 'fake-model',
+    knowledge: skillTestKnowledge,
+    reasoningEffort: 'high',
+    allowedOrigins: [BROWSER_ORIGIN, 'http://localhost:3000'],
+  });
   openServers.push(server);
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);
@@ -99,6 +118,185 @@ describe('agent HTTP server', () => {
     expect(response.status).toBe(422);
     expect(await response.json()).toMatchObject({
       error: { type: 'validation_error' },
+    });
+    expect(model.requests).toEqual([]);
+  });
+
+  it('answers browser preflight only for an allowed team endpoint origin', async () => {
+    const model = new FakeChatModel();
+    const { baseUrl } = await startServer(model);
+
+    const response = await fetch(`${baseUrl}/v1/team-recommendations`, {
+      method: 'OPTIONS',
+      headers: {
+        origin: BROWSER_ORIGIN,
+        'access-control-request-method': 'POST',
+        'access-control-request-headers': 'content-type',
+      },
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-origin')).toBe(BROWSER_ORIGIN);
+    expect(response.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(response.headers.get('access-control-allow-headers')).toBe('Content-Type');
+    expect(response.headers.get('vary')).toBe('Origin');
+    expect(model.requests).toEqual([]);
+  });
+
+  it('rejects disallowed browser origins and browser access to generic chat', async () => {
+    const model = new FakeChatModel();
+    const { baseUrl } = await startServer(model);
+
+    const disallowed = await fetch(`${baseUrl}/health/ready`, {
+      headers: { origin: 'https://example.com' },
+    });
+    const genericChat = await fetch(`${baseUrl}/v1/chat`, {
+      method: 'POST',
+      headers: {
+        origin: BROWSER_ORIGIN,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hello' }] }),
+    });
+
+    expect(disallowed.status).toBe(403);
+    expect(disallowed.headers.get('access-control-allow-origin')).toBeNull();
+    expect(await disallowed.json()).toMatchObject({
+      error: { type: 'forbidden_origin' },
+    });
+    expect(genericChat.status).toBe(403);
+    expect(genericChat.headers.get('access-control-allow-origin')).toBeNull();
+    expect(model.requests).toEqual([]);
+  });
+
+  it('routes a completed browser lineup directly to grounded review', async () => {
+    const model = new FakeChatModel(validReviewDecision);
+    const { baseUrl } = await startServer(model);
+
+    const response = await fetch(`${baseUrl}/v1/team-recommendations`, {
+      method: 'POST',
+      headers: {
+        origin: BROWSER_ORIGIN,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        season: 1,
+        availableHeroes: [],
+        availableSkills: [],
+        teams: completeReviewTeams,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('access-control-allow-origin')).toBe(BROWSER_ORIGIN);
+    expect(await response.json()).toMatchObject({
+      status: 'complete',
+      stoppedAt: null,
+      attempts: { heroes: 0, formations: 0, skills: 0, review: 1 },
+      review: { status: 'complete', verdict: 'sound' },
+    });
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it('runs every recommendation stage for a partial browser lineup', async () => {
+    const input: TeamRecommendationInput = {
+      season: 1,
+      availableHeroes: ['魏丙', '蜀甲'],
+      availableSkills: ['治疗术'],
+      teams: [
+        {
+          formation: null,
+          heroes: [
+            { hero: '魏甲', row: null, skills: ['甲技', null] },
+            { hero: '魏乙', row: '前排', skills: ['乙技', '丙技'] },
+            { hero: null, row: null, skills: ['丁技', '戊技'] },
+          ],
+        },
+      ],
+    };
+    const model = new FakeChatModel([
+      JSON.stringify({
+        assignments: [
+          {
+            teamIndex: 0,
+            slotIndex: 2,
+            hero: '魏丙',
+            reason: '三魏触发10%属性加成。',
+            evidence: ['同阵营三人'],
+          },
+        ],
+      }),
+      JSON.stringify({
+        decisions: [
+          {
+            teamIndex: 0,
+            formation: '雁形阵',
+            rows: [
+              { slotIndex: 0, row: '后排' },
+              { slotIndex: 1, row: '前排' },
+              { slotIndex: 2, row: '后排' },
+            ],
+            reason: '乙在前排承伤，甲与丙在后排发挥。',
+            evidence: ['雁形阵后排增伤'],
+          },
+        ],
+      }),
+      JSON.stringify({
+        assignments: [
+          {
+            teamIndex: 0,
+            slotIndex: 0,
+            skillSlotIndex: 1,
+            skill: '治疗术',
+            reason: '利用智力补充团队治疗。',
+            evidence: ['治疗受智力影响'],
+          },
+        ],
+      }),
+      validReviewDecision,
+    ]);
+    const { baseUrl } = await startServer(model);
+
+    const response = await fetch(`${baseUrl}/v1/team-recommendations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: 'complete',
+      attempts: { heroes: 1, formations: 1, skills: 1, review: 1 },
+      teams: [
+        {
+          formation: '雁形阵',
+          heroes: [
+            { hero: '魏甲', row: '后排', skills: ['甲技', '治疗术'] },
+            { hero: '魏乙', row: '前排', skills: ['乙技', '丙技'] },
+            { hero: '魏丙', row: '后排', skills: ['丁技', '戊技'] },
+          ],
+        },
+      ],
+    });
+    expect(model.requests).toHaveLength(4);
+  });
+
+  it('rejects an invalid team contract before calling the model', async () => {
+    const model = new FakeChatModel();
+    const { baseUrl } = await startServer(model);
+
+    const response = await fetch(`${baseUrl}/v1/team-recommendations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ teams: [] }),
+    });
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toMatchObject({
+      error: {
+        type: 'validation_error',
+        message: 'Request body does not match the team recommendation contract',
+      },
     });
     expect(model.requests).toEqual([]);
   });


### PR DESCRIPTION
## Intent

Expose the existing Sanmou TeamRecommendationGraph through a stable local HTTP endpoint so the production /team-builder page can later invoke it without exposing the generic AI Gateway provider. Add POST /v1/team-recommendations using the same validated input/result contracts as the CLI, load game knowledge once at server startup, preserve generic /v1/chat for non-browser local callers only, bind strictly to loopback, and implement exact-origin CORS for https://sanmouyanwu.com plus local development/preview origins with JSON preflight support and no wildcard or credentials. Ordinary visitors must not be contacted or prompted by this server; desktop Chrome is the only supported browser for the private experiment. Cover complete direct-review and partial full-graph routes, allowed/disallowed origins, generic-chat browser denial, configuration validation, documentation, curl preflight, and a real live-provider endpoint check.

## What Changed

- Added `POST /v1/team-recommendations` to the local agent HTTP server, running the existing `TeamRecommendationGraph` behind the same validated input/result contracts as the CLI, loading game knowledge once at startup, and returning HTTP 422 when the request body fails the contract (routing complete inputs straight to review and partial inputs through the full hero/formation/skill graph).
- Bound the server strictly to loopback and implemented exact-origin CORS for `https://sanmouyanwu.com` plus local dev/preview origins — JSON preflight support, no wildcard, no credentials — while restricting generic `/v1/chat` to non-browser local callers (browser origins receive `403 forbidden_origin`).
- Extended `config.ts` with loopback-only bind and origin validation, updated `.env.example` and the agent/root READMEs, and added `config.test.ts` and `httpServer.test.ts` coverage for the new routes, origin allow/deny behavior, and configuration validation.

## Risk Assessment

✅ Low: The change is a well-bounded, thoroughly tested addition to the local loopback agent server whose security-critical CORS/origin, loopback-bind, and generic-chat-denial logic is correct and matches the authoritative intent.

## Testing

Complete test step: baseline agent-workspace checks all pass — `pnpm typecheck`, `pnpm test` (60 tests including the new HTTP CORS/routing and config-validation cases), and `pnpm build`. Because passing unit tests alone are not sufficient evidence, I additionally exercised the endpoint end-to-end against the real `pnpm start` server (loopback-bound, game knowledge loaded once at startup) pointed at a local OpenAI-compatible mock provider, and captured a full curl transcript proving every intent constraint: exact-origin CORS preflight returning 204 with no wildcard and no credentials, disallowed-origin and browser-origin generic-chat both rejected with 403, the non-browser (no-Origin) /v1/chat path still reaching the provider with 200, a complete lineup returning a 200 TeamRecommendationResult with a 'sound' review over a genuine HTTP provider round-trip (mock call logged), and a 422 for an invalid team contract; lsof confirmed the strict 127.0.0.1 bind. The partial full-graph route is covered by the passing HTTP integration unit test. Note: the "real live-provider" round-trip used a local OpenAI-compatible mock because the actual AI gateway on the default port returned HTTP 400 (auth/model mismatch) and is not reliably usable in this sandbox; the integration path exercised is identical and the full graph completed over real HTTP. This is a UI-adjacent but non-visual (loopback JSON API) change, so no screenshot/GIF applies — the reviewer-facing evidence is the raw HTTP response/header transcript. No product failures found.

<details>
<summary>Evidence: End-to-end curl transcript (real server: startup, loopback bind, CORS preflight, origin allow/deny, generic-chat browser denial, complete 200 review, 422 validation, mock-provider call log)</summary>

```text

======================================================================
Agent server startup (loads game knowledge once, binds loopback, prints allowed origins)
======================================================================
$ tsx src/server.ts
Sanmou agent listening on http://127.0.0.1:8790
Model: mock-model
Browser origins: https://sanmouyanwu.com, http://localhost:3000, http://127.0.0.1:3000, http://localhost:4173, http://127.0.0.1:4173

======================================================================
Loopback bind check (lsof: which address the agent listens on)
======================================================================
COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
node    24804 lma2   21u  IPv4 0xbbf03b0be28ee296      0t0  TCP 127.0.0.1:8790 (LISTEN)

======================================================================
1) CORS preflight from ALLOWED origin https://sanmouyanwu.com -> expect 204 + CORS headers
======================================================================
HTTP/1.1 204 No Content
access-control-allow-origin: https://sanmouyanwu.com
vary: Origin
access-control-allow-methods: GET, POST, OPTIONS
access-control-allow-headers: Content-Type
access-control-max-age: 600
Date: Mon, 10 Aug 2026 02:14:56 GMT
Connection: keep-alive
Keep-Alive: timeout=5


======================================================================
2) Preflight/GET from DISALLOWED origin https://evil.example -> expect 403 forbidden_origin, no ACAO
======================================================================
HTTP/1.1 403 Forbidden
content-type: application/json; charset=utf-8
Date: Mon, 10 Aug 2026 02:14:56 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

{"error":{"message":"Browser origin is not allowed","type":"forbidden_origin"}}
======================================================================
3) Generic /v1/chat WITH a browser Origin -> expect 403 (browser denied even for allowed origin)
======================================================================
HTTP/1.1 403 Forbidden
content-type: application/json; charset=utf-8
Date: Mon, 10 Aug 2026 02:14:56 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

{"error":{"message":"Browser origin is not allowed","type":"forbidden_origin"}}
======================================================================
4) Generic /v1/chat with NO Origin (non-browser CLI caller) -> reaches provider, returns 200
======================================================================
HTTP/1.1 200 OK
content-type: application/json; charset=utf-8
Date: Mon, 10 Aug 2026 02:14:56 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

{"id":"mock-1","model":"mock-model","content":"{\"teams\":[{\"teamIndex\":0,\"strengths\":[],\"warnings\":[]},{\"teamIndex\":1,\"strengths\":[],\"warnings\":[]},{\"teamIndex\":2,\"strengths\":[],\"warnings\":[]}],\"crossTeamWarnings\":[]}","finishReason":"stop","usage":{"promptTokens":10,"completionTokens":20,"totalTokens":30}}
======================================================================
5) POST /v1/team-recommendations from browser origin, COMPLETE lineup -> expect 200 review result
======================================================================
HTTP/1.1 200 OK
access-control-allow-origin: https://sanmouyanwu.com
vary: Origin
content-type: application/json; charset=utf-8
Date: Mon, 10 Aug 2026 02:14:56 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

{"teams":[{"formation":"雁形阵","heroes":[{"hero":"司马懿","row":"前排","skills":["未雨绸缪","奇正相生"]},{"hero":"郝昭","row":"前排","skills":["岿然不动","知人善任"]},{"hero":"曹丕","row":"前排","skills":["折冲御侮","铸甲销戈"]}]},{"formation":"雁形阵","heroes":[{"hero":"孙坚2","row":"后排","skills":["伏兵四起","势如破竹"]},{"hero":"吕布","row":"后排","skills":["千里突袭","兵贵神速"]},{"hero":"貂蝉","row":"前排","skills":["调和阴阳","忘私相助"]}]},{"formation":"方圆阵","heroes":[{"hero":"关羽","row":"后排","skills":["如有神助","及锋而试"]},{"hero":"马云禄","row":"后排","skills":["无难之志","揭竿而起"]},{"hero":"魏延","row":"前排","skills":["断敌粮道","挫锐折锋"]}]}],"status":"complete","stoppedAt":null,"attempts":{"heroes":0,"formations":0,"skills":0,"review":1},"heroAssignments":[],"formationDecisions":[],"skillAssignments":[],"review":{"status":"complete","verdict":"sound","teams":[{"teamIndex":0,"verdict":"sound","strengths":[],"warnings":[]},{"teamIndex":1,"verdict":"sound","strengths":[],"warnings":[]},{"teamIndex":2,"verdict":"sound","strengths":[],"warnings":[]}],"crossTeamWarnings":[],"deterministicRuleWarnings":[],"attempts":1,"warnings":[]},"warnings":[]}
======================================================================
6) POST /v1/team-recommendations with INVALID contract -> expect 422 team recommendation contract
======================================================================
HTTP/1.1 422 Unprocessable Entity
access-control-allow-origin: https://sanmouyanwu.com
vary: Origin
content-type: application/json; charset=utf-8
Date: Mon, 10 Aug 2026 02:14:56 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

{"error":{"message":"Request body does not match the team recommendation contract","type":"validation_error","details":[{"origin":"array","code":"too_small","minimum":1,"inclusive":true,"path":["teams"],"message":"Too small: expected array to have >=1 items"},{"expected":"array","code":"invalid_type","path":["availableHeroes"],"message":"Invalid input: expected array, received undefined"},{"expected":"array","code":"invalid_type","path":["availableSkills"],"message":"Invalid input: expected array, received undefined"}]}}
======================================================================
Mock provider call log (proves the endpoint drove a real HTTP provider round-trip)
======================================================================
[mock-provider] listening on http://127.0.0.1:8801
[mock-provider] completion call #1 (POST /v1/chat/completions)
[mock-provider] completion call #2 (POST /v1/chat/completions)

DONE
```
</details>
<details>
<summary>Evidence: Real agent server startup log (game knowledge loaded once, loopback bind, allowed origins printed)</summary>

<code>$ tsx src/server.ts&#10;Sanmou agent listening on http://127.0.0.1:8790&#10;Model: mock-model&#10;Browser origins: https://sanmouyanwu.com, http://localhost:3000, http://127.0.0.1:3000, http://localhost:4173, http://127.0.0.1:4173</code>

```text
$ tsx src/server.ts
Sanmou agent listening on http://127.0.0.1:8790
Model: mock-model
Browser origins: https://sanmouyanwu.com, http://localhost:3000, http://127.0.0.1:3000, http://localhost:4173, http://127.0.0.1:4173
Received SIGTERM; shutting down
```
</details>
<details>
<summary>Evidence: Key browser-contract responses (allowed preflight 204, disallowed 403, browser-chat 403, complete lineup 200 sound review)</summary>

```text
OPTIONS /v1/team-recommendations (origin https://sanmouyanwu.com) -> 204; access-control-allow-origin: https://sanmouyanwu.com; access-control-allow-methods: GET, POST, OPTIONS; access-control-allow-headers: Content-Type; vary: Origin
GET /health/ready (origin https://evil.example) -> 403 {"error":{"type":"forbidden_origin"}} (no ACAO)
POST /v1/chat (origin https://sanmouyanwu.com) -> 403 forbidden_origin
POST /v1/chat (no origin) -> 200 (provider reached)
POST /v1/team-recommendations (origin https://sanmouyanwu.com, complete-teams.json) -> 200 status:complete attempts.review:1 review.verdict:sound
POST /v1/team-recommendations {"teams":[]} -> 422 'Request body does not match the team recommendation contract'
```
</details>
<details>
<summary>Evidence: Mock OpenAI-compatible provider used for the live round-trip</summary>

```text
// Minimal OpenAI-compatible mock provider for the Sanmou agent end-to-end check.
// Returns an empty-but-valid team review decision so POST /v1/team-recommendations
// completes over a real HTTP round-trip. It counts how many completion calls it saw.
import { createServer } from 'node:http';

let calls = 0;

const server = createServer((req, res) => {
  let body = '';
  req.on('data', (c) => (body += c));
  req.on('end', () => {
    calls += 1;
    // The complete-teams fixture has 3 teams; return an empty valid review for each.
    const content = JSON.stringify({
      teams: [
        { teamIndex: 0, strengths: [], warnings: [] },
        { teamIndex: 1, strengths: [], warnings: [] },
        { teamIndex: 2, strengths: [], warnings: [] },
      ],
      crossTeamWarnings: [],
    });
    const payload = JSON.stringify({
      id: 'mock-1',
      model: 'mock-model',
      choices: [{ message: { content }, finish_reason: 'stop' }],
      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
    });
    res.writeHead(200, { 'content-type': 'application/json' });
    res.end(payload);
    console.error(`[mock-provider] completion call #${calls} (${req.method} ${req.url})`);
  });
});

server.listen(8801, '127.0.0.1', () => {
  console.error('[mock-provider] listening on http://127.0.0.1:8801');
});
```
</details>
<details>
<summary>Evidence: E2E driver script (starts mock provider + real agent, runs curl checks)</summary>

```text
#!/usr/bin/env bash
# End-to-end evidence driver for the team-recommendation HTTP endpoint.
# Starts a mock OpenAI-compatible provider + the REAL Sanmou agent server,
# then drives the browser-facing contract with curl exactly as the website would.
set -u
export PATH="$HOME/.nvm/versions/node/v22.17.1/bin:$PATH"

EV=/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KZMPRAGMRFX6NKCT2MEWRD6J
AGENT_DIR=/Users/lma2/.no-mistakes/worktrees/cddaca7d92a1/01KZMPRAGMRFX6NKCT2MEWRD6J/agent
BASE=http://127.0.0.1:8790
OUT="$EV/e2e-transcript.txt"
: > "$OUT"

log() { echo "$@" | tee -a "$OUT"; }
section() { log ""; log "======================================================================"; log "$1"; log "======================================================================"; }

cleanup() {
  [ -n "${MOCK_PID:-}" ] && kill "$MOCK_PID" 2>/dev/null
  [ -n "${AGENT_PID:-}" ] && kill "$AGENT_PID" 2>/dev/null
}
trap cleanup EXIT

# 1. mock provider
node "$EV/mock-provider.mjs" 2> "$EV/mock-provider.log" &
MOCK_PID=$!

# 2. real agent server pointed at the mock provider (default loopback + default allowed origins)
cd "$AGENT_DIR"
AI_BASE_URL=http://127.0.0.1:8801/v1 AI_MODEL=mock-model pnpm start > "$EV/agent-server.log" 2>&1 &
AGENT_PID=$!

# wait for the agent to report it is listening
for i in $(seq 1 60); do
  if grep -q "Sanmou agent listening" "$EV/agent-server.log" 2>/dev/null; then break; fi
  sleep 0.5
done

section "Agent server startup (loads game knowledge once, binds loopback, prints allowed origins)"
cat "$EV/agent-server.log" | tee -a "$OUT"

section "Loopback bind check (lsof: which address the agent listens on)"
lsof -nP -iTCP:8790 -sTCP:LISTEN 2>/dev/null | tee -a "$OUT" || log "(lsof unavailable)"

section "1) CORS preflight from ALLOWED origin https://sanmouyanwu.com -> expect 204 + CORS headers"
curl -sS --include --request OPTIONS "$BASE/v1/team-recommendations" \
  -H 'origin: https://sanmouyanwu.com' \
  -H 'access-control-request-method: POST' \
  -H 'access-control-request-headers: content-type' 2>&1 | tee -a "$OUT"

section "2) Preflight/GET from DISALLOWED origin https://evil.example -> expect 403 forbidden_origin, no ACAO"
curl -sS --include "$BASE/health/ready" -H 'origin: https://evil.example' 2>&1 | tee -a "$OUT"

section "3) Generic /v1/chat WITH a browser Origin -> expect 403 (browser denied even for allowed origin)"
curl -sS --include --request POST "$BASE/v1/chat" \
  -H 'origin: https://sanmouyanwu.com' \
  -H 'content-type: application/json' \
  --data '{"messages":[{"role":"user","content":"hello"}]}' 2>&1 | tee -a "$OUT"

section "4) Generic /v1/chat with NO Origin (non-browser CLI caller) -> reaches provider, returns 200"
curl -sS --include --request POST "$BASE/v1/chat" \
  -H 'content-type: application/json' \
  --data '{"messages":[{"role":"user","content":"hi"}]}' 2>&1 | tee -a "$OUT"

section "5) POST /v1/team-recommendations from browser origin, COMPLETE lineup -> expect 200 review result"
curl -sS --include --request POST "$BASE/v1/team-recommendations" \
  -H 'origin: https://sanmouyanwu.com' \
  -H 'content-type: application/json' \
  --data-binary @fixtures/complete-teams.json 2>&1 | tee -a "$OUT"

section "6) POST /v1/team-recommendations with INVALID contract -> expect 422 team recommendation contract"
curl -sS --include --request POST "$BASE/v1/team-recommendations" \
  -H 'origin: https://sanmouyanwu.com' \
  -H 'content-type: application/json' \
  --data '{"teams":[]}' 2>&1 | tee -a "$OUT"

section "Mock provider call log (proves the endpoint drove a real HTTP provider round-trip)"
cat "$EV/mock-provider.log" | tee -a "$OUT"

log ""
log "DONE"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd agent &amp;&amp; pnpm typecheck` (Go-native tsc, clean)</code>
- <code>`cd agent &amp;&amp; pnpm test` — 60 vitest tests pass, incl. httpServer.test.ts (preflight allowed origin, disallowed-origin + generic-chat browser denial, complete direct-review route, partial full-graph route running all 4 stages, 422 team-recommendation contract) and config.test.ts (non-loopback bind rejected, path/scheme origin rejected)</code>
- <code>`cd agent &amp;&amp; pnpm build` (tsc build, clean)</code>
- <code>Started the real server (`AI_BASE_URL=http://127.0.0.1:8801/v1 pnpm start`) against a local OpenAI-compatible mock provider; confirmed startup loads game knowledge once, binds 127.0.0.1:8790 (verified via `lsof -nP -iTCP:8790 -sTCP:LISTEN`), and prints allowed origins</code>
- `curl OPTIONS preflight from https://sanmouyanwu.com -> 204 with exact-origin access-control-allow-origin, methods GET/POST/OPTIONS, allow-headers Content-Type, max-age 600, vary: Origin`
- `curl GET /health/ready from https://evil.example -> 403 forbidden_origin with no access-control-allow-origin`
- `curl POST /v1/chat with browser Origin -> 403 forbidden_origin (browser denied even for an allowed origin)`
- `curl POST /v1/chat with no Origin -> 200 (non-browser CLI path preserved, real provider round-trip)`
- `curl POST /v1/team-recommendations from browser origin with fixtures/complete-teams.json -> 200 status:complete, attempts heroes/formations/skills=0 review=1 (direct-review route), review verdict 'sound' via a real HTTP provider call`
- `curl POST /v1/team-recommendations with {"teams":[]} -> 422 'Request body does not match the team recommendation contract'`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
