### PR TITLE
feat(web): integrate local team agent into Team Builder

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -205,6 +205,12 @@ credentials, and continues to accept local curl/CLI calls that have no
 `Origin`. Keep the default loopback bind; non-loopback host values are rejected
 at startup.
 
+The web integration is a private, hidden experiment. Start this Agent, then
+open `/team-builder?local-agent=1` once to enable and remember the Agent button
+in that browser. Use `/team-builder?local-agent=0` to hide it again. Enabling
+the flag makes no network request; the page contacts `127.0.0.1:8790` only
+after an explicit click on `智能补全阵容` or `智能复盘阵容`.
+
 Chrome 142 and later also asks the user for Local Network Access permission
 when a public page calls loopback. The web integration must initiate its first
 health or recommendation request from an explicit click so ordinary visitors

--- a/web/src/components/teamBuilder/AgentReviewPanel.tsx
+++ b/web/src/components/teamBuilder/AgentReviewPanel.tsx
@@ -1,0 +1,250 @@
+import CloseIcon from '@mui/icons-material/Close';
+import UndoIcon from '@mui/icons-material/Undo';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Divider,
+  IconButton,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import type {
+  TeamAgentAssignment,
+  TeamAgentResult,
+  TeamAgentReviewWarning,
+  TeamAgentVerdict,
+} from '../../services/localTeamAgent';
+
+export type TeamAgentRunMode = 'recommend' | 'review';
+
+interface AgentReviewPanelProps {
+  result: TeamAgentResult;
+  mode: TeamAgentRunMode;
+  canUndo: boolean;
+  onUndo: () => void;
+  onDismiss: () => void;
+}
+
+const verdictText: Record<TeamAgentVerdict, string> = {
+  sound: '整体合理',
+  workable: '可用但可改进',
+  needs_changes: '建议调整',
+};
+
+const stoppedAtText = {
+  heroes: '武将补全',
+  formations: '阵型与站位补全',
+  skills: '战法补全',
+} as const;
+
+const assignmentTitle = (assignment: TeamAgentAssignment): string => {
+  const location = `第 ${assignment.teamIndex + 1} 队`;
+  if (assignment.hero) return `${location} · ${assignment.hero}`;
+  if (assignment.formation) return `${location} · ${assignment.formation}`;
+  if (assignment.skill) return `${location} · ${assignment.skill}`;
+  return location;
+};
+
+const WarningList = ({
+  warnings,
+}: {
+  warnings: TeamAgentReviewWarning[];
+}) => (
+  <Stack spacing={1}>
+    {warnings.map((warning, index) => (
+      <Alert
+        severity={warning.severity === 'critical' ? 'error' : 'warning'}
+        key={`${warning.category}-${warning.message}-${index}`}
+      >
+        <Typography variant="body2" fontWeight={800}>
+          {warning.message}
+        </Typography>
+        <Typography variant="body2">建议：{warning.suggestedAction}</Typography>
+        {warning.teamIndexes && (
+          <Typography variant="caption" color="text.secondary">
+            涉及队伍：{warning.teamIndexes.map((item) => item + 1).join('、')}
+          </Typography>
+        )}
+      </Alert>
+    ))}
+  </Stack>
+);
+
+const AssignmentDetails = ({ result }: { result: TeamAgentResult }) => {
+  const assignments = [
+    ...result.heroAssignments,
+    ...result.formationDecisions,
+    ...result.skillAssignments,
+  ];
+  if (assignments.length === 0) return null;
+
+  return (
+    <Accordion disableGutters elevation={0}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Typography fontWeight={800}>
+          Agent 选择依据（{assignments.length} 项）
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Stack spacing={1.25} divider={<Divider flexItem />}>
+          {assignments.map((assignment, index) => (
+            <Box key={`${assignmentTitle(assignment)}-${index}`}>
+              <Typography variant="body2" fontWeight={800}>
+                {assignmentTitle(assignment)}
+              </Typography>
+              <Typography variant="body2">{assignment.reason}</Typography>
+              {assignment.evidence.length > 0 && (
+                <Typography variant="caption" color="text.secondary">
+                  证据：{assignment.evidence.join('、')}
+                </Typography>
+              )}
+            </Box>
+          ))}
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+const AgentReviewPanel = ({
+  result,
+  mode,
+  canUndo,
+  onUndo,
+  onDismiss,
+}: AgentReviewPanelProps) => {
+  const review = result.review;
+  const crossWarnings = review
+    ? [...review.deterministicRuleWarnings, ...review.crossTeamWarnings]
+    : [];
+
+  return (
+    <Paper
+      component="section"
+      aria-label={mode === 'recommend' ? '智能补全结果' : '智能复盘结果'}
+      aria-live="polite"
+      data-testid="local-agent-result"
+      sx={{ mt: 2, border: '1px solid', borderColor: 'divider', p: 2 }}
+    >
+      <Stack spacing={1.5}>
+        <Stack direction="row" alignItems="flex-start" gap={1}>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="h6" fontWeight={900}>
+              {mode === 'recommend' ? '智能补全结果' : '智能复盘结果'}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              调用次数：武将 {result.attempts.heroes} · 阵型{' '}
+              {result.attempts.formations} · 战法 {result.attempts.skills} · 复盘{' '}
+              {result.attempts.review}
+            </Typography>
+          </Box>
+          <Chip
+            size="small"
+            color={result.status === 'complete' ? 'success' : 'warning'}
+            label={result.status === 'complete' ? '已完成' : '未完整补全'}
+          />
+          {canUndo && (
+            <Button size="small" startIcon={<UndoIcon />} onClick={onUndo}>
+              撤销智能补全
+            </Button>
+          )}
+          <IconButton size="small" aria-label="关闭智能结果" onClick={onDismiss}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+
+        {result.status === 'incomplete' && result.stoppedAt && (
+          <Alert severity="warning">
+            Agent 在“{stoppedAtText[result.stoppedAt]}”阶段没有得到通过校验的答案。
+            已保留能够验证的结果，其余位置继续留空。
+          </Alert>
+        )}
+
+        {result.warnings.map((warning, index) => (
+          <Alert severity="warning" key={`${warning}-${index}`}>
+            {warning}
+          </Alert>
+        ))}
+
+        <AssignmentDetails result={result} />
+
+        {review?.status === 'unavailable' && (
+          <Alert severity="warning">
+            阵容补全结果已保留，但本次复盘没有得到通过校验的模型输出。
+          </Alert>
+        )}
+
+        {review?.status === 'complete' && review.verdict && (
+          <>
+            <Alert
+              severity={
+                review.verdict === 'sound'
+                  ? 'success'
+                  : review.verdict === 'workable'
+                    ? 'info'
+                    : 'warning'
+              }
+            >
+              总体结论：{verdictText[review.verdict]}
+            </Alert>
+
+            {review.teams.map((team) => (
+              <Accordion
+                disableGutters
+                elevation={0}
+                key={team.teamIndex}
+                defaultExpanded={team.warnings.length > 0}
+                sx={{ border: '1px solid', borderColor: 'divider' }}
+              >
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Typography fontWeight={900}>
+                      队伍 {team.teamIndex + 1}
+                    </Typography>
+                    <Chip size="small" label={verdictText[team.verdict]} />
+                  </Stack>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Stack spacing={1.25}>
+                    {team.strengths.map((strength, index) => (
+                      <Alert
+                        severity="success"
+                        key={`${strength.category}-${strength.message}-${index}`}
+                      >
+                        {strength.message}
+                      </Alert>
+                    ))}
+                    <WarningList warnings={team.warnings} />
+                    {team.strengths.length === 0 && team.warnings.length === 0 && (
+                      <Typography variant="body2" color="text.secondary">
+                        本队没有额外提示。
+                      </Typography>
+                    )}
+                  </Stack>
+                </AccordionDetails>
+              </Accordion>
+            ))}
+
+            {crossWarnings.length > 0 && (
+              <Box>
+                <Typography fontWeight={900} sx={{ mb: 1 }}>
+                  跨队与资源规则提醒
+                </Typography>
+                <WarningList warnings={crossWarnings} />
+              </Box>
+            )}
+          </>
+        )}
+      </Stack>
+    </Paper>
+  );
+};
+
+export default AgentReviewPanel;

--- a/web/src/components/teamBuilder/__tests__/AgentReviewPanel.test.tsx
+++ b/web/src/components/teamBuilder/__tests__/AgentReviewPanel.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { TeamAgentResult } from '../../../services/localTeamAgent';
+import AgentReviewPanel from '../AgentReviewPanel';
+
+const result: TeamAgentResult = {
+  teams: [],
+  status: 'complete',
+  stoppedAt: null,
+  attempts: { heroes: 1, formations: 1, skills: 2, review: 1 },
+  heroAssignments: [
+    {
+      teamIndex: 0,
+      slotIndex: 1,
+      hero: '郝昭',
+      reason: '补足魏阵营并提供承伤能力',
+      evidence: ['campBonus:魏'],
+    },
+  ],
+  formationDecisions: [],
+  skillAssignments: [],
+  review: {
+    status: 'complete',
+    verdict: 'workable',
+    teams: [
+      {
+        teamIndex: 0,
+        verdict: 'workable',
+        strengths: [
+          {
+            category: 'camp',
+            message: '三名魏将获得阵营加成',
+            evidence: [{ source: 'campBonus', id: 'camp:魏' }],
+          },
+        ],
+        warnings: [
+          {
+            severity: 'warning',
+            category: 'position',
+            message: '后排输出位保护不足',
+            suggestedAction: '调整郝昭到前排',
+            evidence: [{ source: 'hero', id: '郝昭' }],
+          },
+        ],
+      },
+    ],
+    crossTeamWarnings: [],
+    deterministicRuleWarnings: [],
+    attempts: 1,
+    warnings: [],
+  },
+  warnings: [],
+};
+
+test('shows recommendation reasoning, review warnings, and undo', () => {
+  const onUndo = vi.fn();
+  render(
+    <AgentReviewPanel
+      result={result}
+      mode="recommend"
+      canUndo
+      onUndo={onUndo}
+      onDismiss={vi.fn()}
+    />
+  );
+
+  expect(
+    screen.getByRole('region', { name: '智能补全结果' })
+  ).toBeVisible();
+  expect(screen.getByText('总体结论：可用但可改进')).toBeVisible();
+  expect(screen.getByText('后排输出位保护不足')).toBeVisible();
+  expect(screen.getByText('建议：调整郝昭到前排')).toBeVisible();
+
+  fireEvent.click(screen.getByRole('button', { name: '撤销智能补全' }));
+  expect(onUndo).toHaveBeenCalledTimes(1);
+});
+
+test('honestly reports a stopped graph and unavailable review', () => {
+  render(
+    <AgentReviewPanel
+      result={{
+        ...result,
+        status: 'incomplete',
+        stoppedAt: 'skills',
+        review: {
+          ...result.review!,
+          status: 'unavailable',
+          verdict: null,
+          teams: [],
+        },
+      }}
+      mode="recommend"
+      canUndo={false}
+      onUndo={vi.fn()}
+      onDismiss={vi.fn()}
+    />
+  );
+
+  expect(screen.getByText(/“战法补全”阶段/)).toBeVisible();
+  expect(screen.getByText(/本次复盘没有得到通过校验/)).toBeVisible();
+});

--- a/web/src/pages/TeamBuilder.tsx
+++ b/web/src/pages/TeamBuilder.tsx
@@ -18,6 +18,7 @@ import {
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import AutoAwesomeOutlinedIcon from '@mui/icons-material/AutoAwesomeOutlined';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
@@ -25,6 +26,9 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import RestartAltOutlinedIcon from '@mui/icons-material/RestartAltOutlined';
 import CurrentTeam from '../components/game/CurrentTeam';
 import FormationWorkbench from '../components/teamBuilder/FormationWorkbench';
+import AgentReviewPanel, {
+  type TeamAgentRunMode,
+} from '../components/teamBuilder/AgentReviewPanel';
 import { useGame } from '../context/GameContext';
 import { database, recommendationData } from '../data';
 import {
@@ -58,6 +62,16 @@ import {
   type TeamBuilderRow,
 } from '../services/teamBuilderArrangement';
 import { summarizeTeamBuilderRecommendation } from '../services/teamBuilderMessaging';
+import {
+  LocalTeamAgentError,
+  createTeamAgentRequest,
+  isTeamBuilderLayoutComplete,
+  layoutFromTeamAgentTeams,
+  requestLocalTeamRecommendation,
+  syncLocalTeamAgentExperiment,
+  teamBuilderLayoutFingerprint,
+  type TeamAgentResult,
+} from '../services/localTeamAgent';
 import { copyToClipboard } from '../utils/clipboard';
 import { storage } from '../utils/storage';
 
@@ -94,7 +108,7 @@ const sameTeamBuilderLayout = (
 const TeamBuilder = () => {
   const navigate = useNavigate();
   const { state, dispatch } = useGame();
-  const { gameState, availableHeroes, availableSkills } = state;
+  const { gameState, availableHeroes, availableSkills, selectedSeason } = state;
   const [formation, setFormation] =
     useState<FormationRecommendation | null>(null);
   const [resultKey, setResultKey] = useState<string | null>(null);
@@ -110,7 +124,17 @@ const TeamBuilder = () => {
   });
   const [promptInfoAnchor, setPromptInfoAnchor] =
     useState<HTMLElement | null>(null);
+  const [localAgentEnabled] = useState(syncLocalTeamAgentExperiment);
+  const [agentPending, setAgentPending] = useState(false);
+  const [agentResult, setAgentResult] = useState<{
+    result: TeamAgentResult;
+    mode: TeamAgentRunMode;
+  } | null>(null);
+  const [agentError, setAgentError] = useState<string | null>(null);
+  const [agentUndoLayout, setAgentUndoLayout] =
+    useState<TeamBuilderLayout | null>(null);
   const seededPoolKeyRef = useRef<string | null>(null);
+  const agentAbortRef = useRef<AbortController | null>(null);
 
   const heroes = useMemo(
     () => [
@@ -142,6 +166,9 @@ const TeamBuilder = () => {
     () => teamBuilderPoolKey(heroes, skills),
     [heroes, skills]
   );
+  const agentContextFingerprint = `${poolKey}:${selectedSeason}:${teamBuilderLayoutFingerprint(layout)}`;
+  const agentContextFingerprintRef = useRef(agentContextFingerprint);
+  agentContextFingerprintRef.current = agentContextFingerprint;
   const formationCacheKey = useMemo(
     () =>
       teamFormationCacheKey(
@@ -197,12 +224,22 @@ const TeamBuilder = () => {
       seededPoolKeyRef.current = null;
     }
     setHydratedKey(poolKey);
+    setAgentResult(null);
+    setAgentError(null);
+    setAgentUndoLayout(null);
   }, [heroes, poolKey, skills]);
 
   useEffect(() => {
     if (hydratedKey !== poolKey) return;
     storage.saveTeamBuilder(createStoredTeamBuilderLayout(poolKey, layout));
   }, [hydratedKey, layout, poolKey]);
+
+  useEffect(
+    () => () => {
+      agentAbortRef.current?.abort();
+    },
+    []
+  );
 
   useEffect(() => {
     if (!isEligible) {
@@ -336,6 +373,9 @@ const TeamBuilder = () => {
 
   const markEdited = () => {
     seededPoolKeyRef.current = poolKey;
+    setAgentResult(null);
+    setAgentError(null);
+    setAgentUndoLayout(null);
   };
 
   const handleMove = (
@@ -375,6 +415,9 @@ const TeamBuilder = () => {
     if (!recommendedLayout) return;
     setLayout(recommendedLayout);
     seededPoolKeyRef.current = poolKey;
+    setAgentResult(null);
+    setAgentError(null);
+    setAgentUndoLayout(null);
     setSnackbar({ open: true, message: '已恢复当前卡池的阵容库推荐' });
   };
 
@@ -400,6 +443,84 @@ const TeamBuilder = () => {
         ? '强度复盘提示词已复制'
         : '复制失败，请检查浏览器剪贴板权限',
     });
+  };
+
+  const agentMode: TeamAgentRunMode = isTeamBuilderLayoutComplete(layout)
+    ? 'review'
+    : 'recommend';
+
+  const handleRunAgent = async () => {
+    const mode = agentMode;
+    const inputLayout = cloneTeamBuilderLayout(layout);
+    const inputFingerprint = agentContextFingerprint;
+    const controller = new AbortController();
+    agentAbortRef.current?.abort();
+    agentAbortRef.current = controller;
+    setAgentPending(true);
+    setAgentError(null);
+
+    try {
+      const result = await requestLocalTeamRecommendation(
+        createTeamAgentRequest({
+          layout: inputLayout,
+          heroes,
+          skills,
+          season: selectedSeason,
+        }),
+        { signal: controller.signal }
+      );
+      if (inputFingerprint !== agentContextFingerprintRef.current) {
+        setSnackbar({
+          open: true,
+          message: '等待期间阵容已修改，本次 Agent 结果已忽略',
+        });
+        return;
+      }
+
+      if (mode === 'recommend') {
+        const nextLayout = layoutFromTeamAgentTeams(result.teams);
+        setAgentUndoLayout(inputLayout);
+        setLayout(nextLayout);
+        seededPoolKeyRef.current = poolKey;
+      } else {
+        setAgentUndoLayout(null);
+      }
+      setAgentResult({ result, mode });
+      setSnackbar({
+        open: true,
+        message:
+          mode === 'recommend'
+            ? result.status === 'complete'
+              ? 'Agent 已补全阵容并完成复盘'
+              : 'Agent 已保留通过校验的部分结果'
+            : 'Agent 已完成阵容复盘',
+      });
+    } catch (error) {
+      if (error instanceof LocalTeamAgentError && error.code === 'aborted') {
+        return;
+      }
+      const message =
+        error instanceof LocalTeamAgentError && error.code === 'unavailable'
+          ? '无法连接本地 Agent。请确认 8790 服务已启动，并允许 Chrome 访问本地网络。'
+          : error instanceof Error
+            ? `本地 Agent 请求失败：${error.message}`
+            : '本地 Agent 请求失败';
+      setAgentError(message);
+    } finally {
+      if (agentAbortRef.current === controller) {
+        agentAbortRef.current = null;
+        setAgentPending(false);
+      }
+    }
+  };
+
+  const handleUndoAgent = () => {
+    if (!agentUndoLayout) return;
+    setLayout(agentUndoLayout);
+    seededPoolKeyRef.current = poolKey;
+    setAgentUndoLayout(null);
+    setAgentResult(null);
+    setSnackbar({ open: true, message: '已撤销本次智能补全' });
   };
 
   const isSystemRecommendation =
@@ -614,6 +735,32 @@ const TeamBuilder = () => {
                   justifyContent="flex-end"
                   sx={{ ml: 'auto', maxWidth: '100%' }}
                 >
+                  {localAgentEnabled && (
+                    <Tooltip title="调用本机 Agent；首次使用时 Chrome 会询问本地网络权限">
+                      <span>
+                        <Button
+                          variant="contained"
+                          color="primary"
+                          startIcon={
+                            agentPending ? (
+                              <CircularProgress size={18} color="inherit" />
+                            ) : (
+                              <AutoAwesomeOutlinedIcon />
+                            )
+                          }
+                          onClick={handleRunAgent}
+                          disabled={agentPending || heroes.length === 0}
+                          sx={{ minHeight: 44, whiteSpace: 'nowrap' }}
+                        >
+                          {agentPending
+                            ? 'Agent 正在处理...'
+                            : agentMode === 'recommend'
+                              ? '智能补全阵容'
+                              : '智能复盘阵容'}
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  )}
                   <Stack direction="row" spacing={0.25} alignItems="center">
                     <IconButton
                       aria-label="了解强度复盘提示词"
@@ -670,6 +817,28 @@ const TeamBuilder = () => {
                 </Stack>
               }
             />
+            {agentError && (
+              <Alert
+                severity="error"
+                data-testid="local-agent-error"
+                sx={{ mt: 2 }}
+                onClose={() => setAgentError(null)}
+              >
+                {agentError}
+              </Alert>
+            )}
+            {agentResult && (
+              <AgentReviewPanel
+                result={agentResult.result}
+                mode={agentResult.mode}
+                canUndo={agentUndoLayout !== null}
+                onUndo={handleUndoAgent}
+                onDismiss={() => {
+                  setAgentResult(null);
+                  setAgentUndoLayout(null);
+                }}
+              />
+            )}
           </>
         )}
       </Box>

--- a/web/src/services/__tests__/localTeamAgent.test.ts
+++ b/web/src/services/__tests__/localTeamAgent.test.ts
@@ -1,0 +1,203 @@
+import {
+  LOCAL_TEAM_AGENT_EXPERIMENT_KEY,
+  LocalTeamAgentError,
+  createTeamAgentRequest,
+  isTeamBuilderLayoutComplete,
+  layoutFromTeamAgentTeams,
+  parseTeamAgentResult,
+  requestLocalTeamRecommendation,
+  syncLocalTeamAgentExperiment,
+  type TeamAgentTeam,
+} from '../localTeamAgent';
+import {
+  createEmptyTeamBuilderLayout,
+} from '../teamBuilderArrangement';
+
+const completeAgentTeams = (): TeamAgentTeam[] =>
+  Array.from({ length: 3 }, (_, teamIndex) => ({
+    formation: `阵型${teamIndex + 1}`,
+    heroes: Array.from({ length: 3 }, (_, slotIndex) => ({
+      hero: `武将${teamIndex}-${slotIndex}`,
+      row: slotIndex === 0 ? ('前排' as const) : ('后排' as const),
+      skills: [
+        `战法${teamIndex}-${slotIndex}-0`,
+        `战法${teamIndex}-${slotIndex}-1`,
+      ] as [string, string],
+    })) as TeamAgentTeam['heroes'],
+  }));
+
+const validResult = () => ({
+  teams: completeAgentTeams(),
+  status: 'complete',
+  stoppedAt: null,
+  attempts: { heroes: 1, formations: 1, skills: 2, review: 1 },
+  heroAssignments: [
+    {
+      teamIndex: 0,
+      slotIndex: 1,
+      hero: '武将0-1',
+      reason: '同阵营并补足谋略输出',
+      evidence: ['hero:武将0-1'],
+    },
+  ],
+  formationDecisions: [],
+  skillAssignments: [],
+  review: {
+    status: 'complete',
+    verdict: 'sound',
+    teams: [
+      {
+        teamIndex: 0,
+        verdict: 'sound',
+        strengths: [
+          {
+            category: 'camp',
+            message: '三名武将同阵营',
+            evidence: [{ source: 'campBonus', id: 'camp:魏' }],
+          },
+        ],
+        warnings: [],
+      },
+    ],
+    crossTeamWarnings: [],
+    deterministicRuleWarnings: [],
+    attempts: 1,
+    warnings: [],
+  },
+  warnings: [],
+});
+
+describe('local Team Agent experiment', () => {
+  beforeEach(() => localStorage.clear());
+
+  test('persists explicit enable and disable query parameters', () => {
+    expect(syncLocalTeamAgentExperiment('?local-agent=1', localStorage)).toBe(
+      true
+    );
+    expect(localStorage.getItem(LOCAL_TEAM_AGENT_EXPERIMENT_KEY)).toBe(
+      'enabled'
+    );
+    expect(syncLocalTeamAgentExperiment('', localStorage)).toBe(true);
+
+    expect(syncLocalTeamAgentExperiment('?local-agent=0', localStorage)).toBe(
+      false
+    );
+    expect(localStorage.getItem(LOCAL_TEAM_AGENT_EXPERIMENT_KEY)).toBeNull();
+  });
+
+  test('does not enable itself without an explicit or stored flag', () => {
+    expect(syncLocalTeamAgentExperiment('', localStorage)).toBe(false);
+  });
+});
+
+describe('Team Agent request mapping', () => {
+  test('sends only unused resources and does not treat visual row defaults as decisions', () => {
+    const layout = createEmptyTeamBuilderLayout();
+    layout[0].heroes[0].hero = '司马懿';
+    layout[0].heroes[0].skills[0] = '未雨绸缪';
+    layout[1].formation = '雁形阵';
+    layout[1].heroes[0].hero = '曹丕';
+    layout[1].heroes[0].row = '后排';
+
+    const request = createTeamAgentRequest({
+      layout,
+      heroes: ['司马懿', '曹丕', '郝昭'],
+      skills: ['未雨绸缪', '奇正相生'],
+      season: 8,
+    });
+
+    expect(request.availableHeroes).toEqual(['郝昭']);
+    expect(request.availableSkills).toEqual(['奇正相生']);
+    expect(request.season).toBe(8);
+    expect(request.teams[0].formation).toBeNull();
+    expect(request.teams[0].heroes[0].row).toBeNull();
+    expect(request.teams[0].heroes[1].row).toBeNull();
+    expect(request.teams[1].heroes[0].row).toBe('后排');
+  });
+
+  test('detects whether all hero, formation, and skill slots are filled', () => {
+    const layout = layoutFromTeamAgentTeams(completeAgentTeams());
+    expect(isTeamBuilderLayoutComplete(layout)).toBe(true);
+
+    layout[2].heroes[2].skills[1] = null;
+    expect(isTeamBuilderLayoutComplete(layout)).toBe(false);
+  });
+
+  test('maps nullable Agent fields back to safe editable UI defaults', () => {
+    const teams = completeAgentTeams();
+    teams[0].formation = null;
+    teams[0].heroes[0].row = null;
+    teams[0].heroes[0].hero = null;
+    teams[0].heroes[0].skills[0] = null;
+
+    const layout = layoutFromTeamAgentTeams(teams);
+    expect(layout[0].formation).toBe('');
+    expect(layout[0].heroes[0]).toEqual({
+      hero: null,
+      row: '前排',
+      skills: [null, '战法0-0-1'],
+    });
+  });
+});
+
+describe('Team Agent response boundary', () => {
+  test('validates a response before exposing it to the page', () => {
+    expect(parseTeamAgentResult(validResult())).toMatchObject({
+      status: 'complete',
+      stoppedAt: null,
+      attempts: { heroes: 1, formations: 1, skills: 2, review: 1 },
+      review: { status: 'complete', verdict: 'sound' },
+    });
+  });
+
+  test('rejects malformed response teams', () => {
+    const result = validResult();
+    result.teams = result.teams.slice(0, 2);
+    expect(() => parseTeamAgentResult(result)).toThrow(LocalTeamAgentError);
+  });
+
+  test('checks readiness and then posts the recommendation', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: 'ready' }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(validResult()), { status: 200 })
+      );
+    const input = createTeamAgentRequest({
+      layout: layoutFromTeamAgentTeams(completeAgentTeams()),
+      heroes: [],
+      skills: [],
+      season: 8,
+    });
+
+    const result = await requestLocalTeamRecommendation(input, { fetchImpl });
+
+    expect(result.status).toBe('complete');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'http://127.0.0.1:8790/health/ready'
+    );
+    expect(fetchImpl.mock.calls[1][0]).toBe(
+      'http://127.0.0.1:8790/v1/team-recommendations'
+    );
+    expect(fetchImpl.mock.calls[1][1]).toMatchObject({ method: 'POST' });
+  });
+
+  test('classifies a network failure as unavailable', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new TypeError('fetch failed'));
+
+    await expect(
+      requestLocalTeamRecommendation(
+        {
+          teams: [],
+          availableHeroes: [],
+          availableSkills: [],
+          season: 8,
+        },
+        { fetchImpl }
+      )
+    ).rejects.toMatchObject({ code: 'unavailable' });
+  });
+});

--- a/web/src/services/localTeamAgent.ts
+++ b/web/src/services/localTeamAgent.ts
@@ -1,0 +1,526 @@
+import {
+  TEAM_BUILDER_DEFAULT_ROW,
+  collectUsedTeamBuilderItems,
+  createEmptyTeamBuilderLayout,
+  type TeamBuilderLayout,
+  type TeamBuilderRow,
+} from './teamBuilderArrangement';
+
+export const LOCAL_TEAM_AGENT_URL = 'http://127.0.0.1:8790';
+export const LOCAL_TEAM_AGENT_EXPERIMENT_KEY =
+  'sanmou.experimental.localAgent.v1';
+
+export type TeamAgentStage = 'heroes' | 'formations' | 'skills';
+export type TeamAgentVerdict = 'sound' | 'workable' | 'needs_changes';
+export type TeamAgentReviewStatus = 'complete' | 'unavailable';
+
+export interface TeamAgentSlot {
+  hero: string | null;
+  row: TeamBuilderRow | null;
+  skills: [string | null, string | null];
+}
+
+export interface TeamAgentTeam {
+  formation: string | null;
+  heroes: [TeamAgentSlot, TeamAgentSlot, TeamAgentSlot];
+}
+
+export interface TeamAgentRequest {
+  teams: TeamAgentTeam[];
+  availableHeroes: string[];
+  availableSkills: string[];
+  season: number;
+}
+
+export interface TeamAgentEvidenceRef {
+  source: string;
+  id: string;
+}
+
+export interface TeamAgentReviewStrength {
+  category: string;
+  message: string;
+  evidence: TeamAgentEvidenceRef[];
+}
+
+export interface TeamAgentReviewWarning {
+  severity: 'warning' | 'critical';
+  category: string;
+  message: string;
+  suggestedAction: string;
+  evidence: TeamAgentEvidenceRef[];
+  teamIndexes?: number[];
+}
+
+export interface TeamAgentReviewTeam {
+  teamIndex: number;
+  verdict: TeamAgentVerdict;
+  strengths: TeamAgentReviewStrength[];
+  warnings: TeamAgentReviewWarning[];
+}
+
+export interface TeamAgentReview {
+  status: TeamAgentReviewStatus;
+  verdict: TeamAgentVerdict | null;
+  teams: TeamAgentReviewTeam[];
+  crossTeamWarnings: TeamAgentReviewWarning[];
+  deterministicRuleWarnings: TeamAgentReviewWarning[];
+  attempts: number;
+  warnings: string[];
+}
+
+export interface TeamAgentAssignment {
+  teamIndex: number;
+  reason: string;
+  evidence: string[];
+  slotIndex?: number;
+  skillSlotIndex?: number;
+  hero?: string;
+  skill?: string;
+  formation?: string;
+}
+
+export interface TeamAgentResult {
+  teams: TeamAgentTeam[];
+  status: 'complete' | 'incomplete';
+  stoppedAt: TeamAgentStage | null;
+  attempts: {
+    heroes: number;
+    formations: number;
+    skills: number;
+    review: number;
+  };
+  heroAssignments: TeamAgentAssignment[];
+  formationDecisions: TeamAgentAssignment[];
+  skillAssignments: TeamAgentAssignment[];
+  review: TeamAgentReview | null;
+  warnings: string[];
+}
+
+export type LocalTeamAgentErrorCode =
+  | 'unavailable'
+  | 'http'
+  | 'invalid_response'
+  | 'aborted';
+
+export class LocalTeamAgentError extends Error {
+  readonly code: LocalTeamAgentErrorCode;
+
+  constructor(code: LocalTeamAgentErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+type StorageSubset = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+const browserStorage = (): StorageSubset | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Enables the private experiment with ?local-agent=1 and persists that choice.
+ * ?local-agent=0 disables it. Merely enabling the flag never contacts localhost.
+ */
+export function syncLocalTeamAgentExperiment(
+  search = typeof window === 'undefined' ? '' : window.location.search,
+  storage: StorageSubset | null = browserStorage()
+): boolean {
+  const setting = new URLSearchParams(search).get('local-agent');
+  try {
+    if (setting === '1') {
+      storage?.setItem(LOCAL_TEAM_AGENT_EXPERIMENT_KEY, 'enabled');
+      return true;
+    }
+    if (setting === '0') {
+      storage?.removeItem(LOCAL_TEAM_AGENT_EXPERIMENT_KEY);
+      return false;
+    }
+    return storage?.getItem(LOCAL_TEAM_AGENT_EXPERIMENT_KEY) === 'enabled';
+  } catch {
+    return setting === '1';
+  }
+}
+
+export function isTeamBuilderLayoutComplete(
+  layout: TeamBuilderLayout
+): boolean {
+  return layout.every(
+    (team) =>
+      team.formation !== '' &&
+      team.heroes.every(
+        (slot) =>
+          slot.hero !== null && slot.skills.every((skill) => skill !== null)
+      )
+  );
+}
+
+export function createTeamAgentRequest(input: {
+  layout: TeamBuilderLayout;
+  heroes: readonly string[];
+  skills: readonly string[];
+  season: number;
+}): TeamAgentRequest {
+  const used = collectUsedTeamBuilderItems(input.layout);
+  return {
+    teams: input.layout.map((team) => ({
+      formation: team.formation || null,
+      heroes: team.heroes.map((slot) => ({
+        hero: slot.hero,
+        // Rows are only meaningful once a formation exists. Empty slots also
+        // carry a visual UI default that must not constrain Agent reasoning.
+        row:
+          slot.hero === null || team.formation === '' ? null : slot.row,
+        skills: [...slot.skills] as [string | null, string | null],
+      })) as [TeamAgentSlot, TeamAgentSlot, TeamAgentSlot],
+    })),
+    availableHeroes: input.heroes.filter((hero) => !used.heroes.has(hero)),
+    availableSkills: input.skills.filter((skill) => !used.skills.has(skill)),
+    season: input.season,
+  };
+}
+
+export function layoutFromTeamAgentTeams(
+  teams: readonly TeamAgentTeam[]
+): TeamBuilderLayout {
+  if (teams.length !== 3) {
+    throw new LocalTeamAgentError(
+      'invalid_response',
+      'Agent response must contain exactly three teams'
+    );
+  }
+  const layout = createEmptyTeamBuilderLayout();
+  teams.forEach((team, teamIndex) => {
+    layout[teamIndex].formation = team.formation ?? '';
+    team.heroes.forEach((slot, slotIndex) => {
+      layout[teamIndex].heroes[slotIndex] = {
+        hero: slot.hero,
+        row: slot.row ?? TEAM_BUILDER_DEFAULT_ROW,
+        skills: [...slot.skills],
+      };
+    });
+  });
+  return layout;
+}
+
+export const teamBuilderLayoutFingerprint = (
+  layout: TeamBuilderLayout
+): string => JSON.stringify(layout);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value >= 0;
+
+const stringArray = (value: unknown): string[] | null =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string')
+    ? value
+    : null;
+
+const parseEvidence = (value: unknown): TeamAgentEvidenceRef[] | null => {
+  if (!Array.isArray(value)) return null;
+  const evidence: TeamAgentEvidenceRef[] = [];
+  for (const item of value) {
+    if (!isRecord(item) || typeof item.source !== 'string' || typeof item.id !== 'string') {
+      return null;
+    }
+    evidence.push({ source: item.source, id: item.id });
+  }
+  return evidence;
+};
+
+const parseStrengths = (value: unknown): TeamAgentReviewStrength[] | null => {
+  if (!Array.isArray(value)) return null;
+  const strengths: TeamAgentReviewStrength[] = [];
+  for (const item of value) {
+    if (!isRecord(item) || typeof item.category !== 'string' || typeof item.message !== 'string') {
+      return null;
+    }
+    const evidence = parseEvidence(item.evidence);
+    if (evidence === null) return null;
+    strengths.push({ category: item.category, message: item.message, evidence });
+  }
+  return strengths;
+};
+
+const parseReviewWarnings = (
+  value: unknown,
+  crossTeam = false
+): TeamAgentReviewWarning[] | null => {
+  if (!Array.isArray(value)) return null;
+  const warnings: TeamAgentReviewWarning[] = [];
+  for (const item of value) {
+    if (
+      !isRecord(item) ||
+      (item.severity !== 'warning' && item.severity !== 'critical') ||
+      typeof item.category !== 'string' ||
+      typeof item.message !== 'string' ||
+      typeof item.suggestedAction !== 'string'
+    ) {
+      return null;
+    }
+    const evidence = parseEvidence(item.evidence);
+    const teamIndexes = crossTeam
+      ? Array.isArray(item.teamIndexes) && item.teamIndexes.every(isNonNegativeInteger)
+        ? item.teamIndexes
+        : null
+      : undefined;
+    if (evidence === null || (crossTeam && teamIndexes === null)) return null;
+    warnings.push({
+      severity: item.severity,
+      category: item.category,
+      message: item.message,
+      suggestedAction: item.suggestedAction,
+      evidence,
+      ...(Array.isArray(teamIndexes) ? { teamIndexes } : {}),
+    });
+  }
+  return warnings;
+};
+
+const parseReview = (value: unknown): TeamAgentReview | null | undefined => {
+  if (value === null) return null;
+  if (
+    !isRecord(value) ||
+    (value.status !== 'complete' && value.status !== 'unavailable') ||
+    (value.verdict !== null &&
+      value.verdict !== 'sound' &&
+      value.verdict !== 'workable' &&
+      value.verdict !== 'needs_changes') ||
+    !isNonNegativeInteger(value.attempts)
+  ) {
+    return undefined;
+  }
+  if (!Array.isArray(value.teams)) return undefined;
+  const teams: TeamAgentReviewTeam[] = [];
+  for (const item of value.teams) {
+    if (
+      !isRecord(item) ||
+      !isNonNegativeInteger(item.teamIndex) ||
+      (item.verdict !== 'sound' &&
+        item.verdict !== 'workable' &&
+        item.verdict !== 'needs_changes')
+    ) {
+      return undefined;
+    }
+    const strengths = parseStrengths(item.strengths);
+    const warnings = parseReviewWarnings(item.warnings);
+    if (strengths === null || warnings === null) return undefined;
+    teams.push({
+      teamIndex: item.teamIndex,
+      verdict: item.verdict,
+      strengths,
+      warnings,
+    });
+  }
+  const crossTeamWarnings = parseReviewWarnings(value.crossTeamWarnings, true);
+  const deterministicRuleWarnings = parseReviewWarnings(
+    value.deterministicRuleWarnings,
+    true
+  );
+  const warnings = stringArray(value.warnings);
+  if (
+    crossTeamWarnings === null ||
+    deterministicRuleWarnings === null ||
+    warnings === null
+  ) {
+    return undefined;
+  }
+  return {
+    status: value.status,
+    verdict: value.verdict,
+    teams,
+    crossTeamWarnings,
+    deterministicRuleWarnings,
+    attempts: value.attempts,
+    warnings,
+  };
+};
+
+const parseTeamSlot = (value: unknown): TeamAgentSlot | null => {
+  if (
+    !isRecord(value) ||
+    (value.hero !== null && typeof value.hero !== 'string') ||
+    (value.row !== null && value.row !== '前排' && value.row !== '后排') ||
+    !Array.isArray(value.skills) ||
+    value.skills.length !== 2 ||
+    !value.skills.every((skill) => skill === null || typeof skill === 'string')
+  ) {
+    return null;
+  }
+  return {
+    hero: value.hero,
+    row: value.row,
+    skills: [value.skills[0], value.skills[1]],
+  };
+};
+
+const parseTeams = (value: unknown): TeamAgentTeam[] | null => {
+  if (!Array.isArray(value)) return null;
+  const teams: TeamAgentTeam[] = [];
+  for (const team of value) {
+    if (
+      !isRecord(team) ||
+      (team.formation !== null && typeof team.formation !== 'string') ||
+      !Array.isArray(team.heroes) ||
+      team.heroes.length !== 3
+    ) {
+      return null;
+    }
+    const parsedSlots = team.heroes.map(parseTeamSlot);
+    if (parsedSlots.some((slot) => slot === null)) return null;
+    teams.push({
+      formation: team.formation,
+      heroes: parsedSlots as [TeamAgentSlot, TeamAgentSlot, TeamAgentSlot],
+    });
+  }
+  return teams;
+};
+
+const parseAssignments = (value: unknown): TeamAgentAssignment[] | null => {
+  if (!Array.isArray(value)) return null;
+  const assignments: TeamAgentAssignment[] = [];
+  for (const item of value) {
+    if (
+      !isRecord(item) ||
+      !isNonNegativeInteger(item.teamIndex) ||
+      typeof item.reason !== 'string'
+    ) {
+      return null;
+    }
+    const evidence = stringArray(item.evidence);
+    if (evidence === null) return null;
+    const assignment: TeamAgentAssignment = {
+      teamIndex: item.teamIndex,
+      reason: item.reason,
+      evidence,
+    };
+    for (const key of ['slotIndex', 'skillSlotIndex'] as const) {
+      if (isNonNegativeInteger(item[key])) assignment[key] = item[key];
+    }
+    for (const key of ['hero', 'skill', 'formation'] as const) {
+      if (typeof item[key] === 'string') assignment[key] = item[key];
+    }
+    assignments.push(assignment);
+  }
+  return assignments;
+};
+
+export function parseTeamAgentResult(value: unknown): TeamAgentResult {
+  if (
+    !isRecord(value) ||
+    (value.status !== 'complete' && value.status !== 'incomplete') ||
+    (value.stoppedAt !== null &&
+      value.stoppedAt !== 'heroes' &&
+      value.stoppedAt !== 'formations' &&
+      value.stoppedAt !== 'skills') ||
+    !isRecord(value.attempts)
+  ) {
+    throw new LocalTeamAgentError('invalid_response', 'Agent returned an invalid response');
+  }
+  const teams = parseTeams(value.teams);
+  const heroAssignments = parseAssignments(value.heroAssignments);
+  const formationDecisions = parseAssignments(value.formationDecisions);
+  const skillAssignments = parseAssignments(value.skillAssignments);
+  const review = parseReview(value.review);
+  const warnings = stringArray(value.warnings);
+  const attempts = value.attempts;
+  if (
+    teams === null ||
+    teams.length !== 3 ||
+    heroAssignments === null ||
+    formationDecisions === null ||
+    skillAssignments === null ||
+    review === undefined ||
+    warnings === null ||
+    !isNonNegativeInteger(attempts.heroes) ||
+    !isNonNegativeInteger(attempts.formations) ||
+    !isNonNegativeInteger(attempts.skills) ||
+    !isNonNegativeInteger(attempts.review)
+  ) {
+    throw new LocalTeamAgentError('invalid_response', 'Agent returned an invalid response');
+  }
+  return {
+    teams,
+    status: value.status,
+    stoppedAt: value.stoppedAt,
+    attempts: {
+      heroes: attempts.heroes,
+      formations: attempts.formations,
+      skills: attempts.skills,
+      review: attempts.review,
+    },
+    heroAssignments,
+    formationDecisions,
+    skillAssignments,
+    review,
+    warnings,
+  };
+}
+
+const responseErrorMessage = async (response: Response): Promise<string> => {
+  try {
+    const body: unknown = await response.json();
+    if (
+      isRecord(body) &&
+      isRecord(body.error) &&
+      typeof body.error.message === 'string'
+    ) {
+      return body.error.message;
+    }
+  } catch {
+    // The status text below is enough when an error response is not JSON.
+  }
+  return response.statusText || `HTTP ${response.status}`;
+};
+
+export async function requestLocalTeamRecommendation(
+  input: TeamAgentRequest,
+  options: { signal?: AbortSignal; fetchImpl?: typeof fetch } = {}
+): Promise<TeamAgentResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  try {
+    const ready = await fetchImpl(`${LOCAL_TEAM_AGENT_URL}/health/ready`, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: options.signal,
+    });
+    if (!ready.ok) {
+      throw new LocalTeamAgentError('http', await responseErrorMessage(ready));
+    }
+    const response = await fetchImpl(
+      `${LOCAL_TEAM_AGENT_URL}/v1/team-recommendations`,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(input),
+        signal: options.signal,
+      }
+    );
+    if (!response.ok) {
+      throw new LocalTeamAgentError(
+        'http',
+        await responseErrorMessage(response)
+      );
+    }
+    return parseTeamAgentResult(await response.json());
+  } catch (error) {
+    if (error instanceof LocalTeamAgentError) throw error;
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new LocalTeamAgentError('aborted', 'Agent request was cancelled');
+    }
+    throw new LocalTeamAgentError(
+      'unavailable',
+      error instanceof Error ? error.message : 'Local Agent is unavailable'
+    );
+  }
+}

