### PR TITLE
fix(agent): make LangGraph team review reliable under schema retries

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -107,6 +107,19 @@ The review result has its own `status`. If all three review attempts fail
 because the provider output is malformed or cites unavailable evidence, the
 recommendation remains `status: "complete"` and the nested review reports
 `status: "unavailable"`. Lineup weaknesses are findings, not retry reasons.
+The review prompt and validator share the same category, evidence-source, and
+hard-limit constants. The prompt targets a smaller result inside those limits;
+retries receive only a bounded list of path-specific corrections, and an
+unavailable result never exposes the provider's raw validation dump.
+
+The HTTP server and `recommend` CLI emit one compact JSON diagnostic per review
+attempt. It contains prompt character/byte counts, duration, token usage when
+the provider supplies it, finish reason, accepted/rejected outcome, and concise
+validation errors. Full prompts and model responses are never logged. Example:
+
+```json
+{"event":"team_review_attempt","attempt":1,"promptCharacters":12000,"promptBytes":17000,"durationMs":42000,"finishReason":"stop","usage":{"promptTokens":7000,"completionTokens":1800,"totalTokens":8800},"outcome":"accepted","validationErrors":[]}
+```
 
 The model-facing contexts are normalized to keep local calls focused: hero
 facts and equivalent candidate sets are shared across blank slots, the

--- a/agent/src/cli.ts
+++ b/agent/src/cli.ts
@@ -6,6 +6,11 @@ import { OpenAICompatibleChatModel } from './openAiCompatibleChatModel.js';
 import { loadGameKnowledge } from './team/gameData.js';
 import { runTeamRecommendation } from './team/teamRecommendationGraph.js';
 import { teamRecommendationInputSchema } from './team/teamRecommendationSchemas.js';
+import type { TeamReviewAttemptDiagnostic } from './team/teamReviewSubgraph.js';
+
+function logReviewAttempt(diagnostic: TeamReviewAttemptDiagnostic): void {
+  console.error(JSON.stringify({ event: 'team_review_attempt', ...diagnostic }));
+}
 
 function printUsage(): void {
   console.log('Usage:');
@@ -52,6 +57,7 @@ async function runRecommend(inputPath: string | undefined): Promise<void> {
     model,
     knowledge,
     reasoningEffort: config.reasoningEffort,
+    review: { onAttempt: logReviewAttempt },
   });
   console.log(JSON.stringify(result, null, 2));
 }