--- a/web/tests/localAgentTeamBuilder.spec.js
+++ b/web/tests/localAgentTeamBuilder.spec.js
@@ -1,0 +1,302 @@
+const { test, expect } = require('@playwright/test');
+const database = require('../public/game-data/database.json');
+const { seedStoredProgress } = require('./helpers');
+
+const signatureSkills = new Set(
+  Object.values(database.heroes).map((hero) => hero.skill)
+);
+const heroes = Object.keys(database.heroes).sort().slice(0, 4);
+const skills = Object.keys(database.skills)
+  .filter((skill) => !signatureSkills.has(skill))
+  .sort()
+  .slice(0, 5);
+const fullHeroes = Object.keys(database.heroes).sort().slice(0, 9);
+const fullSkills = Object.keys(database.skills)
+  .filter((skill) => !signatureSkills.has(skill))
+  .sort()
+  .slice(0, 18);
+const formations = Object.keys(database.formations).slice(0, 3);
+
+const progress = {
+  gameState: {
+    current_heroes: heroes,
+    current_skills: skills,
+    support_hero: null,
+    support_skills: [],
+    round_number: 1,
+    round_history: [],
+  },
+  currentRoundInputs: { set1: [], set2: [], set3: [] },
+};
+
+const fullProgress = {
+  ...progress,
+  gameState: {
+    ...progress.gameState,
+    current_heroes: fullHeroes,
+    current_skills: fullSkills,
+  },
+};
+
+const fullLayout = Array.from({ length: 3 }, (_, teamIndex) => ({
+  formation: formations[teamIndex],
+  heroes: Array.from({ length: 3 }, (_, slotIndex) => {
+    const resourceIndex = teamIndex * 3 + slotIndex;
+    return {
+      hero: fullHeroes[resourceIndex],
+      row: slotIndex === 0 ? '前排' : '后排',
+      skills: [
+        fullSkills[resourceIndex * 2],
+        fullSkills[resourceIndex * 2 + 1],
+      ],
+    };
+  }),
+}));
+
+const emptyTeams = () =>
+  Array.from({ length: 3 }, () => ({
+    formation: null,
+    heroes: Array.from({ length: 3 }, () => ({
+      hero: null,
+      row: null,
+      skills: [null, null],
+    })),
+  }));
+
+async function openBuilder(page, query = '') {
+  await page.goto(`/team-builder${query}`);
+  await expect(
+    page.getByRole('heading', { level: 1, name: '队伍策案' })
+  ).toBeVisible({ timeout: 30000 });
+  await expect(
+    page.getByRole('heading', { name: '我的比赛阵容' })
+  ).toBeVisible({ timeout: 30000 });
+}
+
+async function mockLocalAgent(
+  page,
+  result,
+  onRequest = () => {},
+  beforeResponse = async () => {}
+) {
+  await page.route('http://127.0.0.1:8790/**', async (route) => {
+    const request = route.request();
+    const corsHeaders = {
+      'access-control-allow-origin': 'http://localhost:3000',
+      'access-control-allow-methods': 'GET, POST, OPTIONS',
+      'access-control-allow-headers': 'Content-Type',
+    };
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers: corsHeaders });
+      return;
+    }
+    if (request.url().endsWith('/health/ready')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: corsHeaders,
+        body: JSON.stringify({ status: 'ready', model: 'test-model' }),
+      });
+      return;
+    }
+    onRequest(request.postDataJSON());
+    await beforeResponse();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: corsHeaders,
+      body: JSON.stringify(result),
+    });
+  });
+}
+
+test.describe('private local Team Agent experiment', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedStoredProgress(page, progress);
+  });
+
+  test('is hidden by default and only contacts localhost after an explicit click', async ({
+    page,
+  }) => {
+    let localRequests = 0;
+    page.on('request', (request) => {
+      if (request.url().startsWith('http://127.0.0.1:8790')) {
+        localRequests += 1;
+      }
+    });
+
+    await openBuilder(page);
+
+    await expect(
+      page.getByRole('button', { name: /智能(?:补全|复盘)阵容/ })
+    ).toHaveCount(0);
+    expect(localRequests).toBe(0);
+  });
+
+  test('applies validated partial progress and can undo it', async ({ page }) => {
+    const agentTeams = emptyTeams();
+    agentTeams[0].heroes[0] = {
+      hero: heroes[0],
+      row: null,
+      skills: [null, null],
+    };
+    const response = {
+      teams: agentTeams,
+      status: 'incomplete',
+      stoppedAt: 'heroes',
+      attempts: { heroes: 3, formations: 0, skills: 0, review: 0 },
+      heroAssignments: [],
+      formationDecisions: [],
+      skillAssignments: [],
+      review: null,
+      warnings: ['没有足够的通过校验候选武将，未猜测剩余位置。'],
+    };
+    let postedBody;
+    await mockLocalAgent(page, response, (body) => {
+      postedBody = body;
+    });
+    await openBuilder(page, '?local-agent=1');
+
+    await page.getByRole('button', { name: '智能补全阵容' }).click();
+
+    await expect(page.getByTestId('local-agent-result')).toBeVisible();
+    await expect(page.getByTestId('hero-slot-0-0')).toContainText(heroes[0]);
+    await expect(page.getByText(/“武将补全”阶段/)).toBeVisible();
+    await expect(
+      page.getByText('没有足够的通过校验候选武将，未猜测剩余位置。')
+    ).toBeVisible();
+    expect(postedBody.availableHeroes).toEqual(heroes);
+    expect(postedBody.availableSkills).toEqual(skills);
+    expect(postedBody.teams[0].heroes[0].row).toBeNull();
+    expect(Number.isInteger(postedBody.season)).toBe(true);
+
+    await page.getByRole('button', { name: '撤销智能补全' }).click();
+    await expect(page.getByTestId('local-agent-result')).toHaveCount(0);
+    await expect(page.getByTestId(`pool-hero-${heroes[0]}`)).toBeVisible();
+    await expect(page.getByText('已撤销本次智能补全')).toBeVisible();
+  });
+
+  test('reviews a complete lineup without replacing it', async ({ page }) => {
+    await seedStoredProgress(page, fullProgress);
+    await page.addInitScript(
+      ({ layout, poolKey }) => {
+        localStorage.setItem(
+          'teamBuilder',
+          JSON.stringify({ version: 2, poolKey, layout })
+        );
+      },
+      {
+        layout: fullLayout,
+        poolKey: JSON.stringify({
+          heroes: [...fullHeroes].sort(),
+          skills: [...fullSkills].sort(),
+        }),
+      }
+    );
+
+    const response = {
+      teams: fullLayout,
+      status: 'complete',
+      stoppedAt: null,
+      attempts: { heroes: 0, formations: 0, skills: 0, review: 1 },
+      heroAssignments: [],
+      formationDecisions: [],
+      skillAssignments: [],
+      review: {
+        status: 'complete',
+        verdict: 'workable',
+        teams: [
+          {
+            teamIndex: 0,
+            verdict: 'workable',
+            strengths: [],
+            warnings: [
+              {
+                severity: 'warning',
+                category: 'position',
+                message: '第一队后排保护不足',
+                suggestedAction: '优先检查前排承伤能力',
+                evidence: [{ source: 'formation', id: formations[0] }],
+              },
+            ],
+          },
+        ],
+        crossTeamWarnings: [],
+        deterministicRuleWarnings: [],
+        attempts: 1,
+        warnings: [],
+      },
+      warnings: [],
+    };
+    let postedBody;
+    await mockLocalAgent(page, response, (body) => {
+      postedBody = body;
+    });
+    await openBuilder(page, '?local-agent=1');
+    const firstSlot = page.getByTestId('hero-slot-0-0');
+    await expect(firstSlot).toContainText(fullHeroes[0]);
+
+    await page.getByRole('button', { name: '智能复盘阵容' }).click();
+
+    await expect(
+      page.getByRole('region', { name: '智能复盘结果' })
+    ).toBeVisible();
+    await expect(page.getByText('总体结论：可用但可改进')).toBeVisible();
+    await expect(page.getByText('第一队后排保护不足')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: '撤销智能补全' })
+    ).toHaveCount(0);
+    await expect(firstSlot).toContainText(fullHeroes[0]);
+    expect(postedBody.availableHeroes).toEqual([]);
+    expect(postedBody.availableSkills).toEqual([]);
+  });
+
+  test('ignores a response when the lineup changes while the Agent is running', async ({
+    page,
+  }) => {
+    const agentTeams = emptyTeams();
+    agentTeams[0].heroes[0] = {
+      hero: heroes[0],
+      row: null,
+      skills: [null, null],
+    };
+    const response = {
+      teams: agentTeams,
+      status: 'incomplete',
+      stoppedAt: 'heroes',
+      attempts: { heroes: 1, formations: 0, skills: 0, review: 0 },
+      heroAssignments: [],
+      formationDecisions: [],
+      skillAssignments: [],
+      review: null,
+      warnings: [],
+    };
+    let releaseResponse;
+    let posted = false;
+    const responseGate = new Promise((resolve) => {
+      releaseResponse = resolve;
+    });
+    await mockLocalAgent(
+      page,
+      response,
+      () => {
+        posted = true;
+      },
+      () => responseGate
+    );
+    await openBuilder(page, '?local-agent=1');
+
+    await page.getByRole('button', { name: '智能补全阵容' }).click();
+    await expect.poll(() => posted).toBe(true);
+    await page.getByTestId(`pool-hero-${heroes[1]}`).click();
+    await page.getByTestId('hero-slot-0-0').click();
+    await expect(page.getByTestId('hero-slot-0-0')).toContainText(heroes[1]);
+    releaseResponse();
+
+    await expect(
+      page.getByText('等待期间阵容已修改，本次 Agent 结果已忽略')
+    ).toBeVisible();
+    await expect(page.getByTestId('hero-slot-0-0')).toContainText(heroes[1]);
+    await expect(page.getByTestId('local-agent-result')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Intent

Integrate the local Sanmou LangGraph Agent into Team Builder behind an explicit browser opt-in, supporting intelligent completion, review-only mode, validated results, warnings, undo, and stale-response safety without exposing the provider or prompting ordinary visitors.

## What Changed

- Added `web/src/services/localTeamAgent.ts`, a client for the local Sanmou LangGraph agent (loopback `127.0.0.1:8790`) that is gated behind an explicit `?local-agent=1` browser opt-in persisted in `localStorage` — enabling the flag alone never contacts localhost — and that builds the request from the current pool, parses/validates the agent's response, and maps failures to typed codes (`unavailable`, `aborted`, `invalid_response`).
- Wired the agent into `web/src/pages/TeamBuilder.tsx` with intelligent-completion (`recommend`) and read-only `review` modes, an `AbortController`/context-fingerprint guard so stale or superseded responses are discarded, and undo of the applied layout after a completion.
- Added `AgentReviewPanel` to surface per-team verdicts, strengths, and severity-tagged warnings with an undo/dismiss control, plus unit tests (`localTeamAgent.test.ts`, `AgentReviewPanel.test.tsx`), a Playwright flow (`localAgentTeamBuilder.spec.js`), and an `agent/README.md` note.

## Risk Assessment

✅ Low: The change is well-bounded and additive, gated behind a hidden experiment flag with no impact on ordinary visitors, has a careful stale-response/undo design, and is covered by unit and e2e tests; the only findings are minor, non-blocking correctness/trust notes.

## Testing

Typecheck, Vitest unit tests, and the localAgentTeamBuilder e2e spec all pass; captured UI screenshots demonstrating opt-in, completion+undo, and review-only modes.

- Evidence: screenshots dir (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KZMVCN04D48WGRPB41DEV529</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `web/src/services/localTeamAgent.ts:515` - A successful HTTP 200 whose body is not valid JSON makes `await response.json()` (line 515) throw a SyntaxError that falls through the catch to the generic `&#39;unavailable&#39;` classification (lines 521-524). TeamBuilder maps `&#39;unavailable&#39;` to the message &#34;无法连接本地 Agent。请确认 8790 服务已启动…&#34;, telling the user the agent isn&#39;t running when it actually responded with a malformed payload. An `&#39;invalid_response&#39;` code already exists for exactly this case; wrapping the `response.json()`/parse in its own catch (or reusing `parseTeamAgentResult`&#39;s error) would report it accurately.
- ℹ️ `web/src/services/localTeamAgent.ts:188` - `layoutFromTeamAgentTeams` and the recommend path replace the entire layout with the agent&#39;s returned teams after only structural validation (`parseTeamAgentResult`). There is no client-side check that returned hero/skill strings actually belong to the sent pool (`availableHeroes`/`availableSkills` + already-filled slots) or that a hero isn&#39;t duplicated across teams (a game-rule violation). The agent contract is expected to guarantee this, and undo mitigates a bad apply, so this is only a note on the trust boundary — a misbehaving local agent could silently place unknown or duplicated heroes into the builder.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm typecheck`
- `pnpm test`
- `pnpm exec playwright test localAgentTeamBuilder`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