--- a/agent/src/httpServer.ts
+++ b/agent/src/httpServer.ts
@@ -9,6 +9,7 @@ import {
 import type { GameKnowledge } from './team/gameData.js';
 import { runTeamRecommendation } from './team/teamRecommendationGraph.js';
 import { teamRecommendationInputSchema } from './team/teamRecommendationSchemas.js';
+import type { TeamReviewAttemptDiagnostic } from './team/teamReviewSubgraph.js';
 
 const MAX_BODY_BYTES = 256 * 1024;
 const BROWSER_ENDPOINTS = new Set([
@@ -23,6 +24,7 @@ export interface AgentHttpServerOptions {
   knowledge: GameKnowledge;
   reasoningEffort?: ReasoningEffort;
   allowedOrigins: readonly string[];
+  onReviewAttempt?: (diagnostic: TeamReviewAttemptDiagnostic) => void;
 }
 
 class RequestBodyError extends Error {
@@ -140,6 +142,9 @@ async function handleRequest(
         ...(options.reasoningEffort === undefined
           ? {}
           : { reasoningEffort: options.reasoningEffort }),
+        ...(options.onReviewAttempt === undefined
+          ? {}
+          : { review: { onAttempt: options.onReviewAttempt } }),
       });
       writeJson(response, 200, result);
       return;

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -63,6 +63,7 @@ export {
   buildTeamReviewPrompt,
   createTeamReviewSubgraph,
   runTeamReview,
+  type TeamReviewAttemptDiagnostic,
   type TeamReviewSubgraphOptions,
 } from './team/teamReviewSubgraph.js';
 export {

--- a/agent/src/server.ts
+++ b/agent/src/server.ts
@@ -2,6 +2,11 @@ import { createAgentHttpServer } from './httpServer.js';
 import { loadLocalEnvironment, readAgentConfig } from './config.js';
 import { OpenAICompatibleChatModel } from './openAiCompatibleChatModel.js';
 import { loadGameKnowledge } from './team/gameData.js';
+import type { TeamReviewAttemptDiagnostic } from './team/teamReviewSubgraph.js';
+
+function logReviewAttempt(diagnostic: TeamReviewAttemptDiagnostic): void {
+  console.log(JSON.stringify({ event: 'team_review_attempt', ...diagnostic }));
+}
 
 loadLocalEnvironment();
 const config = readAgentConfig();
@@ -13,6 +18,7 @@ const server = createAgentHttpServer({
   knowledge,
   reasoningEffort: config.reasoningEffort,
   allowedOrigins: config.allowedOrigins,
+  onReviewAttempt: logReviewAttempt,
 });
 
 server.listen(config.port, config.host, () => {

--- a/agent/src/team/teamRecommendationGraph.ts
+++ b/agent/src/team/teamRecommendationGraph.ts
@@ -46,7 +46,7 @@ export interface TeamRecommendationGraphOptions {
   skill?: Pick<SkillCompletionSubgraphOptions, 'maxCompletionTokens'>;
   review?: Pick<
     TeamReviewSubgraphOptions,
-    'maxCompletionTokens' | 'maxReviewAttempts'
+    'maxCompletionTokens' | 'maxReviewAttempts' | 'onAttempt'
   >;
 }
 

--- a/agent/src/team/teamReviewSchemas.ts
+++ b/agent/src/team/teamReviewSchemas.ts
@@ -50,20 +50,17 @@ const learnedFeatureSchema = z.object({
   support: z.number(),
 });
 
-export const reviewEvidenceRefSchema = z.object({
-  source: z.enum([
-    'hero',
-    'skill',
-    'formation',
-    'bond',
-    'knownTeam',
-    'learnedFeature',
-    'campBonus',
-  ]),
-  id: z.string().min(1),
-});
+export const REVIEW_EVIDENCE_SOURCES = [
+  'hero',
+  'skill',
+  'formation',
+  'bond',
+  'knownTeam',
+  'learnedFeature',
+  'campBonus',
+] as const;
 
-export const reviewCategorySchema = z.enum([
+export const REVIEW_CATEGORIES = [
   'camp',
   'bond',
   'formation',
@@ -75,12 +72,33 @@ export const reviewCategorySchema = z.enum([
   'team_balance',
   'learned_evidence',
   'resource_rule',
-]);
+] as const;
+
+export const REVIEW_OUTPUT_LIMITS = {
+  targetStrengthsPerTeam: 4,
+  targetWarningsPerTeam: 3,
+  targetEvidencePerItem: 3,
+  targetCrossTeamWarnings: 3,
+  maxStrengthsPerTeam: 6,
+  maxWarningsPerTeam: 6,
+  maxEvidencePerItem: 5,
+  maxCrossTeamWarnings: 6,
+} as const;
+
+export const reviewEvidenceRefSchema = z.object({
+  source: z.enum(REVIEW_EVIDENCE_SOURCES),
+  id: z.string().min(1),
+});
+
+export const reviewCategorySchema = z.enum(REVIEW_CATEGORIES);
 
 export const reviewStrengthSchema = z.object({
   category: reviewCategorySchema,
   message: z.string().min(1),
-  evidence: z.array(reviewEvidenceRefSchema).min(1).max(5),
+  evidence: z
+    .array(reviewEvidenceRefSchema)
+    .min(1)
+    .max(REVIEW_OUTPUT_LIMITS.maxEvidencePerItem),
 });
 
 export const reviewWarningSchema = z.object({
@@ -88,7 +106,10 @@ export const reviewWarningSchema = z.object({
   category: reviewCategorySchema,
   message: z.string().min(1),
   suggestedAction: z.string().min(1),
-  evidence: z.array(reviewEvidenceRefSchema).min(1).max(5),
+  evidence: z
+    .array(reviewEvidenceRefSchema)
+    .min(1)
+    .max(REVIEW_OUTPUT_LIMITS.maxEvidencePerItem),
 });
 
 export const crossTeamReviewWarningSchema = reviewWarningSchema.extend({
@@ -170,11 +191,17 @@ export const teamReviewModelDecisionSchema = z
     teams: z.array(
       z.object({
         teamIndex: z.number().int().min(0).max(2),
-        strengths: z.array(reviewStrengthSchema).max(6),
-        warnings: z.array(reviewWarningSchema).max(6),
+        strengths: z
+          .array(reviewStrengthSchema)
+          .max(REVIEW_OUTPUT_LIMITS.maxStrengthsPerTeam),
+        warnings: z
+          .array(reviewWarningSchema)
+          .max(REVIEW_OUTPUT_LIMITS.maxWarningsPerTeam),
       })
     ),
-    crossTeamWarnings: z.array(crossTeamReviewWarningSchema).max(6),
+    crossTeamWarnings: z
+      .array(crossTeamReviewWarningSchema)
+      .max(REVIEW_OUTPUT_LIMITS.maxCrossTeamWarnings),
   })
   .strict();
 

--- a/agent/src/team/teamReviewSubgraph.ts
+++ b/agent/src/team/teamReviewSubgraph.ts
@@ -124,16 +124,31 @@ function formatIssuePath(path: PropertyKey[]): string {
     .join('');
 }
 
+function formatBoundIssue(
+  path: string,
+  origin: string,
+  direction: 'at most' | 'at least',
+  limit: string
+): string {
+  if (origin === 'array' || origin === 'set' || origin === 'file') {
+    return `${path}: return ${direction} ${limit} items`;
+  }
+  if (origin === 'string') {
+    return `${path}: use ${direction} ${limit} characters`;
+  }
+  return `${path}: use a value ${direction} ${limit}`;
+}
+
 function formatZodIssue(issue: z.core.$ZodIssue): string {
   const path = formatIssuePath(issue.path);
   if (issue.code === 'invalid_value') {
     return `${path}: use one of ${issue.values.map(String).join(', ')}`;
   }
   if (issue.code === 'too_big') {
-    return `${path}: return at most ${String(issue.maximum)} items`;
+    return formatBoundIssue(path, issue.origin, 'at most', String(issue.maximum));
   }
   if (issue.code === 'too_small') {
-    return `${path}: return at least ${String(issue.minimum)} items`;
+    return formatBoundIssue(path, issue.origin, 'at least', String(issue.minimum));
   }
   return `${path}: ${issue.message}`;
 }

--- a/agent/src/team/teamReviewSubgraph.ts
+++ b/agent/src/team/teamReviewSubgraph.ts
@@ -6,6 +6,9 @@ import type { GameKnowledge } from './gameData.js';
 import type { PartialTeam } from './schemas.js';
 import { buildTeamReviewContext } from './teamReviewContext.js';
 import {
+  REVIEW_CATEGORIES,
+  REVIEW_EVIDENCE_SOURCES,
+  REVIEW_OUTPUT_LIMITS,
   teamReviewContextSchema,
   teamReviewInputSchema,
   teamReviewModelDecisionSchema,
@@ -17,16 +20,48 @@ import {
 } from './teamReviewSchemas.js';
 
 const DEFAULT_MAX_REVIEW_ATTEMPTS = 3;
+const MAX_RETRY_ERROR_COUNT = 6;
+const MAX_RETRY_ERROR_CHARACTERS = 240;
+
+const tokenUsageSchema = z.object({
+  promptTokens: z.number().int().nonnegative(),
+  completionTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+});
+
+const reviewAttemptMetadataSchema = z.object({
+  promptCharacters: z.number().int().nonnegative(),
+  promptBytes: z.number().int().nonnegative(),
+  durationMs: z.number().int().nonnegative(),
+  finishReason: z.string().nullable(),
+  usage: tokenUsageSchema.nullable(),
+});
 
 const TeamReviewState = new StateSchema({
   input: teamReviewInputSchema,
   context: teamReviewContextSchema.optional(),
-  proposedReview: teamReviewModelDecisionSchema.optional(),
-  modelFailure: z.string().nullable().default(null),
+  proposedReview: teamReviewModelDecisionSchema.nullable().default(null),
+  modelFailures: z.array(z.string()).default(() => []),
   validationErrors: z.array(z.string()).default(() => []),
   attemptCount: z.number().int().nonnegative().default(0),
+  attemptMetadata: reviewAttemptMetadataSchema.optional(),
   result: teamReviewResultSchema.optional(),
 });
+
+export interface TeamReviewAttemptDiagnostic {
+  attempt: number;
+  promptCharacters: number;
+  promptBytes: number;
+  durationMs: number;
+  finishReason: string | null;
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  } | null;
+  outcome: 'accepted' | 'rejected';
+  validationErrors: string[];
+}
 
 export interface TeamReviewSubgraphOptions {
   model: ChatModel;
@@ -34,11 +69,11 @@ export interface TeamReviewSubgraphOptions {
   reasoningEffort?: ReasoningEffort;
   maxCompletionTokens?: number;
   maxReviewAttempts?: number;
+  onAttempt?: (diagnostic: TeamReviewAttemptDiagnostic) => void;
 }
 
 export function buildTeamReviewPrompt(
   context: TeamReviewContext,
-  previousReview: TeamReviewModelDecision | undefined,
   validationErrors: string[]
 ): string {
   const retryFeedback =
@@ -47,13 +82,19 @@ export function buildTeamReviewPrompt(
       : [
           '',
           'Previous response was rejected. Correct every error and return a complete replacement response:',
-          JSON.stringify({ previousReview, validationErrors }),
+          JSON.stringify({ validationErrors: compactValidationErrors(validationErrors) }),
         ];
   return [
     'Review every completed Sanmou team. Report strengths and warnings only; never change the lineup.',
     '',
     'Hard rules:',
     '- Return exactly one review for every teamIndex.',
+    `- category must be exactly one of: ${REVIEW_CATEGORIES.join(', ')}.`,
+    `- evidence.source must be exactly one of: ${REVIEW_EVIDENCE_SOURCES.join(', ')}.`,
+    `- For each team, return 1-${REVIEW_OUTPUT_LIMITS.targetStrengthsPerTeam} strengths and 0-${REVIEW_OUTPUT_LIMITS.targetWarningsPerTeam} warnings.`,
+    `- Each strength or warning must cite 1-${REVIEW_OUTPUT_LIMITS.targetEvidencePerItem} evidence references.`,
+    `- Return at most ${REVIEW_OUTPUT_LIMITS.targetCrossTeamWarnings} crossTeamWarnings.`,
+    `- Hard limits: no more than ${REVIEW_OUTPUT_LIMITS.maxStrengthsPerTeam} strengths, ${REVIEW_OUTPUT_LIMITS.maxWarningsPerTeam} warnings, or ${REVIEW_OUTPUT_LIMITS.maxEvidencePerItem} evidence references in any item.`,
     '- Keep team warnings inside that team; use crossTeamWarnings only for interactions across teams.',
     '- Cite only exact IDs present in the supplied context, using the matching source.',
     '- Use critical only for a material incompatibility; use warning for a meaningful improvement opportunity.',
@@ -70,6 +111,64 @@ export function buildTeamReviewPrompt(
     'Team-review context:',
     JSON.stringify(context),
   ].join('\n');
+}
+
+function formatIssuePath(path: PropertyKey[]): string {
+  if (path.length === 0) return 'response';
+  return path
+    .map((part, index) =>
+      typeof part === 'number'
+        ? `[${part}]`
+        : `${index === 0 ? '' : '.'}${String(part)}`
+    )
+    .join('');
+}
+
+function formatZodIssue(issue: z.core.$ZodIssue): string {
+  const path = formatIssuePath(issue.path);
+  if (issue.code === 'invalid_value') {
+    return `${path}: use one of ${issue.values.map(String).join(', ')}`;
+  }
+  if (issue.code === 'too_big') {
+    return `${path}: return at most ${String(issue.maximum)} items`;
+  }
+  if (issue.code === 'too_small') {
+    return `${path}: return at least ${String(issue.minimum)} items`;
+  }
+  return `${path}: ${issue.message}`;
+}
+
+function truncateError(error: string): string {
+  const normalized = error.replace(/\s+/g, ' ').trim();
+  return normalized.length <= MAX_RETRY_ERROR_CHARACTERS
+    ? normalized
+    : `${normalized.slice(0, MAX_RETRY_ERROR_CHARACTERS - 1)}…`;
+}
+
+function compactValidationErrors(errors: readonly string[]): string[] {
+  return [
+    ...new Set(errors.map(truncateError).filter((error) => error.length > 0)),
+  ].slice(0, MAX_RETRY_ERROR_COUNT);
+}
+
+function compactModelFailure(error: unknown): string[] {
+  if (error instanceof z.ZodError) {
+    return compactValidationErrors(error.issues.map(formatZodIssue));
+  }
+  return compactValidationErrors([
+    error instanceof Error ? error.message : String(error),
+  ]);
+}
+
+function emitAttemptDiagnostic(
+  onAttempt: TeamReviewSubgraphOptions['onAttempt'],
+  diagnostic: TeamReviewAttemptDiagnostic
+): void {
+  try {
+    onAttempt?.(diagnostic);
+  } catch {
+    // Diagnostics must never change recommendation behavior.
+  }
 }
 
 function evidenceKey(source: string, id: string): string {
@@ -130,9 +229,9 @@ function validateEvidence(
 
 function validateReview(
   context: TeamReviewContext,
-  review: TeamReviewModelDecision | undefined
+  review: TeamReviewModelDecision | null
 ): string[] {
-  if (review === undefined) return ['Model did not return a structured team review'];
+  if (review === null) return ['Model did not return a structured team review'];
   const errors: string[] = [];
   const requiredTeams = new Set(context.teams.map(({ teamIndex }) => teamIndex));
   const seenTeams = new Set<number>();
@@ -241,6 +340,10 @@ export function createTeamReviewSubgraph(options: TeamReviewSubgraphOptions) {
 
   const reasonNode: GraphNode<typeof TeamReviewState> = async (state) => {
     if (state.context === undefined) throw new Error('Team review context was not prepared');
+    const prompt = buildTeamReviewPrompt(state.context, state.validationErrors);
+    const startedAt = Date.now();
+    let finishReason: string | null = null;
+    let usage: TeamReviewAttemptDiagnostic['usage'] = null;
     try {
       const completion = await options.model.complete({
         messages: [
@@ -251,34 +354,59 @@ export function createTeamReviewSubgraph(options: TeamReviewSubgraphOptions) {
           },
           {
             role: 'user',
-            content: buildTeamReviewPrompt(
-              state.context,
-              state.proposedReview,
-              state.validationErrors
-            ),
+            content: prompt,
           },
         ],
         reasoningEffort,
         maxCompletionTokens: options.maxCompletionTokens ?? 8192,
       });
+      finishReason = completion.finishReason;
+      usage = completion.usage;
       return {
         proposedReview: teamReviewModelDecisionSchema.parse(extractJson(completion.content)),
-        modelFailure: null,
+        modelFailures: [],
         attemptCount: state.attemptCount + 1,
+        attemptMetadata: {
+          promptCharacters: prompt.length,
+          promptBytes: Buffer.byteLength(prompt),
+          durationMs: Date.now() - startedAt,
+          finishReason,
+          usage,
+        },
       };
     } catch (error) {
       return {
-        proposedReview: undefined,
-        modelFailure: error instanceof Error ? error.message : String(error),
+        proposedReview: null,
+        modelFailures: compactModelFailure(error),
         attemptCount: state.attemptCount + 1,
+        attemptMetadata: {
+          promptCharacters: prompt.length,
+          promptBytes: Buffer.byteLength(prompt),
+          durationMs: Date.now() - startedAt,
+          finishReason,
+          usage,
+        },
       };
     }
   };
 
   const validateNode: GraphNode<typeof TeamReviewState> = (state) => {
     if (state.context === undefined) throw new Error('Team review context was not prepared');
-    const validationErrors = validateReview(state.context, state.proposedReview);
-    if (state.modelFailure !== null) validationErrors.unshift(state.modelFailure);
+    const validationErrors = compactValidationErrors(
+      state.proposedReview === null
+        ? state.modelFailures.length > 0
+          ? state.modelFailures
+          : ['Model did not return a structured team review']
+        : validateReview(state.context, state.proposedReview)
+    );
+    if (state.attemptMetadata !== undefined) {
+      emitAttemptDiagnostic(options.onAttempt, {
+        attempt: state.attemptCount,
+        ...state.attemptMetadata,
+        outcome: validationErrors.length === 0 ? 'accepted' : 'rejected',
+        validationErrors,
+      });
+    }
     if (validationErrors.length > 0) {
       if (state.attemptCount < maxReviewAttempts) return { validationErrors };
       return {
@@ -292,12 +420,12 @@ export function createTeamReviewSubgraph(options: TeamReviewSubgraphOptions) {
           attempts: state.attemptCount,
           warnings: [
             `Team review was unavailable after ${state.attemptCount} attempts.`,
-            ...validationErrors,
+            `Last validation errors: ${validationErrors.join('; ')}`,
           ],
         },
       };
     }
-    if (state.proposedReview === undefined) {
+    if (state.proposedReview === null) {
       throw new Error('Validated team review is missing');
     }
     return {

--- a/agent/tests/httpServer.test.ts
+++ b/agent/tests/httpServer.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createAgentHttpServer } from '../src/httpServer.js';
 import type { ChatCompletionRequest, ChatModel } from '../src/model.js';
 import type { TeamRecommendationInput } from '../src/team/teamRecommendationSchemas.js';
+import type { TeamReviewAttemptDiagnostic } from '../src/team/teamReviewSubgraph.js';
 import {
   completeReviewTeams,
   skillTestKnowledge,
@@ -34,13 +35,17 @@ class FakeChatModel implements ChatModel {
 
 const openServers: Server[] = [];
 
-async function startServer(model: ChatModel): Promise<{ server: Server; baseUrl: string }> {
+async function startServer(
+  model: ChatModel,
+  onReviewAttempt?: (diagnostic: TeamReviewAttemptDiagnostic) => void
+): Promise<{ server: Server; baseUrl: string }> {
   const server = createAgentHttpServer({
     model,
     modelName: 'fake-model',
     knowledge: skillTestKnowledge,
     reasoningEffort: 'high',
     allowedOrigins: [BROWSER_ORIGIN, 'http://localhost:3000'],
+    ...(onReviewAttempt === undefined ? {} : { onReviewAttempt }),
   });
   openServers.push(server);
   await new Promise<void>((resolve, reject) => {
@@ -171,7 +176,10 @@ describe('agent HTTP server', () => {
 
   it('routes a completed browser lineup directly to grounded review', async () => {
     const model = new FakeChatModel(validReviewDecision);
-    const { baseUrl } = await startServer(model);
+    const diagnostics: TeamReviewAttemptDiagnostic[] = [];
+    const { baseUrl } = await startServer(model, (diagnostic) =>
+      diagnostics.push(diagnostic)
+    );
 
     const response = await fetch(`${baseUrl}/v1/team-recommendations`, {
       method: 'POST',
@@ -196,6 +204,14 @@ describe('agent HTTP server', () => {
       review: { status: 'complete', verdict: 'sound' },
     });
     expect(model.requests).toHaveLength(1);
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        attempt: 1,
+        outcome: 'accepted',
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        validationErrors: [],
+      }),
+    ]);
   });
 
   it('runs every recommendation stage for a partial browser lineup', async () => {

--- a/agent/tests/promptContracts.test.ts
+++ b/agent/tests/promptContracts.test.ts
@@ -16,6 +16,11 @@ import { buildSkillCompletionPrompt } from '../src/team/skillCompletionSubgraph.
 import { teamRecommendationInputSchema } from '../src/team/teamRecommendationSchemas.js';
 import { buildTeamReviewContext } from '../src/team/teamReviewContext.js';
 import { buildTeamReviewPrompt } from '../src/team/teamReviewSubgraph.js';
+import {
+  REVIEW_CATEGORIES,
+  REVIEW_EVIDENCE_SOURCES,
+  REVIEW_OUTPUT_LIMITS,
+} from '../src/team/teamReviewSchemas.js';
 
 describe('model prompt contracts', () => {
   it('normalizes repeated hero, formation, and skill facts within their size budgets', async () => {
@@ -100,10 +105,24 @@ describe('model prompt contracts', () => {
       { teams: completeFixture.teams },
       knowledge
     );
-    const reviewPrompt = buildTeamReviewPrompt(reviewContext, undefined, []);
+    const reviewPrompt = buildTeamReviewPrompt(reviewContext, []);
     expect(reviewContext.teams).toHaveLength(3);
     expect(Object.keys(reviewContext.heroCatalog)).toHaveLength(9);
     expect(reviewPrompt.match(/"skillCatalog"/g)).toHaveLength(1);
+    expect(reviewPrompt).toContain(REVIEW_CATEGORIES.join(', '));
+    expect(reviewPrompt).toContain(REVIEW_EVIDENCE_SOURCES.join(', '));
+    expect(reviewPrompt).toContain(
+      `1-${REVIEW_OUTPUT_LIMITS.targetStrengthsPerTeam} strengths`
+    );
+    expect(reviewPrompt).toContain(
+      `0-${REVIEW_OUTPUT_LIMITS.targetWarningsPerTeam} warnings`
+    );
+    expect(reviewPrompt).toContain(
+      `1-${REVIEW_OUTPUT_LIMITS.targetEvidencePerItem} evidence references`
+    );
+    expect(reviewPrompt).toContain(
+      `no more than ${REVIEW_OUTPUT_LIMITS.maxStrengthsPerTeam} strengths`
+    );
     expect(reviewPrompt.length).toBeLessThanOrEqual(30_000);
 
     for (const prompt of [heroPrompt, formationPrompt, skillPrompt, reviewPrompt]) {

--- a/agent/tests/teamFixtures.ts
+++ b/agent/tests/teamFixtures.ts
@@ -1,4 +1,8 @@
-import type { ChatCompletionRequest, ChatModel } from '../src/model.js';
+import type {
+  ChatCompletionRequest,
+  ChatModel,
+  TokenUsage,
+} from '../src/model.js';
 import type { GameKnowledge } from '../src/team/gameData.js';
 import type { HeroCompletionInput } from '../src/team/schemas.js';
 import type { PartialTeam } from '../src/team/schemas.js';
@@ -200,7 +204,10 @@ export const validReviewDecision = JSON.stringify({
 export class FakeChatModel implements ChatModel {
   readonly requests: ChatCompletionRequest[] = [];
 
-  constructor(private readonly content: string | string[]) {}
+  constructor(
+    private readonly content: string | string[],
+    private readonly usage: TokenUsage | null = null
+  ) {}
 
   async complete(request: ChatCompletionRequest) {
     const responseIndex = this.requests.length;
@@ -213,7 +220,7 @@ export class FakeChatModel implements ChatModel {
       model: 'fake-model',
       content,
       finishReason: 'stop',
-      usage: null,
+      usage: this.usage,
     };
   }
 }

--- a/agent/tests/teamReviewSubgraph.test.ts
+++ b/agent/tests/teamReviewSubgraph.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { buildTeamReviewContext } from '../src/team/teamReviewContext.js';
-import { runTeamReview } from '../src/team/teamReviewSubgraph.js';
+import {
+  runTeamReview,
+  type TeamReviewAttemptDiagnostic,
+} from '../src/team/teamReviewSubgraph.js';
 import {
   completeReviewTeams,
   FakeChatModel,
@@ -88,6 +91,69 @@ describe('TeamReviewSubgraph', () => {
     );
   });
 
+  it('turns schema violations into compact actionable retry feedback', async () => {
+    const strengths = Array.from({ length: 7 }, (_, index) => ({
+      category: index === 0 ? 'damage' : 'formation',
+      message: `strength ${index}`,
+      evidence:
+        index === 1
+          ? Array.from({ length: 6 }, () => ({
+              source: 'formation',
+              id: '雁形阵',
+            }))
+          : [{ source: 'formation', id: '雁形阵' }],
+    }));
+    const invalidReview = JSON.stringify({
+      teams: [{ teamIndex: 0, strengths, warnings: [] }],
+      crossTeamWarnings: [],
+    });
+    const model = new FakeChatModel([invalidReview, validReviewDecision], {
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+    });
+    const diagnostics: TeamReviewAttemptDiagnostic[] = [];
+
+    const result = await runTeamReview(
+      { teams: completeReviewTeams },
+      {
+        model,
+        knowledge: skillTestKnowledge,
+        onAttempt: (diagnostic) => diagnostics.push(diagnostic),
+      }
+    );
+
+    expect(result).toMatchObject({ status: 'complete', attempts: 2 });
+    const initialPrompt = model.requests[0]?.messages[1]?.content ?? '';
+    const retryPrompt = model.requests[1]?.messages[1]?.content ?? '';
+    expect(retryPrompt).toContain(
+      'teams[0].strengths[0].category: use one of camp, bond, formation'
+    );
+    expect(retryPrompt).toContain(
+      'teams[0].strengths[1].evidence: return at most 5 items'
+    );
+    expect(retryPrompt).toContain(
+      'teams[0].strengths: return at most 6 items'
+    );
+    expect(retryPrompt).not.toContain('invalid_value');
+    expect(retryPrompt).not.toContain('too_big');
+    expect(retryPrompt.length - initialPrompt.length).toBeLessThan(2_000);
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics[0]).toMatchObject({
+      attempt: 1,
+      outcome: 'rejected',
+      finishReason: 'stop',
+      usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+    });
+    expect(diagnostics[0]?.promptCharacters).toBe(initialPrompt.length);
+    expect(diagnostics[0]?.promptBytes).toBeGreaterThan(initialPrompt.length);
+    expect(diagnostics[1]).toMatchObject({
+      attempt: 2,
+      outcome: 'accepted',
+      validationErrors: [],
+    });
+  });
+
   it('rejects a cross-team warning that targets only one team', async () => {
     const invalidCrossTeamWarning = JSON.stringify({
       teams: [{ teamIndex: 0, strengths: [], warnings: [] }],
@@ -131,6 +197,9 @@ describe('TeamReviewSubgraph', () => {
       teams: [],
     });
     expect(result.warnings.join(' ')).toContain('Team review was unavailable');
+    expect(result.warnings.join(' ')).not.toContain('invalid_value');
+    expect(result.warnings.join(' ')).not.toContain('"code"');
+    expect(result.warnings.join(' ').length).toBeLessThan(1_000);
     expect(input.teams).toEqual(completeReviewTeams);
     expect(model.requests).toHaveLength(3);
   });


### PR DESCRIPTION
## Intent

Make the LangGraph team review reliable after the deployed browser flow exhausted three attempts on schema-invalid output. Keep one holistic high-effort review call normally, make prompt and Zod contract share exact categories/sources/limits, request a smaller bounded result, replace raw Zod retry payloads/user warnings with concise path corrections, and add privacy-safe per-attempt size/duration/token/finish/validation diagnostics. Do not lower token limits, split reviews, or add structured output until live measurements justify those follow-ups.

## What Changed

- Made the prompt and Zod contract share one source of truth in `teamReviewSchemas.ts` by extracting `REVIEW_CATEGORIES`, `REVIEW_EVIDENCE_SOURCES`, and a new `REVIEW_OUTPUT_LIMITS` (smaller bounded targets plus hard maxima), and had `buildTeamReviewPrompt` spell out the exact allowed categories/sources and per-team/per-item limits so the model is asked for a smaller, in-bounds result.
- Replaced raw Zod retry payloads and the echoed previous review with concise, deduplicated, truncated path corrections (`formatZodIssue`/`compactValidationErrors`, worded by `issue.origin` so array/string/number bounds read correctly), and reworded the exhaustion warning to a single "last validation errors" line instead of leaking raw Zod codes to users.
- Added privacy-safe per-attempt diagnostics — prompt characters/bytes, duration, finish reason, and token usage with an `accepted`/`rejected` outcome — emitted through an `onAttempt` callback wired into the CLI, HTTP server, and server runtime; the review stays a single holistic call and token limits are unchanged.
- Updated `agent/` tests (subgraph retry-feedback, diagnostics, and exhaustion paths, plus prompt-contract and httpServer coverage) and `agent/README.md` accordingly.

## Risk Assessment

✅ Low: The sole change since the last review is a small, well-bounded auto-fix that words Zod bound-issue retry corrections by issue.origin (array→items, string→characters, other→value), correctly resolving the prior finding without altering behavior or breaking existing test expectations.

## Testing

Ran the scoped agent workspace checks (`pnpm typecheck` and `pnpm test`, 61 tests passing under Node 22.17.1) plus two manual end-to-end harnesses that exercise the real team-review subgraph through the public onAttempt/log-line path. The harnesses produced product-level CLI transcripts showing the reliability fix (invalid attempt 1 → accepted attempt 2 → status complete), the concise path-based retry feedback that replaced raw Zod payloads, the exhaustion path's short privacy-safe warnings, and the per-attempt size/duration/token/finish/validation diagnostics an operator sees in the server log — with the single-call, unchanged-token behavior preserved. All checks passed; no findings.

<details>
<summary>Evidence: Team review retry + per-attempt diagnostics (end-to-end transcript)</summary>

<code>{&#34;event&#34;:&#34;team_review_attempt&#34;,&#34;attempt&#34;:1,...,&#34;outcome&#34;:&#34;rejected&#34;,&#34;validationErrors&#34;:[&#34;teams[0].strengths[0].category: use one of camp, bond, formation, ...&#34;,&#34;teams[0].strengths[1].evidence: return at most 5 items&#34;,&#34;teams[0].strengths: return at most 6 items&#34;]}&#10;{&#34;event&#34;:&#34;team_review_attempt&#34;,&#34;attempt&#34;:2,...,&#34;outcome&#34;:&#34;accepted&#34;,&#34;validationErrors&#34;:[]}&#10;Final: {&#34;status&#34;:&#34;complete&#34;,&#34;verdict&#34;:&#34;sound&#34;,&#34;attempts&#34;:2}</code>

```text
{"event":"team_review_attempt","attempt":1,"promptCharacters":4294,"promptBytes":4838,"durationMs":1,"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":50,"totalTokens":150},"outcome":"rejected","validationErrors":["teams[0].strengths[0].category: use one of camp, bond, formation, position, damage_type, skill_synergy, sustain, control, team_balance, learned_evidence, resource_rule","teams[0].strengths[1].evidence: return at most 5 items","teams[0].strengths: return at most 6 items"]}
{"event":"team_review_attempt","attempt":2,"promptCharacters":4686,"promptBytes":5230,"durationMs":0,"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":50,"totalTokens":150},"outcome":"accepted","validationErrors":[]}

===== RETRY PROMPT FEEDBACK (attempt 2, user message tail) =====
Previous response was rejected. Correct every error and return a complete replacement response:
{"validationErrors":["teams[0].strengths[0].category: use one of camp, bond, formation, position, damage_type, skill_synergy, sustain, control, team_balance, learned_evidence, resource_rule","teams[0].strengths[1].evidence: return at most 5 items","teams[0].strengths: return at most 6 items"]}

Team-review context:
{"heroCatalog":{"魏甲":{"camp":"魏","troop":"骑","stats":{"wl":80,"zl":180,"ts":190,"xg":100},"signatureSkill":"甲策","generalEvidence":null},"魏乙":{"camp":"魏","troop":"盾","stats":{"wl":70,"zl":

===== FINAL REVIEW RESULT (what the browser flow receives) =====
{
  "status": "complete",
  "verdict": "sound",
  "attempts": 2
}
```
</details>
<details>
<summary>Evidence: Prompt shared categories/sources/bounded targets + exhaustion-path warnings</summary>

<code>Hard rules: category one of: camp, bond, formation, ...; evidence.source one of: hero, skill, formation, ...; return 1-4 strengths and 0-3 warnings; cite 1-3 evidence references; at most 3 crossTeamWarnings; Hard limits: no more than 6 strengths, 6 warnings, or 5 evidence refs.&#10;Exhaustion: status unavailable, attempts 3, warnings=[&#34;Team review was unavailable after 3 attempts.&#34;,&#34;Last validation errors: Expected 1 team reviews but received 0; Team 0 was not reviewed&#34;] (no raw Zod codes)</code>

```text
===== PROMPT "Hard rules" (shared categories/sources + bounded targets) =====
Hard rules:
- Return exactly one review for every teamIndex.
- category must be exactly one of: camp, bond, formation, position, damage_type, skill_synergy, sustain, control, team_balance, learned_evidence, resource_rule.
- evidence.source must be exactly one of: hero, skill, formation, bond, knownTeam, learnedFeature, campBonus.
- For each team, return 1-4 strengths and 0-3 warnings.
- Each strength or warning must cite 1-3 evidence references.
- Return at most 3 crossTeamWarnings.
- Hard limits: no more than 6 strengths, 6 warnings, or 5 evidence references in any item.
- Keep team warnings inside that team; use crossTeamWarnings only for interactions across teams.
- Cite only exact IDs present in the supplied context, using t

===== EXHAUSTION PATH (invalid every attempt -> concise user warnings) =====
{
  "status": "unavailable",
  "attempts": 3,
  "warnings": [
    "Team review was unavailable after 3 attempts.",
    "Last validation errors: Expected 1 team reviews but received 0; Team 0 was not reviewed"
  ]
}

requests made: 3
warning bytes: 133 (no raw Zod codes: true)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `agent/src/team/teamReviewSubgraph.ts:132` - formatZodIssue (agent/src/team/teamReviewSubgraph.ts:132-137) phrases every too_big/too_small issue as &#34;return at most/least N items&#34;. This is correct for array-size violations but misleading for scalar bounds: a too_big on teamIndex (max 2) yields &#34;teams[0].teamIndex: return at most 2 items&#34; and a too_small on a message string (min 1) yields &#34;...message: return at least 1 items&#34;. Since the change&#39;s purpose is reliable, concise path corrections, use issue.origin (array vs number vs string) to word these accurately.

🔧 Fix: word Zod bound-issue retries by issue.origin
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node v22.17.1` + `pnpm typecheck` (tsc --noEmit) — clean</code>
- <code>`pnpm test` (vitest run) — 11 files / 61 tests passed, including the new retry-feedback, diagnostics, and exhaustion cases in `agent/tests/teamReviewSubgraph.test.ts`, `promptContracts.test.ts`, `httpServer.test.ts`</code>
- <code>Manual end-to-end harness driving the real `runTeamReview` subgraph via `FakeChatModel` (invalid→valid): captured per-attempt `team_review_attempt` diagnostic log lines, the retry prompt showing concise path corrections, and final `status: complete, attempts: 2`</code>
- `Manual harness for the exhaustion path (invalid×3): captured concise user warnings with no raw Zod codes, and the built prompt's shared categories/sources + bounded-target rules`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
