### PR TITLE
feat(yanwu): import 飞将吕布 workbook with skill rankings into guide and game UI

### DIFF
--- a/.agents/skills/update-game-database-from-csv/SKILL.md
+++ b/.agents/skills/update-game-database-from-csv/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-game-database-from-csv
-description: Validates and imports the five-sheet 三谋吕布 演武 XLSX workbook into web/public/game-data/database.json through the deterministic workbook importer.
+description: Validates and imports the seven-sheet 飞将吕布 演武 XLSX workbook into web/public/game-data/database.json through the deterministic workbook importer.
 allowed-tools:
   - open_files
   - grep
@@ -10,10 +10,14 @@ allowed-tools:
 # Update Game Database From Workbook
 
 Use `data/import_yanwu_workbook.py`; do not hand-edit the generated workbook
-fields in `web/public/game-data/database.json`.
+fields in `web/public/game-data/database.json`. Follow the repository's approved
+plan/feature-branch lifecycle before changing the importer, schema, or UI.
+
+## Import workflow
 
 1. Put the source at the repository root with the exact filename
-   `三谋吕布-演武.xlsx`. Treat it as read-only and never commit it.
+   `三谋演武-飞将吕布.xlsx`. Treat it as read-only and never commit it.
+   Confirm `git check-ignore -v '三谋演武-飞将吕布.xlsx'` succeeds.
 2. Run the default dry run:
 
    ```bash
@@ -21,44 +25,89 @@ fields in `web/public/game-data/database.json`.
    ```
 
 3. Stop on any validation error. Do not fuzzy-match, silently skip a cell, or
-   invent an alias. Add an explicitly reviewed alias and a focused test to the
-   importer when the workbook uses a new exact spelling.
-4. Review the reported cardinalities and diff expectation. The audited workbook
-   produces 100 heroes, 231 skills, 68 strong entries, 15 championship entries,
-   77 unique teams, 3 cross-source overlaps, 13 matchup builds, 5 championship
-   groups, 2 analysis sections, and 6 analysis points.
-   Require `yanwuGuide.source` to contain exactly:
+   invent an alias. Report every unknown hero, skill, formation, category, or
+   layout change with its source cell. Add an explicitly reviewed exact alias
+   and a focused test only after the user confirms it.
+4. Require exactly these sheets, in order:
 
    ```yaml
-   provider: 三谋吕布
-   workbook: 三谋吕布-演武.xlsx
-   updatedAt: 2026-07-28
-   attribution: 攻略数据由三谋吕布提供
+   - 目录
+   - 武将Tier
+   - 战法Tier
+   - 强队Tier
+   - 克制关系
+   - 夺冠御三家
+   - 阵容解析
    ```
 
-   Reject the import if VX, an account number, or any other provider contact
-   text would enter the output. Omit the workbook's contact prefaces entirely.
-   If this workflow also updates UI attribution, show it only on
-   `/guides/yanwu`.
-5. Apply only when the update is intended:
+5. Review the reported cardinalities. This audited workbook produces 100
+   heroes, 231 catalog skills, 98 ranked skills across 6 categories, 70 strong
+   entries, 15 championship entries, 79 unique teams, 3 cross-source overlaps,
+   13 matchup builds, 5 championship groups, 2 analysis sections, and 6
+   analysis points.
+6. Require `yanwuGuide.source` to contain exactly:
+
+   ```yaml
+   provider: 飞将吕布
+   workbook: 三谋演武-飞将吕布.xlsx
+   updatedAt: 2026-08-11T16:07:04+10:00
+   attribution: 攻略数据由飞将吕布提供
+   ```
+
+   The reviewed timestamp is pinned to this immutable workbook revision; do not
+   read the wall clock during import because that would break idempotence.
+7. Apply only when the update is intended:
 
    ```bash
    uv run python data/import_yanwu_workbook.py --apply
    ```
 
-6. Prove idempotence by running the same apply command again; require
+8. Prove idempotence by running the same apply command again; require
    `changes=no` and `written=no`.
-7. Run the importer tests and validate the JSON:
+9. Run the importer tests and validate the JSON:
 
    ```bash
    uv run pytest data/test_import_yanwu_workbook.py -q
    python3 -m json.tool web/public/game-data/database.json >/dev/null
    ```
 
-8. Inspect `git diff -- web/public/game-data/database.json` and confirm:
-   hero rankings/camps, removed legacy skill tiers/notes, normalized formations
-   and skill alternatives, content-derived build references, all five workbook
-   sheets represented, and no VX/contact data.
+10. Because the generated database drives the React UI, run the checks required
+    by `web/AGENTS.md`: `pnpm typecheck`, `pnpm test`, `pnpm test:e2e`, and
+    `pnpm build` from `web/`.
+11. Inspect `git diff -- web/public/game-data/database.json` and confirm hero
+    rankings/camps, optional skill rankings/categories, normalized formations
+    and skill alternatives, content-derived build references, all seven sheets,
+    and the absence of provider contact/link data.
+
+## Audited contract decisions
+
+- `战法Tier` ranks a reviewed subset of 98 catalog skills. Each listed skill gets
+  paired `ranking` (`S`–`D`) and `category` (`兵刃`, `谋略`, `治疗`, `防御`,
+  `辅助`, or `文武`). Skills absent from the sheet remain unranked. These fields
+  are presentation-only and must not affect recommendation/model scores.
+- Every `夺冠御三家` row is rank `S`. Builds are keyed by formation, ordered
+  heroes, and every normalized skill alternative. Same heroes with different
+  skills therefore remain distinct builds. Exact duplicate payloads share one
+  build ID, while every championship group keeps its original reference.
+- Matchup labels resolve to one normalized strong-build identity, not a row
+  coordinate. The two 司马懿/曹操/曹丕 variants are distinguished by the
+  presence of `运智铺谋` plus `谋而后动`. Fail if any label resolves to zero
+  or multiple builds.
+- Contact prefaces and directory links are never imported. Reject contact or
+  URL markers in the generated `yanwuGuide` payload. Attribution appears only
+  on `/guides/yanwu`.
+- The exact reviewed abbreviations include `暗度` → `暗渡阴平`, `瞋目` →
+  `瞋目横矛`, and `谋而` → `谋而后动`; they are tested and must not be
+  generalized into fuzzy matching.
+
+## Layout-drift response
+
+The previous workbook used five sheets, the filename `三谋吕布-演武.xlsx`,
+provider `三谋吕布`, fixed matchup row anchors, and no imported skill ranking
+sheet. Those assumptions were intentionally removed. If a future workbook
+changes filename, provider, sheet order, categories, cardinalities, or matchup
+identity, stop at dry-run, report the complete drift, agree on the new contract,
+then update the importer, focused tests, this skill, and affected UI together.
 
 The importer is dry-run by default, validates before writing, and uses an atomic
 replace only when output bytes changed.

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ bilibili/
 
 # Local guide source (contains provider contact details; import derived data only)
 三谋吕布-演武.xlsx
+三谋演武-飞将吕布.xlsx
 
 # Playwright test output
 test-results/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help:
 	@echo "  make evaluate-recommendation  - Run grouped rolling evaluation (ignored JSON result; no production changes)"
 	@echo "  make build-telemetry EXPORT=  - Build the public aggregate and incremental checkpoint"
 	@echo "  make import-web-battles EXPORT= - Import one bounded D1 export and rebuild recommendation data"
-	@echo "  make import-yanwu [APPLY=1]     - Validate the local five-sheet guide workbook; APPLY=1 updates database.json"
+	@echo "  make import-yanwu [APPLY=1]     - Validate the local seven-sheet guide workbook; APPLY=1 updates database.json"
 	@echo "  make install                  - Sync dependencies with uv (alias for 'sync')"
 	@echo "  make sync                     - Install/sync all dependencies via 'uv sync'"
 	@echo "  make clean                    - Remove temporary files (pytest cache, coverage, extracted_results, tmp_crops, __pycache__)"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ patterns can be reviewed later; transport submission IDs remain D1-only.
 ## Quickstart
 
 - `web/public/game-data/database.json` holds the catalog plus the imported
-  三谋吕布 hero rankings, complete strong/championship builds, matchup matrix,
+  飞将吕布 hero/skill rankings, complete strong/championship builds, matchup matrix,
   and analysis guide.
 - Copy game screenshots into `data/images/`.
 - `make extract` — OCR the images into `data/battles/*.json`, then rebuild `web/src/recommendation_data.json`.
@@ -36,8 +36,8 @@ patterns can be reviewed later; transport submission IDs remain D1-only.
 - `make build-telemetry EXPORT=/path/to/round_telemetry.sql` — validate the
   current D1 table export, fold rows newer than the committed cursor, and
   rebuild the public aggregate artifact plus `data/telemetry_state.json`.
-- `make import-yanwu` — validate the local five-sheet
-  `三谋吕布-演武.xlsx` without writing; `make import-yanwu APPLY=1` atomically
+- `make import-yanwu` — validate the local seven-sheet
+  `三谋演武-飞将吕布.xlsx` without writing; `make import-yanwu APPLY=1` atomically
   updates the derived guide data in `database.json`.
 - `make web` — start the React dev server (http://localhost:3000).
 
@@ -329,13 +329,13 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
   browser origins while keeping generic chat outside browser CORS. See
   [agent/README.md](agent/README.md) for the graph nodes and the
   `pnpm recommend` fixture run.
-- `data/import_yanwu_workbook.py` — strict, deterministic five-sheet workbook
+- `data/import_yanwu_workbook.py` — strict, deterministic seven-sheet workbook
   importer. It defaults to a no-write dry run and requires `--apply` to update
   `web/public/game-data/database.json`; the source workbook itself stays
   untracked.
-- `web/public/game-data/database.json` — catalog and guide data. Hero rankings,
+- `web/public/game-data/database.json` — catalog and guide data. Hero/skill rankings,
   known builds, championship references, matchup relationships, and analysis
-  are attributed in the guide metadata to 三谋吕布; contact details from the
+  are attributed in the guide metadata to 飞将吕布; contact details from the
   workbook are never published.
 - `web/public/game-data/telemetry_data.json` — generated, aggregate-only
   player-choice analytics and gated preference-model artifact; updated weekly

--- a/data/import_yanwu_workbook.py
+++ b/data/import_yanwu_workbook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Import the five-sheet 三谋吕布 演武 workbook into database.json.
+"""Import the seven-sheet 飞将吕布 演武 workbook into database.json.
 
 The command is a dry run unless ``--apply`` is supplied.  It parses every
 source sheet, validates all catalog references before rendering, and replaces
@@ -27,24 +27,29 @@ from openpyxl.worksheet.worksheet import Worksheet
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_WORKBOOK = ROOT / "三谋吕布-演武.xlsx"
+DEFAULT_WORKBOOK = ROOT / "三谋演武-飞将吕布.xlsx"
 DEFAULT_DATABASE = ROOT / "web/public/game-data/database.json"
 
 EXPECTED_SHEETS = (
-    "国家排行榜",
-    "强队排行榜",
+    "目录",
+    "武将Tier",
+    "战法Tier",
+    "强队Tier",
     "克制关系",
     "夺冠御三家",
     "阵容解析",
 )
-PROVIDER = "三谋吕布"
-WORKBOOK_NAME = "三谋吕布-演武.xlsx"
-UPDATED_AT = "2026-07-28"
-ATTRIBUTION = "攻略数据由三谋吕布提供"
+PROVIDER = "飞将吕布"
+WORKBOOK_NAME = "三谋演武-飞将吕布.xlsx"
+# This is the reviewed import timestamp for this immutable workbook revision.
+# Keeping it source-controlled preserves byte-for-byte idempotence.
+UPDATED_AT = "2026-08-11T16:07:04+10:00"
+ATTRIBUTION = "攻略数据由飞将吕布提供"
 
 HERO_RANKINGS = ("S", "A", "B", "C", "D")
 TEAM_RANKINGS = ("S", "A", "B")
 RANKING_ORDER = {ranking: index for index, ranking in enumerate(HERO_RANKINGS)}
+SKILL_CATEGORIES = ("兵刃", "谋略", "治疗", "防御", "辅助", "文武")
 SECTION_TO_CAMP = {
     "魏国": "魏",
     "蜀国": "蜀",
@@ -102,6 +107,9 @@ SKILL_ALIASES = {
     "铸甲": "铸甲销戈",
     "锐不": "锐不可当",
     "韬光": "韬光养晦",
+    "暗度": "暗渡阴平",
+    "瞋目": "瞋目横矛",
+    "谋而": "谋而后动",
 }
 
 FORMATION_ALIASES = {
@@ -127,23 +135,27 @@ INVERSE_OUTCOME = {
     "largeDisadvantage": "largeAdvantage",
     "self": "self",
 }
+CONTACT_PATTERN = re.compile(
+    r"vx|v信|微信|qq|群号|公众号|联系方式|https?://",
+    re.IGNORECASE,
+)
 
-# Matrix labels deliberately resolve to exact builds, not merely hero sets.
-# The first two labels have the same heroes but different formations/skills.
-MATCHUP_LABEL_ANCHORS = (
-    ("司马懿+曹操+曹丕", "B8", ("司马懿", "曹操", "曹丕")),
-    ("法刀司马+曹操+曹丕", "B12", ("司马懿", "曹操", "曹丕")),
-    ("曹操+张春华+王异", "G16", ("曹操", "张春华", "王异")),
-    ("姜维+sp诸葛亮+刘备", "B40", ("姜维", "诸葛亮2", "刘备")),
-    ("sp周瑜+诸葛瑾+诸葛亮", "B65", ("周瑜2", "诸葛瑾", "诸葛亮")),
-    ("祝融+孟获+sp诸葛亮", "G94", ("祝融", "孟获", "诸葛亮2")),
-    ("袁术+皇甫嵩+孙坚", "B94", ("袁术", "皇甫嵩2", "孙坚2")),
-    ("姜维+sp诸葛亮+黄月英", "G40", ("姜维", "诸葛亮2", "黄月英")),
-    ("司马懿+郝昭+皇甫嵩", "G8", ("司马懿", "郝昭", "皇甫嵩2")),
-    ("祝融+吴国太+貂蝉", "G98", ("祝融", "吴国太", "貂蝉")),
-    ("孟获+祝融+木鹿", "B98", ("孟获", "祝融", "木鹿大王")),
-    ("祝融+孟获+袁绍", "G102", ("祝融", "孟获", "袁绍")),
-    ("袁术+皇甫嵩+朱儁", "L98", ("袁术", "皇甫嵩2", "朱儁")),
+# Matrix labels resolve by normalized build identity rather than row anchors.
+# The first two labels share a hero set and are distinguished by 司马懿's skills.
+MATCHUP_LABEL_IDENTITIES = (
+    ("司马懿+曹操+曹丕", ("司马懿", "曹操", "曹丕"), "non-fadao"),
+    ("法刀司马+曹操+曹丕", ("司马懿", "曹操", "曹丕"), "fadao"),
+    ("曹操+张春华+王异", ("曹操", "张春华", "王异"), None),
+    ("姜维+sp诸葛亮+刘备", ("姜维", "诸葛亮2", "刘备"), None),
+    ("sp周瑜+诸葛瑾+诸葛亮", ("周瑜2", "诸葛瑾", "诸葛亮"), None),
+    ("祝融+孟获+sp诸葛亮", ("祝融", "孟获", "诸葛亮2"), None),
+    ("袁术+皇甫嵩+孙坚", ("袁术", "皇甫嵩2", "孙坚2"), None),
+    ("姜维+sp诸葛亮+黄月英", ("姜维", "诸葛亮2", "黄月英"), None),
+    ("司马懿+郝昭+皇甫嵩", ("司马懿", "郝昭", "皇甫嵩2"), None),
+    ("祝融+吴国太+貂蝉", ("祝融", "吴国太", "貂蝉"), None),
+    ("孟获+祝融+木鹿", ("孟获", "祝融", "木鹿大王"), None),
+    ("祝融+孟获+袁绍", ("祝融", "孟获", "袁绍"), None),
+    ("袁术+皇甫嵩+朱儁", ("袁术", "皇甫嵩2", "朱儁"), None),
 )
 
 
@@ -165,6 +177,8 @@ class ParsedBuild:
 class ImportStats:
     heroes: int
     skills: int
+    ranked_skills: int
+    skill_categories: int
     strong_entries: int
     championship_entries: int
     teams: int
@@ -176,9 +190,11 @@ class ImportStats:
 
 
 EXPECTED_IMPORT_CARDINALITIES = {
-    "strong_entries": 68,
+    "ranked_skills": 98,
+    "skill_categories": 6,
+    "strong_entries": 70,
     "championship_entries": 15,
-    "teams": 77,
+    "teams": 79,
     "cross_source_overlaps": 3,
     "matchup_builds": 13,
     "championship_groups": 5,
@@ -281,10 +297,11 @@ def normalize_formation(
     return formation
 
 
-def _validate_provider_and_date(workbook: Any) -> None:
+def _validate_provider(workbook: Any) -> None:
     provider_cells = {
-        "国家排行榜": "A2",
-        "强队排行榜": "B2",
+        "武将Tier": "A2",
+        "战法Tier": "A2",
+        "强队Tier": "B2",
         "克制关系": "A1",
         "夺冠御三家": "A2",
         "阵容解析": "B2",
@@ -295,18 +312,6 @@ def _validate_provider_and_date(workbook: Any) -> None:
             raise ImportValidationError(
                 f"{sheet}!{coordinate}: expected provider {PROVIDER!r}, got {provider!r}"
             )
-
-    update_text = _compact(workbook["国家排行榜"]["G2"].value)
-    match = re.fullmatch(r"更新[：:](\d{4})-(\d{1,2})-(\d{1,2})", update_text)
-    if not match:
-        raise ImportValidationError(
-            "国家排行榜!G2: expected an 更新：YYYY-M-D source date"
-        )
-    normalized_date = f"{int(match[1]):04d}-{int(match[2]):02d}-{int(match[3]):02d}"
-    if normalized_date != UPDATED_AT:
-        raise ImportValidationError(
-            f"国家排行榜!G2: expected source date {UPDATED_AT}, got {normalized_date}"
-        )
 
 
 def parse_hero_rankings(
@@ -364,9 +369,67 @@ def parse_hero_rankings(
     extra = sorted(set(rankings) - set(hero_catalog))
     if missing or extra:
         raise ImportValidationError(
-            "国家排行榜 must rank every catalog hero exactly once; "
+            "武将Tier must rank every catalog hero exactly once; "
             f"missing={missing}, extra={extra}"
         )
+    return rankings
+
+
+def parse_skill_rankings(
+    sheet: Worksheet,
+    skill_catalog: Mapping[str, Any],
+) -> dict[str, dict[str, str]]:
+    """Parse exact skill category/tier metadata without requiring full coverage."""
+
+    current_category: str | None = None
+    categories: list[str] = []
+    rankings: dict[str, dict[str, str]] = {}
+
+    for row in range(1, sheet.max_row + 1):
+        marker = _compact(sheet.cell(row, 1).value)
+        if not marker:
+            continue
+        if marker in SKILL_CATEGORIES:
+            current_category = marker
+            categories.append(marker)
+            continue
+        if marker not in HERO_RANKINGS:
+            if current_category is not None:
+                raise ImportValidationError(
+                    f"{sheet.title}!A{row}: unexpected skill-tier marker {marker!r}"
+                )
+            continue
+        if current_category is None:
+            raise ImportValidationError(
+                f"{sheet.title}!A{row}: ranking appears before a skill category"
+            )
+
+        for column in range(2, sheet.max_column + 1):
+            raw = sheet.cell(row, column).value
+            if raw is None or (isinstance(raw, str) and not raw.strip()):
+                continue
+            coordinate = sheet.cell(row, column).coordinate
+            skill = normalize_skill(
+                raw,
+                skill_catalog,
+                context=f"{sheet.title}!{coordinate}",
+            )
+            if skill in rankings:
+                raise ImportValidationError(
+                    f"{sheet.title}!{coordinate}: duplicate ranking for {skill}"
+                )
+            rankings[skill] = {
+                "ranking": marker,
+                "category": current_category,
+            }
+
+    if tuple(categories) != SKILL_CATEGORIES:
+        raise ImportValidationError(
+            f"战法Tier categories must be exactly {SKILL_CATEGORIES!r}; "
+            f"got {tuple(categories)!r}"
+        )
+    if not rankings:
+        raise ImportValidationError("战法Tier contains no ranked skills")
     return rankings
 
 
@@ -476,7 +539,7 @@ def parse_strong_builds(
             )
 
     if not builds:
-        raise ImportValidationError("强队排行榜 contains no builds")
+        raise ImportValidationError("强队Tier contains no builds")
     return builds
 
 
@@ -486,15 +549,10 @@ def parse_championship_builds(
     skill_catalog: Mapping[str, Any],
     formations: Mapping[str, Any],
 ) -> tuple[list[ParsedBuild], list[list[str]]]:
-    current_ranking: str | None = None
     builds: list[ParsedBuild] = []
     group_origins: list[list[str]] = []
 
     for row in range(1, sheet.max_row + 1):
-        marker = _compact(sheet.cell(row, 1).value)
-        if marker in TEAM_RANKINGS:
-            current_ranking = marker
-
         row_builds: list[ParsedBuild] = []
         for start_column in (1, 6, 11):
             formation_value = sheet.cell(row, start_column + 3).value
@@ -502,17 +560,12 @@ def parse_championship_builds(
                 isinstance(formation_value, str) and not formation_value.strip()
             ):
                 continue
-            if current_ranking is None:
-                coordinate = sheet.cell(row, start_column + 3).coordinate
-                raise ImportValidationError(
-                    f"{sheet.title}!{coordinate}: build appears before ranking"
-                )
             row_builds.append(
                 _parse_build(
                     sheet,
                     row,
                     start_column,
-                    ranking=current_ranking,
+                    ranking="S",
                     source="championship",
                     section="夺冠御三家",
                     hero_catalog=hero_catalog,
@@ -643,12 +696,24 @@ def _cell_outcome(cell: Cell) -> str:
     return outcome
 
 
+def _is_fadao_sima_build(team: Mapping[str, Any]) -> bool:
+    for member in team["members"]:
+        if member["hero"] != "司马懿":
+            continue
+        skills = {
+            skill
+            for alternatives in member["skillSlots"]
+            for skill in alternatives
+        }
+        return {"运智铺谋", "谋而后动"}.issubset(skills)
+    return False
+
+
 def parse_matchups(
     sheet: Worksheet,
-    origin_to_id: Mapping[str, str],
     teams: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any]:
-    expected_labels = tuple(item[0] for item in MATCHUP_LABEL_ANCHORS)
+    expected_labels = tuple(item[0] for item in MATCHUP_LABEL_IDENTITIES)
     column_labels = tuple(_prose(sheet.cell(3, column).value) for column in range(2, 15))
     row_labels = tuple(_prose(sheet.cell(row, 1).value) for row in range(4, 17))
     if column_labels != expected_labels:
@@ -658,24 +723,27 @@ def parse_matchups(
     if row_labels != expected_labels:
         raise ImportValidationError(f"克制关系 row labels changed: {row_labels!r}")
 
-    teams_by_id = {team["id"]: team for team in teams}
     build_ids: list[str] = []
-    for label, anchor, expected_heroes in MATCHUP_LABEL_ANCHORS:
-        origin = f"强队排行榜!{anchor}"
-        build_id = origin_to_id.get(origin)
-        if build_id is None:
+    for label, expected_heroes, variant in MATCHUP_LABEL_IDENTITIES:
+        candidates = [
+            team
+            for team in teams
+            if "strong" in team["sources"]
+            and sorted(member["hero"] for member in team["members"])
+            == sorted(expected_heroes)
+        ]
+        if variant == "fadao":
+            candidates = [team for team in candidates if _is_fadao_sima_build(team)]
+        elif variant == "non-fadao":
+            candidates = [
+                team for team in candidates if not _is_fadao_sima_build(team)
+            ]
+        if len(candidates) != 1:
             raise ImportValidationError(
-                f"克制关系 label {label!r} requires missing build {origin}"
+                f"克制关系 label {label!r} must resolve to exactly one strong build; "
+                f"candidate_ids={[team['id'] for team in candidates]}"
             )
-        actual_heroes = tuple(
-            member["hero"] for member in teams_by_id[build_id]["members"]
-        )
-        if sorted(actual_heroes) != sorted(expected_heroes):
-            raise ImportValidationError(
-                f"{origin}: matchup label {label!r} expected heroes "
-                f"{expected_heroes!r}, got {actual_heroes!r}"
-            )
-        build_ids.append(build_id)
+        build_ids.append(candidates[0]["id"])
 
     outcomes = [
         [_cell_outcome(sheet.cell(row, column)) for column in range(2, 15)]
@@ -843,6 +911,20 @@ def validate_generated_database(database: Mapping[str, Any]) -> None:
         if "tier" in skill or "note" in skill:
             raise ImportValidationError(
                 f"skills[{skill_name!r}] still contains tier/note"
+            )
+        ranking = skill.get("ranking")
+        category = skill.get("category")
+        if (ranking is None) != (category is None):
+            raise ImportValidationError(
+                f"skills[{skill_name!r}] ranking/category must appear together"
+            )
+        if ranking is not None and ranking not in HERO_RANKINGS:
+            raise ImportValidationError(
+                f"skills[{skill_name!r}].ranking must be S/A/B/C/D"
+            )
+        if category is not None and category not in SKILL_CATEGORIES:
+            raise ImportValidationError(
+                f"skills[{skill_name!r}].category is invalid"
             )
 
     if formations.get("方圆阵") != SQUARE_FORMATION_DESCRIPTION:
@@ -1048,12 +1130,11 @@ def validate_generated_database(database: Mapping[str, Any]) -> None:
         ):
             raise ImportValidationError("analysis points are invalid")
 
-    serialized = _canonical_json(database)
-    forbidden = ("VX", "850509047", "微信", "联系方式")
-    leaked = [token for token in forbidden if token in serialized]
+    serialized = _canonical_json(guide)
+    leaked = CONTACT_PATTERN.search(serialized)
     if leaked:
         raise ImportValidationError(
-            f"generated database contains forbidden contact data: {leaked}"
+            f"generated guide contains forbidden contact data: {leaked.group(0)!r}"
         )
 
 
@@ -1078,7 +1159,7 @@ def build_database(
             f"workbook sheets must be exactly {EXPECTED_SHEETS!r}; "
             f"got {tuple(workbook.sheetnames)!r}"
         )
-    _validate_provider_and_date(workbook)
+    _validate_provider(workbook)
 
     database = copy.deepcopy(dict(original_database))
     heroes = _require_mapping(database.get("heroes"), "heroes")
@@ -1088,7 +1169,7 @@ def build_database(
         raise ImportValidationError("heroes, skills, and formations must be non-empty")
 
     formations["方圆阵"] = SQUARE_FORMATION_DESCRIPTION
-    hero_rankings = parse_hero_rankings(workbook["国家排行榜"], heroes)
+    hero_rankings = parse_hero_rankings(workbook["武将Tier"], heroes)
     for hero_name, hero_data in heroes.items():
         hero = _require_mapping(hero_data, f"heroes[{hero_name!r}]")
         hero.pop("label", None)
@@ -1096,13 +1177,28 @@ def build_database(
         hero["ranking"] = hero_rankings[hero_name]["ranking"]
         hero["camp"] = hero_rankings[hero_name]["camp"]
 
+    skill_rankings = parse_skill_rankings(workbook["战法Tier"], skills)
+    hero_signature_skills = {
+        _require_mapping(hero_data, f"heroes[{hero_name!r}]").get("skill")
+        for hero_name, hero_data in heroes.items()
+    }
+    ranked_signature_skills = sorted(set(skill_rankings) & hero_signature_skills)
+    if ranked_signature_skills:
+        raise ImportValidationError(
+            "战法Tier must not rank hero signature skills; "
+            f"got {ranked_signature_skills}"
+        )
     for skill_name, skill_data in skills.items():
         skill = _require_mapping(skill_data, f"skills[{skill_name!r}]")
         skill.pop("tier", None)
         skill.pop("note", None)
+        skill.pop("ranking", None)
+        skill.pop("category", None)
+        if skill_name in skill_rankings:
+            skill.update(skill_rankings[skill_name])
 
     strong_builds = parse_strong_builds(
-        workbook["强队排行榜"],
+        workbook["强队Tier"],
         heroes,
         skills,
         formations,
@@ -1119,7 +1215,6 @@ def build_database(
     )
     matchups = parse_matchups(
         workbook["克制关系"],
-        origin_to_id,
         teams,
     )
     championship_groups = build_championship_groups(
@@ -1149,6 +1244,8 @@ def build_database(
     stats = ImportStats(
         heroes=len(heroes),
         skills=len(skills),
+        ranked_skills=len(skill_rankings),
+        skill_categories=len({item["category"] for item in skill_rankings.values()}),
         strong_entries=len(strong_builds),
         championship_entries=len(championship_builds),
         teams=len(teams),
@@ -1264,6 +1361,8 @@ def _print_summary(
     print(f"mode={'apply' if apply else 'dry-run'}")
     print(f"heroes={stats.heroes}")
     print(f"skills={stats.skills}")
+    print(f"ranked_skills={stats.ranked_skills}")
+    print(f"skill_categories={stats.skill_categories}")
     print(f"strong_entries={stats.strong_entries}")
     print(f"championship_entries={stats.championship_entries}")
     print(f"teams={stats.teams}")
@@ -1281,7 +1380,7 @@ def _print_summary(
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Validate and import 三谋吕布-演武.xlsx. "
+            "Validate and import 三谋演武-飞将吕布.xlsx. "
             "The default is a no-write dry run."
         )
     )

--- a/data/test_import_yanwu_workbook.py
+++ b/data/test_import_yanwu_workbook.py
@@ -10,6 +10,7 @@ from openpyxl.styles import PatternFill
 
 from data.import_yanwu_workbook import (
     ATTRIBUTION,
+    MATCHUP_LABEL_IDENTITIES,
     OUTCOME_BY_RGB,
     PROVIDER,
     SQUARE_FORMATION_DESCRIPTION,
@@ -27,7 +28,10 @@ from data.import_yanwu_workbook import (
     normalize_hero,
     normalize_skill,
     parse_analysis_sections,
+    parse_championship_builds,
     parse_hero_rankings,
+    parse_matchups,
+    parse_skill_rankings,
     parse_skill_slot,
     parse_strong_builds,
     validate_generated_database,
@@ -60,11 +64,16 @@ def test_exact_aliases_normalize_without_fuzzy_matching() -> None:
         "锐不可当": {},
         "明其虚实": {},
         "暗渡阴平": {},
+        "瞋目横矛": {},
+        "谋而后动": {},
         "铸甲销戈": {},
     }
     assert normalize_skill("拔刀相助", skills) == "拔刀相向"
     assert normalize_skill("明起虚实", skills) == "明其虚实"
     assert normalize_skill("暗度阴平", skills) == "暗渡阴平"
+    assert normalize_skill("暗度", skills) == "暗渡阴平"
+    assert normalize_skill("瞋目", skills) == "瞋目横矛"
+    assert normalize_skill("谋而", skills) == "谋而后动"
     assert normalize_skill("铸甲", skills) == "铸甲销戈"
     assert parse_skill_slot(
         "拔刀相助 / 锐不 / 拔刀",
@@ -92,7 +101,7 @@ def test_exact_aliases_normalize_without_fuzzy_matching() -> None:
 def test_national_rankings_cover_catalog_and_disambiguate_sunjian() -> None:
     workbook = Workbook()
     sheet = workbook.active
-    sheet.title = "国家排行榜"
+    sheet.title = "武将Tier"
     sheet["A4"] = "魏国"
     sheet["A5"] = "S"
     sheet["B5"] = "司马懿"
@@ -127,10 +136,66 @@ def test_national_rankings_cover_catalog_and_disambiguate_sunjian() -> None:
     }
 
 
+def test_skill_rankings_import_exact_categories_and_allow_unranked_catalog() -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "战法Tier"
+    catalog = {f"{category}战法": {} for category in ("兵刃", "谋略", "治疗", "防御", "辅助", "文武")}
+    catalog["未排名战法"] = {}
+
+    row = 4
+    for ranking, category in zip("SABCDS", ("兵刃", "谋略", "治疗", "防御", "辅助", "文武")):
+        sheet.cell(row, 1).value = category
+        sheet.cell(row + 1, 1).value = ranking
+        sheet.cell(row + 1, 2).value = f"{category}战法"
+        row += 3
+
+    result = parse_skill_rankings(sheet, catalog)
+
+    assert result == {
+        f"{category}战法": {"ranking": ranking, "category": category}
+        for ranking, category in zip("SABCDS", ("兵刃", "谋略", "治疗", "防御", "辅助", "文武"))
+    }
+    assert "未排名战法" not in result
+
+
+def test_championship_builds_are_s_rank_and_exact_duplicates_share_ids() -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "夺冠御三家"
+    heroes = {name: {} for name in ("甲", "乙", "丙", "丁", "戊", "己", "庚", "辛", "壬")}
+    skills = {f"{hero}{slot}": {} for hero in heroes for slot in (1, 2)}
+    skills["甲2-备选"] = {}
+    for row in (5, 9):
+        for start, names in zip((1, 6, 11), (("甲", "乙", "丙"), ("丁", "戊", "己"), ("庚", "辛", "壬"))):
+            for offset, hero in enumerate(names):
+                sheet.cell(row, start + offset).value = hero
+                sheet.cell(row + 1, start + offset).value = f"{hero}1"
+                sheet.cell(row + 2, start + offset).value = f"{hero}2"
+            sheet.cell(row, start + 3).value = "方圆阵"
+    sheet["A11"] = "甲2-备选"
+
+    builds, group_origins = parse_championship_builds(
+        sheet,
+        heroes,
+        skills,
+        {"方圆阵": SQUARE_FORMATION_DESCRIPTION},
+    )
+    teams, origin_to_id, _ = merge_builds([], builds)
+    groups = build_championship_groups(group_origins, origin_to_id)
+
+    assert len(builds) == 6
+    assert all(build.ranking == "S" for build in builds)
+    assert len(teams) == 4
+    assert len(groups) == 2
+    assert groups[0]["teamIds"][0] != groups[1]["teamIds"][0]
+    assert groups[0]["teamIds"][1:] == groups[1]["teamIds"][1:]
+
+
 def test_strong_build_parser_normalizes_slots_and_formation() -> None:
     workbook = Workbook()
     sheet = workbook.active
-    sheet.title = "强队排行榜"
+    sheet.title = "强队Tier"
     sheet["B5"] = "魏国"
     sheet["B7"] = "S"
     sheet["B8"] = "sp诸葛亮"
@@ -160,7 +225,7 @@ def test_strong_build_parser_normalizes_slots_and_formation() -> None:
     )
 
     assert len(builds) == 1
-    assert builds[0].origin == "强队排行榜!B8"
+    assert builds[0].origin == "强队Tier!B8"
     assert builds[0].formation == "方圆阵"
     assert builds[0].members == (
         {
@@ -250,6 +315,51 @@ def test_matchup_fill_colors_parse_to_exact_outcome_enum(
     cell = workbook.active["A1"]
     cell.fill = PatternFill(fill_type="solid", fgColor=rgb)
     assert _cell_outcome(cell) == expected
+
+
+def test_matchups_resolve_stable_build_identity_without_row_anchors() -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "克制关系"
+    teams = []
+    expected_ids = []
+    for index, (label, heroes, variant) in enumerate(MATCHUP_LABEL_IDENTITIES):
+        sheet.cell(3, index + 2).value = label
+        sheet.cell(index + 4, 1).value = label
+        members = []
+        for hero in heroes:
+            if hero == "司马懿" and variant == "fadao":
+                slots = [["运智铺谋"], ["谋而后动"]]
+            elif hero == "司马懿":
+                slots = [["未雨绸缪"], ["潜龙在渊"]]
+            else:
+                slots = [[f"{hero}战法一"], [f"{hero}战法二-{index}"]]
+            members.append({"hero": hero, "skillSlots": slots})
+        payload = {"formation": "方圆阵", "members": members}
+        team_id = make_build_id(payload)
+        expected_ids.append(team_id)
+        teams.append(
+            {
+                "id": team_id,
+                "ranking": "S",
+                "sources": ["strong"],
+                "section": "魏国",
+                **payload,
+            }
+        )
+
+    even_rgb = next(rgb for rgb, outcome in OUTCOME_BY_RGB.items() if outcome == "even")
+    self_rgb = next(rgb for rgb, outcome in OUTCOME_BY_RGB.items() if outcome == "self")
+    for row in range(13):
+        for column in range(13):
+            sheet.cell(row + 4, column + 2).fill = PatternFill(
+                fill_type="solid",
+                fgColor=self_rgb if row == column else even_rgb,
+            )
+
+    result = parse_matchups(sheet, teams)
+
+    assert result["buildIds"] == expected_ids
 
 
 def test_analysis_parser_joins_continuations_and_omits_contact_preface() -> None:

--- a/web/README.md
+++ b/web/README.md
@@ -20,9 +20,9 @@ the model data is generated and community reports are imported.
   skill slots, alternatives, and the exact 已获得 / 本轮可获得 / 尚未获得 states.
   Championship references sort ahead of ordinary S builds without inventing a
   new tier.
-- **演武攻略**: `/guides/yanwu` presents the national hero tiers, full strong
+- **演武攻略**: `/guides/yanwu` presents the hero and categorized skill tiers, full strong
   team library, five championship groups, 13×13 matchup explorer, and workbook
-  analysis. This full guide is the sole UI location for the 三谋吕布 attribution.
+  analysis. This full guide is the sole UI location for the 飞将吕布 attribution.
 - **Manual Editing**: Edit team composition manually at any time
 - **Team Builder**: Start from one conservative, confidence-first three-team
   recommendation. Every placed hero must independently pass its `H` gate and
@@ -208,7 +208,7 @@ hero and skill positions remain blank.
 ### 演武攻略
 
 - **YanwuGuide**: Lazy-loaded `/guides/yanwu` page backed by the guide-only
-  database module. It is the only component that renders `攻略数据由三谋吕布提供`.
+  database module. It is the only component that renders `攻略数据由飞将吕布提供`.
 - The matchup matrix is read as **column build versus row build** and remains a
   reference view; neither it nor the S–D hero ranking changes model scores.
 
@@ -253,14 +253,15 @@ hero and skill positions remain blank.
 Core app data is bundled at build time. Copied web-LLM prompts may fetch the public static data files for extra details:
 
 - `public/game-data/database.json` — canonical catalog plus imported guide data.
-  Heroes use one compact `ranking` (`S`–`D`) with no within-tier order. Skills
-  have no tier or note. Known teams store a formation and two alternative-aware
+  Heroes use one compact `ranking` (`S`–`D`) with no within-tier order. Ranked
+  skills use optional `ranking` (`S`–`D`) plus `category`; unlisted skills stay
+  unranked. Known teams store a formation and two alternative-aware
   skill slots for each of three heroes, with `strong` and/or `championship`
   provenance. `yanwuGuide` stores the attribution metadata, 13×13 matchup
   matrix, five championship reference groups, and analysis sections. Copied
   prompts link to the file with a weekly `?v=<week-start-date>` cache-buster.
-- `../data/import_yanwu_workbook.py` — validates the exact five-sheet
-  `三谋吕布-演武.xlsx` contract and renders the guide-backed portion of the
+- `../data/import_yanwu_workbook.py` — validates the exact seven-sheet
+  `三谋演武-飞将吕布.xlsx` contract and renders the guide-backed portion of the
   database deterministically. It is dry-run by default, writes only with
   `--apply`, and excludes the workbook's contact line.
 - `public/game-data/formula.md` — public formula reference for copied web-LLM prompts.

--- a/web/public/game-data/database.json
+++ b/web/public/game-data/database.json
@@ -414,7 +414,7 @@
         "xg": 126
       },
       "season": 3,
-      "ranking": "C"
+      "ranking": "B"
     },
     "甘夫人": {
       "skill": "皇思淑仁",
@@ -505,7 +505,7 @@
         "xg": 208
       },
       "season": 2,
-      "ranking": "B"
+      "ranking": "C"
     },
     "陈宫": {
       "skill": "智令从计",
@@ -622,7 +622,7 @@
         "xg": 132
       },
       "season": 1,
-      "ranking": "A"
+      "ranking": "B"
     },
     "张郃": {
       "skill": "大破街亭",
@@ -674,7 +674,7 @@
         "xg": 221
       },
       "season": 1,
-      "ranking": "B"
+      "ranking": "C"
     },
     "程昱": {
       "skill": "勇冠贲育",
@@ -687,7 +687,7 @@
         "xg": 174
       },
       "season": 1,
-      "ranking": "C"
+      "ranking": "D"
     },
     "夏侯惇": {
       "skill": "刚烈",
@@ -869,7 +869,7 @@
         "xg": 188
       },
       "season": 1,
-      "ranking": "C"
+      "ranking": "D"
     },
     "孙尚香": {
       "skill": "弓腰姬",
@@ -882,7 +882,7 @@
         "xg": 179
       },
       "season": 1,
-      "ranking": "C"
+      "ranking": "D"
     },
     "小乔": {
       "skill": "天香",
@@ -1220,7 +1220,7 @@
         "xg": 103
       },
       "season": 1,
-      "ranking": "B"
+      "ranking": "C"
     },
     "张梁": {
       "skill": "妖武",
@@ -1604,14 +1604,18 @@
       "type": "主动",
       "prob": 60,
       "desc": "使自身和随机友军单体规避率提升10%（受统率影响），持续1回合；并有30%概率（受目标与自身兵力差影响）对敌军随机单体（优先选择后排目标）施加虚弱，持续1回合。",
-      "season": 16
+      "season": 16,
+      "ranking": "B",
+      "category": "辅助"
     },
     "暗渡阴平": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "奇数回合结束时，自身受到10%当前兵力的逃兵伤害并使自身和友军兵力最低单体获得自身当前兵力10%的伏兵，持续1回合。",
-      "season": 16
+      "season": 16,
+      "ranking": "B",
+      "category": "辅助"
     },
     "折节学问": {
       "color": "orange",
@@ -2024,7 +2028,9 @@
       "type": "指挥",
       "prob": 100,
       "desc": "战斗开始前3回合，自带战法造成治疗后（攻心和倒戈无效），令目标受到伤害降低3%（受智力和统率影响），可叠加6次，持续到战斗结束；第4回合起，每回合行动时，对敌军随机两人造成50%谋略伤害（额外受全队累积治疗量影响）",
-      "season": 13
+      "season": 13,
+      "ranking": "C",
+      "category": "防御"
     },
     "未雨绸缪": {
       "color": "orange",
@@ -2034,70 +2040,90 @@
       "damageEstimate": 168,
       "critEstimate": 10,
       "critDamageEstimate": 10,
-      "season": 13
+      "season": 13,
+      "ranking": "S",
+      "category": "谋略"
     },
     "诱敌深入": {
       "color": "orange",
       "type": "主动",
       "prob": 70,
       "desc": "嘲讽全体敌军,持续1回合,并获得5%(受先攻影响)当前兵力的伏兵。伏兵:功能性增益状态,数量上限1500,回合结束时消失，受到伤害时，消耗伏兵抵挡其中50%的伤害,并使伤害来源产生等额逃兵",
-      "season": 12
+      "season": 12,
+      "ranking": "D",
+      "category": "防御"
     },
     "风助火势": {
       "color": "orange",
       "type": "主动",
       "prob": 70,
       "desc": "对敌军全体施加风暴和火攻,持续1回合,若目标已持有风暴状态,则额外使其武力降低20点(受武力影响),持续1回合;若目标已持有火攻状态,则额外使其智力降低20点(受智力影响),持续1回合",
-      "season": 12
+      "season": 12,
+      "ranking": "A",
+      "category": "文武"
     },
     "瞋目横矛": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "战斗开始时,使我军随机单体(优先前排)获得横矛:造成伤害后,有50%概率(受横矛持有者武力影响)对目标施加畏惧(每回合每名敌军最多触发1次)持续1回合,若目标已持有畏惧,则兵刃伤害提升2%(受横持有者武力影响),可叠加",
-      "season": 12
+      "season": 12,
+      "ranking": "B",
+      "category": "辅助"
     },
     "掠阵破军": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "提升自身15%破甲(受规避率影响),每回合结束时，对敌军全体造成50%的伤害(伤害类型由武力和智力最高决定，本回合内自身每成功规避一次，额外提升10%系数，最高可提升50%",
-      "season": 11
+      "season": 11,
+      "ranking": "A",
+      "category": "文武"
     },
     "及锋而试": {
       "color": "orange",
       "type": "主动",
       "prob": 60,
       "desc": "提升自身20%兵刃伤害，持续2回合，然后对敌军随机两人造成160%兵刃伤害，目标存在属性降低状态，该次伤害系数额外提升30%",
-      "season": 11
+      "season": 11,
+      "ranking": "S",
+      "category": "兵刃"
     },
     "调和阴阳": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "自身与随机友方单体受到兵刃或谋略伤害前，有35%概率令得目标造成的该类伤害降低3%,持续2回合，可叠加10次，同时恢复其兵力(治疗率25%，受智力影响)，每回合最多触发3次。我军每存在一名女性武将该次治疗率额外提升10%",
-      "season": 11
+      "season": 11,
+      "ranking": "B",
+      "category": "防御"
     },
     "蹈锋饮血": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "受到伤害后,有55%概率提升自身5点武力(受武力影响)，可叠加15次，持续到战斗结束，并对伤害来源施加畏惧，持续2回合，若目标已持有畏惧效果，则额外使其受到伤害提升8%，可加2次，持续2回合。每回合最多触发4次",
-      "season": 10
+      "season": 10,
+      "ranking": "S",
+      "category": "兵刃"
     },
     "践墨随敌": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "战斗前3回合，自身受到伤害后，60%概率降低伤害来源50点武力(受智力影响),50点智力(受统率影响),可叠加3次，持续到回合结束",
-      "season": 10
+      "season": 10,
+      "ranking": "A",
+      "category": "防御"
     },
     "机变无穷": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "自带战法造成伤害后，有60%概率(受智力影响)提升10%谋略伤害，可叠加，持续到回合结束，并对随机敌军造成60%谋略伤害。每回合最多触发4次",
-      "season": 10
+      "season": 10,
+      "ranking": "A",
+      "category": "谋略"
     },
     "潜龙在渊": {
       "color": "orange",
@@ -2105,49 +2131,63 @@
       "prob": 100,
       "desc": "战斗开始前3回合，自身无法进行普通攻击。第4、6、8回合结束时，分别对敌军全体造成340%、380%、420%的伤害（伤害类型由武力和智力最高决定）",
       "damageEstimate": 428,
-      "season": 9
+      "season": 9,
+      "ranking": "S",
+      "category": "文武"
     },
     "御敌临前": {
       "color": "orange",
       "type": "主动",
       "prob": 75,
       "desc": "使自身和一名随机队友受到伤害降低20%(受先攻影响)，持续1回合，若自身为前排，额外恢复自身兵力(治疗率120%，受智力和先攻影响",
-      "season": 9
+      "season": 9,
+      "ranking": "S",
+      "category": "防御"
     },
     "虎步连环": {
       "color": "orange",
       "type": "追击",
       "prob": 50,
       "desc": "普通攻击后，对敌军随机两人造成110%兵刃伤害并有60%概率使目标随机获得1种控制状态，持续1回合，每个目标独立判定",
-      "season": 9
+      "season": 9,
+      "ranking": "B",
+      "category": "兵刃"
     },
     "神略制变": {
       "color": "orange",
       "type": "主动",
       "prob": 100,
       "desc": "前4回合发动时，恢复我军随机两人兵力(治疗率110%，受智力影响)后4回合发动时，对敌军随机两人造成160%谋略伤害",
-      "season": 8
+      "season": 8,
+      "ranking": "B",
+      "category": "谋略"
     },
     "惩前毖后": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "每个回合开始时,对敌军随机两人造成90%谋略伤害(额外受全队累积治疗量影响)。每个回合结束时，恢复我军前排兵力(治疗率50%，受智力影响",
-      "season": 8
+      "season": 8,
+      "ranking": "S",
+      "category": "谋略"
     },
     "万军辟易": {
       "color": "orange",
       "type": "追击",
       "prob": 35,
       "desc": "普通攻击后，对敌军全体造成140%兵刃伤害，偶数回合发动时额外对敌军兵力最低单体造成100%兵刃伤害，若上个回合没有发动，该次战法伤害提升50%",
-      "season": 8
+      "season": 8,
+      "ranking": "A",
+      "category": "兵刃"
     },
     "谋而后动": {
       "color": "orange",
       "type": "追击",
       "prob": 75,
       "desc": "普通攻击后，对敌军全体造成40%谋略伤害，有50%概率(受智力影响)额外再发动一次谋而后动(无法再次发动)，谋而后动的伤害系数每回合提升12%",
-      "season": 7
+      "season": 7,
+      "ranking": "A",
+      "category": "谋略"
     },
     "黄天惑心": {
       "color": "orange",
@@ -2155,28 +2195,36 @@
       "prob": 55,
       "desc": "对敌方全体造成140%的谋略伤害，并施加妖术，持续2回合，若目标已持有妖术状态则额外使其造成伤害降低16%，持续1回合",
       "damageEstimate": 231,
-      "season": 7
+      "season": 7,
+      "ranking": "A",
+      "category": "谋略"
     },
     "断戈夺锋": {
       "color": "orange",
       "type": "主动",
       "prob": 50,
       "desc": "对敌军随机两人造成220%兵刃伤害，并有75%概率施加缴械，持续1回合",
-      "season": 7
+      "season": 7,
+      "ranking": "C",
+      "category": "兵刃"
     },
     "空城计": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "战斗开始前3回合，敌我全体主动战法发动率降低14%（受智力影响）第4回合开始时，我军智力最高单体造成谋略伤害提升16%（受智力影响），我军智力最低单体受到谋略伤害降低16%（受智力影响）",
-      "season": 6
+      "season": 6,
+      "ranking": "C",
+      "category": "辅助"
     },
     "步步为营": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "每回合开始时，有60%概率使自身及随机友军单体受到的伤害降低24%（受统率影响），持续1回合，每回合触发概率提升10%，每个武将独立判断",
-      "season": 6
+      "season": 6,
+      "ranking": "S",
+      "category": "防御"
     },
     "智破千军": {
       "color": "orange",
@@ -2184,21 +2232,27 @@
       "prob": 50,
       "desc": "普通攻击后，对敌军随机两人造成180%谋略伤害，并有35%（受智力影响）令该次伤害额外提升20%，每个目标独立判定",
       "damageEstimate": 193,
-      "season": 6
+      "season": 6,
+      "ranking": "C",
+      "category": "谋略"
     },
     "挫锐折锋": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "战斗开始前3回合，敌军武力最高单体造成兵刃伤害降低25%（受统率影响），敌军智力最高单体造成谋略伤害降低25%（受统率影响）",
-      "season": 5
+      "season": 5,
+      "ranking": "S",
+      "category": "辅助"
     },
     "运智铺谋": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "普通攻击后，谋略伤害提升7%，可叠加5次。造成谋略伤害后，有50%概率对敌军随机单体造成1次普通攻击，每个回合最多触发1次",
-      "season": 5
+      "season": 5,
+      "ranking": "S",
+      "category": "辅助"
     },
     "十面埋伏": {
       "color": "orange",
@@ -2206,28 +2260,36 @@
       "prob": 45,
       "desc": "对敌军全体造成150%兵刃伤害，并有75%概率施加断粮，持续1回合",
       "damageEstimate": 203,
-      "season": 5
+      "season": 5,
+      "ranking": "C",
+      "category": "兵刃"
     },
     "折冲御侮": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "战斗开始前3回合，我军随机两人受到伤害降低24%（受智力影响），并在第4回合开始时为我军全体恢复兵力（治疗率360%，受智力影响）",
-      "season": 4
+      "season": 4,
+      "ranking": "S",
+      "category": "防御"
     },
     "洗筋伐髓": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "回合开始时，使自身造成伤害提升10%，可叠加3次，持续到战斗结束。\n回合行动时，有55%概率使自身获得以下效果：恢复自身兵力（治疗率200%，受最高属性影响）：受到伤害降低20%，持续1回合，每个效果独立判断",
-      "season": 4
+      "season": 4,
+      "ranking": "S",
+      "category": "辅助"
     },
     "经天纬地": {
       "color": "orange",
       "type": "主动",
       "prob": 45,
       "desc": "准备1回合，对敌军全体造成260%谋略伤害，并有80%概率使目标随机获得1种控制状态，持续2回合",
-      "season": 4
+      "season": 4,
+      "ranking": "B",
+      "category": "谋略"
     },
     "文韬武略": {
       "color": "orange",
@@ -2235,14 +2297,18 @@
       "prob": 50,
       "desc": "普通攻击后，对敌军智力最低单体造成160%谋略伤害，对敌军统率最低单体造成160%兵刃伤害",
       "damageEstimate": 160,
-      "season": 4
+      "season": 4,
+      "ranking": "D",
+      "category": "文武"
     },
     "缮甲厉兵": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "自身反击率提升50%%，成功普通攻击后，使自身受到兵刃伤害降低5%，持续2回合，可叠加4次",
-      "season": 3
+      "season": 3,
+      "ranking": "D",
+      "category": "兵刃"
     },
     "同舟共济": {
       "color": "orange",
@@ -2250,14 +2316,18 @@
       "prob": 100,
       "desc": "每个回合行动时恢复自身和随机一名队友兵力（治疗率90%，受智力和统率影响）",
       "healingEstimate": 180,
-      "season": 3
+      "season": 3,
+      "ranking": "B",
+      "category": "治疗"
     },
     "金城汤池": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "回合开始时我军全体有80%概率获得1层抵御，个回合概率降低12％",
-      "season": 3
+      "season": 3,
+      "ranking": "A",
+      "category": "防御"
     },
     "明其虚实": {
       "color": "orange",
@@ -2266,7 +2336,9 @@
       "desc": "夺取敌军随机两人20点智力，统率（受智力影响），持续2回合，并造成140%谋略伤害",
       "attributeEstimate": 112,
       "damageEstimate": 126,
-      "season": 3
+      "season": 3,
+      "ranking": "S",
+      "category": "谋略"
     },
     "烈火张天": {
       "color": "orange",
@@ -2274,7 +2346,9 @@
       "prob": 50,
       "desc": "对敌军全体施加火攻，持续2回合，并造成90%谋略和兵刃伤害",
       "damageEstimate": 270,
-      "season": 3
+      "season": 3,
+      "ranking": "A",
+      "category": "文武"
     },
     "冲锐巧变": {
       "color": "orange",
@@ -2282,28 +2356,36 @@
       "prob": 40,
       "desc": "对敌军随机单体造成360%兵刃伤害，并使自身下一次释放的准备战法跳过一定回合准备。",
       "damageEstimate": 144,
-      "season": 3
+      "season": 3,
+      "ranking": "B",
+      "category": "兵刃"
     },
     "摧坚克难": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "提升自身20%会心几率，每个回合行动结束时对敌军随机两人造成110%兵刃伤害",
-      "season": 2
+      "season": 2,
+      "ranking": "A",
+      "category": "兵刃"
     },
     "胜敌益强": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "造成兵刃伤害后提升自身16点武力，可叠加8次，造成谋略伤害后提升自身16点智力，可叠加8次",
-      "season": 2
+      "season": 2,
+      "ranking": "S",
+      "category": "文武"
     },
     "知人善任": {
       "color": "orange",
       "type": "主动",
       "prob": 75,
       "desc": "使我军智力最高单体受到伤害降低25%（受智力影响），持续2回合，并获得1层抵御",
-      "season": 2
+      "season": 2,
+      "ranking": "A",
+      "category": "防御"
     },
     "三军夺气": {
       "color": "orange",
@@ -2311,35 +2393,45 @@
       "prob": 55,
       "desc": "普通攻击后，使攻击目标武力、智力、统率降低30点，持续2回合，最多可叠加5次",
       "attributeEstimate": 99,
-      "season": 2
+      "season": 2,
+      "ranking": "D",
+      "category": "辅助"
     },
     "乘间投隙": {
       "color": "orange",
       "type": "追击",
       "prob": 60,
       "desc": "普通攻击后，对敌军随机单体施加混乱，持续1回合，并造成120%谋略伤害，若目标已处于混乱状悉，则对其友军随机单体造成100%谋略伤害",
-      "season": 2
+      "season": 2,
+      "ranking": "D",
+      "category": "谋略"
     },
     "韬光养晦": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "自带主动战法发动率提升6%（受智力影响），每个回合开始时使自身造成谋略伤害提升8%，可叠加，持续到战斗结束",
-      "season": 2
+      "season": 2,
+      "ranking": "S",
+      "category": "谋略"
     },
     "奇正相生": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "第2回合起，回合开始时，有65%概率恢复我军随机两人兵力(治疗率为150%，受智力影响），回合结束时，有65%概率对敌军随机两人造成150%谋略伤害",
-      "season": 2
+      "season": 2,
+      "ranking": "A",
+      "category": "治疗"
     },
     "固若金汤": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "自身统率提升15%，第2回合起，每个回合开始时有60%概率(受统率影响）嘲讽敌军随机两人，持续2回合",
-      "season": 2
+      "season": 2,
+      "ranking": "B",
+      "category": "防御"
     },
     "任人唯贤": {
       "color": "purple",
@@ -2362,7 +2454,9 @@
       "prob": 60,
       "desc": "驱散我军随机两人1种负面状态，并恢复其兵力(治疗率180%，受智力影响）",
       "healingEstimate": 216,
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "治疗"
     },
     "文武双全": {
       "color": "orange",
@@ -2370,14 +2464,18 @@
       "prob": 65,
       "desc": "对敌军武力最高单体造成220%谋略伤害，对敌军智力最高单体造成220%兵刃伤害",
       "damageEstimate": 286,
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "文武"
     },
     "万夫莫当": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "普通攻击后，有60%概率对攻击目标的两名队友造成该次普通攻击100%的传递伤害，若自身武力高于目标，则额外造成30%兵刃伤害",
-      "season": 1
+      "season": 1,
+      "ranking": "D",
+      "category": "兵刃"
     },
     "伏兵四起": {
       "color": "orange",
@@ -2385,14 +2483,18 @@
       "prob": 50,
       "desc": "对敌军随机单体造成100%至140%兵刃伤害，施放4次，且发动期间附带25%会心几率。",
       "damageEstimate": 315,
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "兵刃"
     },
     "断敌粮道": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "回合开始时，对敌军单体施加断粮，持续2回合。回合结束时，对持有断粮状态的敌军造成110%谋略伤害",
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "谋略"
     },
     "料事如神": {
       "color": "orange",
@@ -2400,14 +2502,18 @@
       "prob": 45,
       "desc": "对敌军随机两人造成180%谋略伤害，并有50%概率施加技穷，持续1回合",
       "damageEstimate": 162,
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "谋略"
     },
     "洞若观火": {
       "color": "orange",
       "type": "主动",
       "prob": 50,
       "desc": "恢复我军随机单体兵力(治疗率260%，受智力影响），并使其获得清醒，持续2回合",
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "治疗"
     },
     "破阵驰围": {
       "color": "orange",
@@ -2416,7 +2522,9 @@
       "desc": "准备1回合，使敌军随机单体受到伤害提升30%，持续2回合。然后对其造成440%兵刃伤害。若该战法首回合发动则无需准备。",
       "damageEstimate": 149,
       "damageTakenIncreaseEstimate": 17,
-      "season": 1
+      "season": 1,
+      "ranking": "D",
+      "category": "兵刃"
     },
     "运筹帷幄": {
       "color": "orange",
@@ -2424,28 +2532,36 @@
       "prob": 45,
       "desc": "降低敌军随机两人25武力，智力，统率，先攻(受智力影响），持续2回合",
       "attributeEstimate": 140,
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "辅助"
     },
     "铁骑横冲": {
       "color": "orange",
       "type": "追击",
       "prob": 40,
       "desc": "普通攻击后，提升自身20%会心几率，持续2回合，然后对当前目标造成400%兵刃伤害。无论是否发动，该伤害系数每回合降低25%",
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "兵刃"
     },
     "横扫千军": {
       "color": "orange",
       "type": "追击",
       "prob": 45,
       "desc": "普通攻击后，对敌军全体造成120%兵刃伤害，成功释放后下一次横扫千军伤害系数提升12%，可叠加5次，持续到战斗结束",
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "兵刃"
     },
     "舍生取义": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "战斗开始前2回合，我军全体连击率提升30%，我军武力最高单体获得清醒，自身获得缴械，持续2回合。",
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "辅助"
     },
     "指点乾坤": {
       "color": "orange",
@@ -2453,63 +2569,81 @@
       "prob": 50,
       "desc": "令我军武力最高单体对敌军全体造成80%兵刃伤害，令我军智力最高单体对敌军全体造成80%谋略伤害",
       "damageEstimate": 240,
-      "season": 1
+      "season": 1,
+      "ranking": "S",
+      "category": "文武"
     },
     "水淹七军": {
       "color": "orange",
       "type": "主动",
       "prob": 40,
       "desc": "准备1回合，对敌军全体施加洪水，持续2回合，并造成260%兵刃伤害，并施加技穷或缴械中的一种，持续1回合",
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "兵刃"
     },
     "出其不意": {
       "color": "orange",
       "type": "主动",
       "prob": 55,
       "desc": "对敌军随机单体造成350%谋略伤害，若目标持有负面状态该次伤害值提升25%",
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "谋略"
     },
     "奇门遁甲": {
       "color": "orange",
       "type": "主动",
       "prob": 40,
       "desc": "准备1回合,对敌军全体造成250%谋略伤害，并有25%概率施加震慑，持续1回合，目标每多一种异常状态，谋略伤害系数提升25%，震慑概率提升8%，可提升5次",
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "谋略"
     },
     "五雷轰顶": {
       "color": "orange",
       "type": "主动",
       "prob": 50,
       "desc": "准备1回合 ，对敌军随机单体造成160%谋略伤害，施放5次，每次命中持有洪水状态的目标时，额外对其造成40%谋略伤害",
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "谋略"
     },
     "任人择势": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "第3回合起，两名队友每回合有80%概率使下一次伤害必定触发会心和奇谋，且该次会心和奇谋伤害提升40%",
-      "season": 1
+      "season": 1,
+      "ranking": "D",
+      "category": "辅助"
     },
     "坚如磐石": {
       "color": "orange",
       "type": "主动",
       "prob": 55,
       "desc": "嘲讽全体敌军，并使自身受到伤害降低30%，持续2回合",
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "防御"
     },
     "无难之志": {
       "color": "orange",
       "type": "主动",
       "prob": 70,
       "desc": "提升两名队友45%连击率和20%倒戈，持续2回合",
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "辅助"
     },
     "斩将夺旗": {
       "color": "orange",
       "type": "主动",
       "prob": 55,
       "desc": "对统率最低的敌军单体造成220%兵刃伤害，并施加断粮，持续2回合，若目标已持有断粮状态，则额外造成80%兵刃伤害",
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "兵刃"
     },
     "势如破竹": {
       "color": "orange",
@@ -2517,7 +2651,9 @@
       "prob": 50,
       "desc": "提升自身20%会心几率，持续2回合 ，然后对敌军全体造成140%兵刃伤害",
       "damageEstimate": 210,
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "兵刃"
     },
     "上智为间": {
       "color": "orange",
@@ -2525,14 +2661,18 @@
       "prob": 45,
       "desc": "使敌军随机单体混乱，持续1回合，并造成300%谋略伤害",
       "damageEstimate": 135,
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "谋略"
     },
     "锐不可当": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "提升自身16%破甲和35%造成伤害",
-      "season": 1
+      "season": 1,
+      "ranking": "S",
+      "category": "辅助"
     },
     "烈火焚营": {
       "color": "orange",
@@ -2540,14 +2680,18 @@
       "prob": 45,
       "desc": "对敌军全体造成80%谋略伤害，并施加火攻状态，持续2回合。再进行3次焚营：对敌军随机单体造成80％谋略伤害。若目标处于风暴状态，焚营的伤害值提升30%",
       "damageEstimate": 216,
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "谋略"
     },
     "风卷残云": {
       "color": "orange",
       "type": "主动",
       "prob": 60,
       "desc": "调整后：对敌军随机两人造成190%兵刃伤害，若目标处于风暴状态，则自身造成伤害提升15%，持续2回合，可叠加2次。若自身处于风暴状态，则自身规避率提升10%，持续2回合。",
-      "season": 1
+      "season": 1,
+      "ranking": "D",
+      "category": "兵刃"
     },
     "威名显赫": {
       "color": "orange",
@@ -2555,35 +2699,45 @@
       "prob": 50,
       "desc": "提升自身30%倒戈，持续2回合。然后对敌军随机两人造成220%兵刃伤害",
       "damageEstimate": 220,
-      "season": 1
+      "season": 1,
+      "ranking": "S",
+      "category": "兵刃"
     },
     "忘私相助": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "自身受到伤害前，有50%概率恢复两名队友兵力(治疗率50%，受智力和统率影响）",
-      "season": 1
+      "season": 1,
+      "ranking": "S",
+      "category": "治疗"
     },
     "青囊急救": {
       "color": "orange",
       "type": "主动",
       "prob": 55,
       "desc": "驱散我军兵力最低单体3种负面状态，并恢复其兵力(治疗率260%，受智力影响）",
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "治疗"
     },
     "巧利天灾": {
       "color": "orange",
       "type": "主动",
       "prob": 50,
       "desc": "对除自身外的敌我全体目标造成140%谋略伤害若为敌军目标且处于火攻状态，则有35%概率施加混乱，持续1回合若为敌军目标且处于洪水状态，则有35%概率施加缴械，持续1回合若为敌军目标且处于风暴状态，则有35%概率施加技穷，持续1回合",
-      "season": 1
+      "season": 1,
+      "ranking": "D",
+      "category": "谋略"
     },
     "狂风大作": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "第2和第4回合开始时，敌我全体会陷入风暴状态，持续2回合。奇数回合开始时，有60%概率对敌军全体造成100%谋略伤害偶数回合开始时，有60%概率对敌军随机单体造成280%谋略伤害",
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "谋略"
     },
     "战八方": {
       "color": "orange",
@@ -2591,28 +2745,36 @@
       "prob": 55,
       "desc": "对敌军全体造成130%兵刃伤害，并施加畏惧，持续2回合",
       "damageEstimate": 215,
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "兵刃"
     },
     "趁火打劫": {
       "color": "orange",
       "type": "主动",
       "prob": 50,
       "desc": "准备1回合 ，对敌军随机两人造成220%谋略和兵刃伤害,若目标处于火攻状态，则额外施加混乱状态，持续2回合",
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "文武"
     },
     "披坚执锐": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "战斗开始时，使我军随机单体(优先前排)获得披坚：行动前恢复自身兵力(治疗率80%，受目标智力统率影响），受到兵刃伤害降低20%使我军武力最高单体获得执锐：普通攻击后，有50％概率对敌军随机单体造成1次100%兵刃伤害",
-      "season": 1
+      "season": 1,
+      "ranking": "B",
+      "category": "辅助"
     },
     "以静制动": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "奇数回合，自身无法进行普通攻击，自身和随机队友受到兵刃伤害，普通攻击伤害，追击战法伤害减少20%（受统率影响）；偶数回合，自身无法发动主动战法，自身和随机队友受到谋略伤害，主动战法伤害减少20%（受统率影响）。",
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "防御"
     },
     "攻其不备": {
       "color": "orange",
@@ -2620,7 +2782,9 @@
       "prob": 40,
       "desc": "普通攻击后，对攻击目标造成280%兵刃伤害，并施加技穷，持续1回合。若目标已处于技穷状态则有50%概率施加震慑，持续1回合",
       "damageEstimate": 112,
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "兵刃"
     },
     "计袭粮仓": {
       "color": "orange",
@@ -2628,7 +2792,9 @@
       "prob": 45,
       "desc": "普通攻击后，对攻击目标造成300%谋略伤害，并施加断粮，持续2回合，若目标已持有断粮状态则额外对其造成100%谋略伤害",
       "damageEstimate": 180,
-      "season": 1
+      "season": 1,
+      "ranking": "D",
+      "category": "谋略"
     },
     "千里突袭": {
       "color": "orange",
@@ -2636,21 +2802,27 @@
       "prob": 40,
       "desc": "普通攻击后，对先攻最低的敌军单体造成280%(额外受双方先攻差值影响）兵刃伤害，若目标为后排额外造成100%兵刃伤害",
       "damageEstimate": 152,
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "兵刃"
     },
     "辕门射戟": {
       "color": "orange",
       "type": "追击",
       "prob": 70,
       "desc": "普通攻击后，对敌军随机单体造成200%兵刃伤害。若自身为后排，则有75%概率提升自身10%主动战法发动率，持续2回合，可叠加3次",
-      "season": 1
+      "season": 1,
+      "ranking": "D",
+      "category": "兵刃"
     },
     "轻装驰援": {
       "color": "orange",
       "type": "追击",
       "prob": 50,
       "desc": "普通攻击后，对我军随机两人施加1层抵御，并使其受到伤害降低20%，持续2回合",
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "防御"
     },
     "破军袭敌": {
       "color": "orange",
@@ -2658,14 +2830,18 @@
       "prob": 50,
       "desc": "准备1回合，对敌军全体造成300%兵刃伤害",
       "damageEstimate": 225,
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "兵刃"
     },
     "乘虚而入": {
       "color": "orange",
       "type": "追击",
       "prob": 40,
       "desc": "普通攻击后，对敌军随机单体造成280%兵刃伤害，若目标持有虚弱状态，则该次伤害值提升30%，若未持有虚弱状态，则有80%概率施加虚弱，持续1回合。",
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "兵刃"
     },
     "兵贵神速": {
       "color": "orange",
@@ -2673,42 +2849,54 @@
       "prob": 40,
       "desc": "普通攻击后，提升自身30点先攻，持续2回合，并对敌军随机两人造成180%兵刃伤害(额外受先攻影响）",
       "damageEstimate": 144,
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "兵刃"
     },
     "横征暴敛": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "战斗中，施加负面效果后恢复自身兵力(治疗率40%，受智力和统率影响），并使自身受到伤害降低10%，持续2回合，可叠加4次",
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "防御"
     },
     "勇冠三军": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "自身倒戈提升30%，普通攻击之后，使自身造成兵刃伤害提升6%，可叠加6次，累积进行3次普通攻击之后，对敌军随机单体造成200%兵刃伤害",
-      "season": 1
+      "season": 1,
+      "ranking": "D",
+      "category": "兵刃"
     },
     "百战不殆": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "我军统率/智力/武力最高单体受到伤害时，有60%概率对应提升7点统率/智力/武力，可叠加8次，持续到战斗结束，可对同一目标生效",
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "辅助"
     },
     "王佐之才": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "自身奇谋提升20%(受智力影响），造成谋略伤害后有50%概率提升百身10点智力，持续2回合，可叠加4次",
-      "season": 1
+      "season": 1,
+      "ranking": "C",
+      "category": "辅助"
     },
     "蓄势待发": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "每回合开始时提升两名队友7%造成伤害，可叠加，持续到战斗结束",
-      "season": 1
+      "season": 1,
+      "ranking": "A",
+      "category": "辅助"
     },
     "临阵突袭": {
       "color": "purple",
@@ -2931,14 +3119,18 @@
       "type": "指挥",
       "prob": 100,
       "desc": "我军全体每消耗2次抵御，我军全体获得1层据守：统率提升24点，可叠加3次，持续到回合结束。回合结束时，恢复我军兵力最低单体兵力（治疗率60%，受智力和统率影响），每持有1层据守，治疗率提升20%",
-      "season": 14
+      "season": 14,
+      "ranking": "B",
+      "category": "防御"
     },
     "睿虑合图": {
       "color": "orange",
       "type": "指挥",
       "prob": 100,
       "desc": "我军前排受到伤害后，使我军随机2人奇谋提升2%（受智力影响），可叠加15次，持续到战斗结束",
-      "season": 12
+      "season": 12,
+      "ranking": "A",
+      "category": "辅助"
     },
     "千机重城": {
       "color": "orange",
@@ -2976,14 +3168,18 @@
       "type": "指挥",
       "prob": 100,
       "desc": "我军每造成2次自带战法伤害后，自身获得1层“潜袭”：受到伤害降低 3%（受智力影响），可叠加6层，持续到回合结束。满层时，额外使自身造成谋略伤害提升 10%（受智力影响），持续1回合。每回合结束时，有 50% 概率为我军兵力最低单体施加治疗（治疗率160%，受智力影响）。",
-      "season": 15
+      "season": 15,
+      "ranking": "D",
+      "category": "辅助"
     },
     "拔刀相向": {
       "color": "orange",
       "type": "被动",
       "prob": 100,
       "desc": "战斗中，自身尝试发动主动战法时，最高属性提升10点，造成伤害提升7%（受最高属性影响），可叠加5次，持续到战斗结束",
-      "season": 15
+      "season": 15,
+      "ranking": "A",
+      "category": "辅助"
     },
     "曲辞谄媚": {
       "color": "purple",
@@ -3527,7 +3723,7 @@
     "锥形阵": "前排造成的伤害提升16%，后排受到的伤害降低5%",
     "鱼鳞阵": "前排规避率提升12%，后排会心几率和奇谋几率提升8%",
     "钩行阵": "前排受到的伤害降低8%，后排连击率提升25%",
-    "方圆阵": "前排受到的伤害降低5%，后排连击率提升40%"
+    "方圆阵": "前后排协同布阵，兼顾攻防"
   },
   "buffs": {
     "hui_xin": {
@@ -4763,7 +4959,7 @@
       ]
     },
     {
-      "id": "yanwu-姜维-赵云-甘夫人-81b36ace2e454a66",
+      "id": "yanwu-姜维-赵云-甘夫人-91c5b5ebd5accc9a",
       "ranking": "A",
       "sources": [
         "strong"
@@ -4789,6 +4985,7 @@
               "锐不可当"
             ],
             [
+              "掠阵破军",
               "摧坚克难"
             ]
           ]
@@ -5117,7 +5314,7 @@
       ]
     },
     {
-      "id": "yanwu-刘禅-赵云-甘夫人-3161fe845a7f199c",
+      "id": "yanwu-刘禅-赵云-甘夫人-6fbe3fff94de7d98",
       "ranking": "A",
       "sources": [
         "strong"
@@ -5132,7 +5329,8 @@
               "乐不思蜀"
             ],
             [
-              "暗渡阴平"
+              "暗渡阴平",
+              "瞋目横矛"
             ]
           ]
         },
@@ -5157,6 +5355,50 @@
             [
               "金城汤池",
               "调和阴阳"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": "yanwu-诸葛亮-诸葛瑾-庞统-d9d0e4ec64f8bec3",
+      "ranking": "A",
+      "sources": [
+        "strong"
+      ],
+      "section": "蜀国",
+      "formation": "偃月阵",
+      "members": [
+        {
+          "hero": "诸葛亮",
+          "skillSlots": [
+            [
+              "机变无穷"
+            ],
+            [
+              "胜敌益强"
+            ]
+          ]
+        },
+        {
+          "hero": "诸葛瑾",
+          "skillSlots": [
+            [
+              "折冲御侮"
+            ],
+            [
+              "睿虑合图"
+            ]
+          ]
+        },
+        {
+          "hero": "庞统",
+          "skillSlots": [
+            [
+              "惩前毖后"
+            ],
+            [
+              "王佐之才"
             ]
           ]
         }
@@ -5253,7 +5495,7 @@
       ]
     },
     {
-      "id": "yanwu-马云禄-诸葛亮2-乐进-f4b35e0c93ac5fcc",
+      "id": "yanwu-马云禄-诸葛亮2-乐进-e2f15b85e69daa56",
       "ranking": "B",
       "sources": [
         "strong"
@@ -5290,7 +5532,51 @@
               "无难之志"
             ],
             [
-              "战八方",
+              "指点乾坤"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": "yanwu-马云禄-诸葛亮2-糜夫人-cde3dc70448a757a",
+      "ranking": "B",
+      "sources": [
+        "strong"
+      ],
+      "section": "蜀国",
+      "formation": "雁形阵",
+      "members": [
+        {
+          "hero": "马云禄",
+          "skillSlots": [
+            [
+              "锐不可当"
+            ],
+            [
+              "铁骑横冲"
+            ]
+          ]
+        },
+        {
+          "hero": "诸葛亮2",
+          "skillSlots": [
+            [
+              "折冲御侮"
+            ],
+            [
+              "惩前毖后",
+              "谋而后动"
+            ]
+          ]
+        },
+        {
+          "hero": "糜夫人",
+          "skillSlots": [
+            [
+              "无难之志"
+            ],
+            [
               "指点乾坤"
             ]
           ]
@@ -7181,10 +7467,10 @@
   "yanwuGuide": {
     "schemaVersion": 1,
     "source": {
-      "provider": "三谋吕布",
-      "workbook": "三谋吕布-演武.xlsx",
-      "updatedAt": "2026-07-28",
-      "attribution": "攻略数据由三谋吕布提供"
+      "provider": "飞将吕布",
+      "workbook": "三谋演武-飞将吕布.xlsx",
+      "updatedAt": "2026-08-11T16:07:04+10:00",
+      "attribution": "攻略数据由飞将吕布提供"
     },
     "matchups": {
       "orientation": "column-build-vs-row-build",

--- a/web/src/components/game/AnalysisGrid.tsx
+++ b/web/src/components/game/AnalysisGrid.tsx
@@ -1,7 +1,7 @@
 import { Grid, Card, CardContent, Typography, Button, Box, Chip } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import StarIcon from '@mui/icons-material/Star';
-import { formatHeroRanking } from '../../utils/itemMetadata';
+import { formatHeroRanking, formatSkillRanking } from '../../utils/itemMetadata';
 import type { OptionAnalysis, Contribution } from '../../services/recommendationEngine';
 import type { CurrentRoundInputs, SetName, RoundType, HeroMeta, SkillMeta } from '../../types/game';
 import type { PreferencePrediction } from '../../types/telemetryData';
@@ -43,6 +43,7 @@ const AnalysisGrid = ({
   onSelectSet,
   roundType,
   heroMetadata = null,
+  skillMetadata = null,
 }: AnalysisGridProps) => {
   const itemColor = roundType === 'hero' ? 'primary' : 'secondary';
   const hasRecommendedIndex =
@@ -77,7 +78,8 @@ const AnalysisGrid = ({
       const tag = formatHeroRanking(heroMetadata?.[item]);
       return tag ? `${item} · ${tag}` : item;
     }
-    return item;
+    const tag = formatSkillRanking(skillMetadata?.[item]);
+    return tag ? `${item} · ${tag}` : item;
   };
 
   const renderContributions = (items: Contribution[]) => {

--- a/web/src/components/game/__tests__/AnalysisGrid.test.tsx
+++ b/web/src/components/game/__tests__/AnalysisGrid.test.tsx
@@ -118,7 +118,7 @@ describe('AnalysisGrid player preference display', () => {
     expect(screen.queryByTestId('preference-disagreement')).not.toBeInTheDocument();
   });
 
-  test('shows hero guide rankings but keeps skill candidates free of removed tiers', () => {
+  test('shows hero and skill guide rankings without affecting unranked items', () => {
     const { rerender } = render(
       <AnalysisGrid
         sets={{ set1: ['甲'], set2: ['乙'], set3: ['丙'] }}
@@ -144,15 +144,16 @@ describe('AnalysisGrid player preference display', () => {
         onSelectSet={vi.fn()}
         roundType="skill"
         skillMetadata={{
-          战法甲: { season: 1 },
-          战法乙: { season: 1 },
+          战法甲: { season: 1, ranking: 'S', category: '兵刃' },
+          战法乙: { season: 1, ranking: 'B', category: '辅助' },
           战法丙: { season: 1 },
         }}
       />
     );
 
-    expect(screen.getByText('战法甲')).toBeInTheDocument();
-    expect(screen.queryByText(/T[0-9]/)).not.toBeInTheDocument();
+    expect(screen.getByText('战法甲 · S档')).toBeInTheDocument();
+    expect(screen.getByText('战法乙 · B档')).toBeInTheDocument();
+    expect(screen.getByText('战法丙')).toBeInTheDocument();
   });
 
   test('shows exact signed values for positive and negative combination evidence', () => {

--- a/web/src/components/game/__tests__/KnownStrongTeams.test.tsx
+++ b/web/src/components/game/__tests__/KnownStrongTeams.test.tsx
@@ -141,7 +141,7 @@ describe('KnownStrongTeams', () => {
     expect(screen.getByLabelText('满宠：尚未获得')).toBeInTheDocument();
     expect(screen.queryByTestId('known-team-skill-slot')).not.toBeInTheDocument();
     expect(screen.queryByText('S+')).not.toBeInTheDocument();
-    expect(screen.queryByText(/三谋吕布/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/飞将吕布/)).not.toBeInTheDocument();
   });
 
   test('skill rounds retain hero status and show two slots with slash alternatives', () => {

--- a/web/src/guideData.ts
+++ b/web/src/guideData.ts
@@ -1,5 +1,5 @@
 /**
- * Lazy route boundary for the 三谋吕布 editorial guide payload.
+ * Lazy route boundary for the 飞将吕布 editorial guide payload.
  *
  * The canonical source remains public/game-data/database.json. Vite extracts
  * only `yanwuGuide` into this virtual module so the matchup matrix and analysis

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -34,7 +34,7 @@ import GroupsIcon from '@mui/icons-material/Groups';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import { api } from '../services/api';
 import { database } from '../data';
-import { heroRankingRank } from '../utils/rankings';
+import { heroRankingRank, skillRankingRank } from '../utils/rankings';
 import AutocompleteInput from '../components/common/AutocompleteInput';
 import TagList from '../components/common/TagList';
 import ResponsiveDisclosure from '../components/common/ResponsiveDisclosure';
@@ -330,7 +330,11 @@ const Analytics = () => {
     Object.entries(database.heroes || {}).map(([name, hero]) => [name, { ranking: hero.ranking }])
   ), []);
   const skillMetadata = useMemo<Record<string, SkillMeta>>(() => Object.fromEntries(
-    Object.entries(database.skills || {}).map(([name, skill]) => [name, { season: skill.season }])
+    Object.entries(database.skills || {}).map(([name, skill]) => [name, {
+      ranking: skill.ranking,
+      category: skill.category,
+      season: skill.season,
+    }])
   ), []);
 
   // A skill shown in 全部战法 is a 影 (transferred/split) skill in either of
@@ -375,8 +379,13 @@ const Analytics = () => {
     if (!data) return [];
     return data.skills
       .map((s) => s.name)
-      .sort((a, b) => a.localeCompare(b, 'zh-Hans-CN'));
-  }, [data]);
+      .sort((a, b) => {
+        const ra = skillRankingRank(skillMetadata[a]?.ranking);
+        const rb = skillRankingRank(skillMetadata[b]?.ranking);
+        if (ra !== rb) return ra - rb;
+        return a.localeCompare(b, 'zh-Hans-CN');
+      });
+  }, [data, skillMetadata]);
 
   const heroFilterSet = new Set(selectedHeroes);
   const skillFilterSet = new Set(selectedSkills);

--- a/web/src/pages/YanwuGuide.tsx
+++ b/web/src/pages/YanwuGuide.tsx
@@ -44,6 +44,11 @@ const OUTCOME: Record<string, { label: string; color: string; background: string
 
 type GuideTeam = (typeof database.team)[number];
 
+const formatUpdatedAtDate = (updatedAt: string) => {
+  const match = /^\d{4}-\d{2}-\d{2}/.exec(updatedAt);
+  return match ? match[0] : updatedAt;
+};
+
 const isChampionship = (team: GuideTeam) =>
   team.sources.includes('championship');
 
@@ -205,7 +210,7 @@ const YanwuGuide = () => {
       >
         <Typography sx={{ fontWeight: 800 }}>{yanwuGuide.source.attribution}</Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mt: 0.35 }}>
-          数据更新：{yanwuGuide.source.updatedAt}
+          数据更新：{formatUpdatedAtDate(yanwuGuide.source.updatedAt)}
         </Typography>
       </Paper>
 

--- a/web/src/pages/YanwuGuide.tsx
+++ b/web/src/pages/YanwuGuide.tsx
@@ -23,6 +23,7 @@ import { yanwuGuide } from '../guideData';
 import ResponsiveDisclosure from '../components/common/ResponsiveDisclosure';
 
 const HERO_RANKINGS = ['S', 'A', 'B', 'C', 'D'] as const;
+const SKILL_CATEGORIES = ['兵刃', '谋略', '治疗', '防御', '辅助', '文武'] as const;
 const TEAM_RANKINGS = ['S', 'A', 'B'] as const;
 const TEAM_TIERS = ['冠军', ...TEAM_RANKINGS] as const;
 const CAMP_SECTIONS = [
@@ -190,10 +191,10 @@ const YanwuGuide = () => {
       <Box>
         <Typography variant="overline" color="error.main">演武攻略资料</Typography>
         <Typography component="h1" variant="h3" sx={{ mt: 0.5 }}>
-          三国谋定天下演武武将与阵容指南
+          三国谋定天下演武武将、战法与阵容指南
         </Typography>
         <Typography color="text.secondary" sx={{ mt: 1.25, maxWidth: 820 }}>
-          查看国家武将排行、完整阵容战法、夺冠御三家、阵容克制关系与核心武将解析。
+          查看武将与战法排行、完整阵容战法、夺冠御三家、阵容克制关系与核心武将解析。
         </Typography>
       </Box>
 
@@ -239,6 +240,52 @@ const YanwuGuide = () => {
                       </Typography>
                       <Stack direction="row" gap={0.75} flexWrap="wrap">
                         {heroes.map((hero) => <Chip key={hero} label={hero} size="small" />)}
+                      </Stack>
+                    </Box>
+                  );
+                })}
+              </Stack>
+            </Paper>
+          ))}
+        </Box>
+      </Box>
+
+      <Divider />
+
+      <Box component="section" aria-labelledby="skill-ranking-heading" data-testid="guide-skill-rankings">
+        <Typography id="skill-ranking-heading" component="h2" variant="h4">
+          战法排行榜
+        </Typography>
+        <Typography color="text.secondary" sx={{ mt: 0.75 }}>
+          按战法定位与档位查看；未出现在源榜单中的战法不显示档位。
+        </Typography>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', lg: 'repeat(2, minmax(0, 1fr))' },
+            gap: 2,
+            mt: 2,
+          }}
+        >
+          {SKILL_CATEGORIES.map((category) => (
+            <Paper key={category} variant="outlined" sx={{ p: 2 }}>
+              <Typography component="h3" variant="h6" sx={{ mb: 1.5 }}>{category}</Typography>
+              <Stack spacing={1.25}>
+                {HERO_RANKINGS.map((ranking) => {
+                  const skills = Object.entries(database.skills)
+                    .filter(([, skill]) => skill.category === category && skill.ranking === ranking)
+                    .map(([name]) => name)
+                    .sort((a, b) => a.localeCompare(b, 'zh-Hans-CN'));
+                  return (
+                    <Box
+                      key={ranking}
+                      sx={{ display: 'grid', gridTemplateColumns: '32px minmax(0, 1fr)', gap: 1 }}
+                    >
+                      <Typography sx={{ fontWeight: 850, color: ranking === 'S' ? 'error.main' : 'text.primary' }}>
+                        {ranking}
+                      </Typography>
+                      <Stack direction="row" gap={0.75} flexWrap="wrap">
+                        {skills.map((skill) => <Chip key={skill} label={skill} size="small" />)}
                       </Stack>
                     </Box>
                   );

--- a/web/src/seo/config.ts
+++ b/web/src/seo/config.ts
@@ -40,10 +40,10 @@ export const SEO_ROUTES: readonly SeoRoute[] = [
   },
   {
     path: '/guides/yanwu',
-    title: '三国谋定天下演武武将排行与强队阵容攻略｜演武参谋',
+    title: '三国谋定天下演武武将战法排行与强队攻略｜演武参谋',
     description:
       '查看三国谋定天下演武国家武将榜、战法推荐、冠军与 S/A/B 强队阵容，以及阵容克制关系。',
-    heading: '三国谋定天下演武武将与阵容指南',
+    heading: '三国谋定天下演武武将、战法与阵容指南',
     navLabel: '演武攻略',
     index: true,
     ogType: 'article',

--- a/web/src/services/__tests__/api.test.ts
+++ b/web/src/services/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 import { database } from '../../data';
 import { api } from '../api';
 import { clearTelemetryDataCacheForTests } from '../telemetryData';
-import { heroRankingRank } from '../../utils/rankings';
+import { heroRankingRank, skillRankingRank } from '../../utils/rankings';
 
 const compareChineseNames = (a: string, b: string): number =>
   a.localeCompare(b, 'zh-Hans-CN');
@@ -28,12 +28,14 @@ describe('database items', () => {
     }
     for (const name of skillNames) {
       expect(items.skillMetadata[name]?.season).toBe(database.skills[name].season);
+      expect(items.skillMetadata[name]?.ranking).toBe(database.skills[name].ranking);
+      expect(items.skillMetadata[name]?.category).toBe(database.skills[name].category);
       expect(items.skillMetadata[name]).not.toHaveProperty('tier');
       expect(items.skillMetadata[name]).not.toHaveProperty('note');
     }
   });
 
-  test('sorts heroes by presentation ranking then Chinese name, and skills only by Chinese name', async () => {
+  test('sorts heroes and skills by presentation ranking then Chinese name', async () => {
     const items = await api.getDatabaseItems();
     const expectedHeroes = Object.keys(database.heroes).sort((a, b) => {
       const rankingDelta =
@@ -56,7 +58,12 @@ describe('database items', () => {
       items.orangeRegularSkills,
       items.heroSkills,
     ]) {
-      expect(skills).toEqual([...skills].sort(compareChineseNames));
+      expect(skills).toEqual([...skills].sort((a, b) => {
+        const rankingDelta =
+          skillRankingRank(database.skills[a].ranking) -
+          skillRankingRank(database.skills[b].ranking);
+        return rankingDelta || compareChineseNames(a, b);
+      }));
     }
   });
 

--- a/web/src/services/__tests__/promptGenerator.test.ts
+++ b/web/src/services/__tests__/promptGenerator.test.ts
@@ -349,7 +349,7 @@ describe('generateLLMPrompt - model context', () => {
       expect(prompt).toContain('阵型:');
       expect(prompt).toContain('战法位1:');
       expect(prompt).toContain('战法位2:');
-      expect(prompt).not.toContain('三谋吕布');
+      expect(prompt).not.toContain('飞将吕布');
     }
   });
 
@@ -415,7 +415,7 @@ describe('generateLLMPrompt - model context', () => {
     expect(prompt).not.toContain('【玩家心得】');
     expect(prompt).not.toContain('战法强度说明：');
     expect(prompt).toContain('证据概览（本组选项贡献）');
-    expect(prompt).not.toContain('三谋吕布');
+    expect(prompt).not.toContain('飞将吕布');
     expect(prompt).not.toContain('S+');
   });
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -9,7 +9,7 @@ import type { DatabaseItems, RoundType, GameState } from '../types/game';
 import type { PreferencePrediction } from '../types/telemetryData';
 import { getCachedTelemetryData, preloadTelemetryData } from './telemetryData';
 import { predictPlayerPreference } from './preferenceModel';
-import { heroRankingRank } from '../utils/rankings';
+import { heroRankingRank, skillRankingRank } from '../utils/rankings';
 
 const compareChineseNames = (a: string, b: string): number =>
   a.localeCompare(b, 'zh-Hans-CN');
@@ -43,6 +43,16 @@ export const api = {
         ? rankingA - rankingB
         : compareChineseNames(nameA, nameB);
     };
+    const compareSkills = (
+      [nameA, skillA]: (typeof allSkillEntries)[number],
+      [nameB, skillB]: (typeof allSkillEntries)[number]
+    ) => {
+      const rankingA = skillRankingRank(skillA.ranking);
+      const rankingB = skillRankingRank(skillB.ranking);
+      return rankingA !== rankingB
+        ? rankingA - rankingB
+        : compareChineseNames(nameA, nameB);
+    };
     const sortedHeroEntries = [...heroEntries].sort(compareHeroes);
     const heroes = sortedHeroEntries.map(([n]) => n);
     const heroMetadata = Object.fromEntries(
@@ -63,18 +73,29 @@ export const api = {
 
     const skillMetadata = Object.fromEntries(
       allSkillEntries.map(([name, skill]) => [name, {
+        ranking: skill.ranking,
+        category: skill.category,
         season: skill.season,
       }])
     );
     const regularSkills = allSkillEntries
       .filter(([name]) => !heroSkillSet.has(name))
-      .sort(([nameA], [nameB]) => compareChineseNames(nameA, nameB))
+      .sort(compareSkills)
       .map(([name]) => name);
     const orangeRegularSkills = allSkillEntries
       .filter(([name, s]) => !heroSkillSet.has(name) && s.color === 'orange')
-      .sort(([nameA], [nameB]) => compareChineseNames(nameA, nameB))
+      .sort(compareSkills)
       .map(([name]) => name);
-    const allSkills = [...new Set([...regularSkills, ...heroSkills])].sort(compareChineseNames);
+    const skillByName = new Map(allSkillEntries);
+    const allSkills = [...new Set([...regularSkills, ...heroSkills])].sort((nameA, nameB) => {
+      const skillA = skillByName.get(nameA);
+      const skillB = skillByName.get(nameB);
+      const rankingA = skillRankingRank(skillA?.ranking);
+      const rankingB = skillRankingRank(skillB?.ranking);
+      return rankingA !== rankingB
+        ? rankingA - rankingB
+        : compareChineseNames(nameA, nameB);
+    });
     const maxSeason = [...heroEntries, ...allSkillEntries].reduce(
       (latest, [, item]) =>
         Number.isInteger(item.season) && item.season >= 1

--- a/web/src/types/domain.ts
+++ b/web/src/types/domain.ts
@@ -12,6 +12,8 @@ export interface HeroStats {
 }
 
 export type HeroRanking = 'S' | 'A' | 'B' | 'C' | 'D';
+export type SkillRanking = HeroRanking;
+export type SkillCategory = '兵刃' | '谋略' | '治疗' | '防御' | '辅助' | '文武';
 
 export interface Hero {
   skill: string;
@@ -36,6 +38,10 @@ export interface Skill {
   season: number;
   /** A transferred/split hero skill that follows hero-skill draft rules. */
   shadow?: boolean;
+  /** Optional presentation tier from the source guide; never used as a model score. */
+  ranking?: SkillRanking;
+  /** Guide category paired with `ranking`; absent for unranked catalog skills. */
+  category?: SkillCategory;
   /** Optional numeric estimate fields, e.g. `damageEstimate`, `critEstimate`. */
   [estimate: `${string}Estimate`]: number | undefined;
 }
@@ -87,10 +93,10 @@ export type MatchupOutcome =
   | 'self';
 
 export interface YanwuGuideSource {
-  provider: '三谋吕布';
-  workbook: '三谋吕布-演武.xlsx';
+  provider: '飞将吕布';
+  workbook: '三谋演武-飞将吕布.xlsx';
   updatedAt: string;
-  attribution: '攻略数据由三谋吕布提供';
+  attribution: '攻略数据由飞将吕布提供';
 }
 
 export interface YanwuGuideMatchups {

--- a/web/src/types/game.ts
+++ b/web/src/types/game.ts
@@ -3,7 +3,7 @@
  * Mirrors `context/GameContext` and `services/gameLogic`.
  */
 import type { Dispatch } from 'react';
-import type { HeroRanking } from './domain';
+import type { HeroRanking, SkillCategory, SkillRanking } from './domain';
 
 export type RoundType = 'hero' | 'skill';
 
@@ -38,6 +38,9 @@ export interface HeroMeta {
   season?: number;
 }
 export interface SkillMeta {
+  /** Presentation-only tier; recommendation scoring does not consume it. */
+  ranking?: SkillRanking;
+  category?: SkillCategory;
   season?: number;
 }
 

--- a/web/src/utils/__tests__/itemMetadata.test.ts
+++ b/web/src/utils/__tests__/itemMetadata.test.ts
@@ -1,6 +1,7 @@
 import {
   formatHeroRanking,
   formatHeroSearchText,
+  formatSkillRanking,
   formatSkillSearchText,
 } from '../itemMetadata';
 
@@ -11,8 +12,12 @@ describe('item metadata', () => {
       .toBe('吕布 S S档');
   });
 
-  test('keeps skill search text free of removed tier and note metadata', () => {
-    expect(formatSkillSearchText('辕门射戟', { 辕门射戟: { season: 1 } }))
-      .toBe('辕门射戟');
+  test('formats and searches skill guide ranking and category metadata', () => {
+    const metadata = { 辕门射戟: { ranking: 'D' as const, category: '兵刃' as const } };
+    expect(formatSkillRanking(metadata.辕门射戟)).toBe('D档');
+    expect(formatSkillSearchText('辕门射戟', metadata))
+      .toBe('辕门射戟 兵刃 D D档');
+    expect(formatSkillSearchText('未排名战法', { 未排名战法: { season: 1 } }))
+      .toBe('未排名战法');
   });
 });

--- a/web/src/utils/itemMetadata.ts
+++ b/web/src/utils/itemMetadata.ts
@@ -16,7 +16,16 @@ export const formatHeroSearchText = (
 
 export const formatSkillDisplay = (skillName: string): string => skillName;
 
+export const formatSkillRanking = (skill: SkillMeta | null | undefined): string =>
+  skill?.ranking ? `${skill.ranking}档` : '';
+
 export const formatSkillSearchText = (
   skillName: string,
-  _skillMetadata: Record<string, SkillMeta> = {}
-): string => skillName;
+  skillMetadata: Record<string, SkillMeta> = {}
+): string => {
+  const skill = skillMetadata?.[skillName];
+  if (!skill) return skillName;
+  return [skillName, skill.category, skill.ranking, formatSkillRanking(skill)]
+    .filter(Boolean)
+    .join(' ');
+};

--- a/web/src/utils/rankings.ts
+++ b/web/src/utils/rankings.ts
@@ -1,4 +1,4 @@
-import type { HeroRanking, TeamRanking } from '../types/domain';
+import type { HeroRanking, SkillRanking, TeamRanking } from '../types/domain';
 
 const HERO_RANKING_ORDER: Record<HeroRanking, number> = {
   S: 0,
@@ -21,6 +21,10 @@ export const heroRankingRank = (
   ranking != null && ranking in HERO_RANKING_ORDER
     ? HERO_RANKING_ORDER[ranking as HeroRanking]
     : Number.MAX_SAFE_INTEGER;
+
+export const skillRankingRank = (
+  ranking: SkillRanking | string | null | undefined
+): number => heroRankingRank(ranking);
 
 /** Unknown or absent values sort after every supported known-team tier. */
 export const teamRankingRank = (

--- a/web/tests-production/prerender.spec.js
+++ b/web/tests-production/prerender.spec.js
@@ -4,7 +4,7 @@ const database = require('../public/game-data/database.json');
 const PRERENDERED_ROUTES = [
   ['/', '演武配将与战法推荐'],
   ['/analytics', '数据洞察'],
-  ['/guides/yanwu', '三国谋定天下演武武将与阵容指南'],
+  ['/guides/yanwu', '三国谋定天下演武武将、战法与阵容指南'],
   ['/contributors', '战报贡献榜'],
   ['/contribute', '上传战报'],
   ['/team-builder', '队伍策案'],
@@ -85,7 +85,7 @@ test.describe('with JavaScript disabled', () => {
 
     await page.goto('/guides/yanwu');
     await expect(page.getByRole('heading', { name: '强队阵容' })).toBeVisible();
-    await expect(page.getByText(/三谋吕布/)).toBeVisible();
+    await expect(page.getByText(/飞将吕布/)).toBeVisible();
   });
 });
 
@@ -293,7 +293,7 @@ test('hydrates without replacing content and client navigation still works', asy
   await expect(
     page.getByRole('heading', {
       level: 1,
-      name: '三国谋定天下演武武将与阵容指南',
+      name: '三国谋定天下演武武将、战法与阵容指南',
     })
   ).toBeVisible();
 

--- a/web/tests/helpers.js
+++ b/web/tests/helpers.js
@@ -53,6 +53,15 @@ const heroChipLabel = (name) => {
   return `${name} · ${h.ranking}档`;
 };
 
+const rankedSkills = Object.entries(database.skills)
+  .filter(([, skill]) => ['S', 'A', 'B', 'C', 'D'].includes(skill.ranking))
+  .map(([name]) => name);
+
+const skillChipLabel = (name) => {
+  const skill = database.skills[name];
+  return `${name} · ${skill.ranking}档`;
+};
+
 const anySkills = (n) => Object.keys(database.skills).slice(0, n);
 
 // Strict battle-upload fixture: signature skill is positional slot 0; equipped
@@ -94,6 +103,8 @@ module.exports = {
   makeGameState,
   heroesWithMeta,
   heroChipLabel,
+  rankedSkills,
+  skillChipLabel,
   anySkills,
   makeValidUploadBattle,
 };

--- a/web/tests/optionAnalysisLabels.spec.js
+++ b/web/tests/optionAnalysisLabels.spec.js
@@ -1,12 +1,12 @@
 const { test, expect } = require('@playwright/test');
 const {
   seedGame, makeGameState,
-  heroesWithMeta, heroChipLabel, anySkills,
+  heroesWithMeta, heroChipLabel, rankedSkills, skillChipLabel, anySkills,
 } = require('./helpers');
 
 // Acceptance tests for the labels added to 选项分析 (option analysis):
 //   - hero rounds: each candidate hero chip shows `名 · 档位`
-//   - skill rounds: candidate chips stay as bare names (the old skill tier is gone)
+//   - skill rounds: ranked candidate chips show `名 · 档位`
 // See web/src/components/game/AnalysisGrid.js (itemChipLabel).
 //
 // Labels must appear ONLY inside 选项分析 — the rest of the app (team chips,
@@ -137,9 +137,9 @@ test.describe('选项分析 — hero & skill labels', () => {
     }
   });
 
-  test('skill round: candidate chips stay as bare names', async ({ page }) => {
+  test('skill round: ranked candidate chips show skill ranking', async ({ page }) => {
     const team = heroesWithMeta.slice(0, 4);
-    const candidates = anySkills(9);
+    const candidates = rankedSkills.slice(0, 9);
 
     await seedGame(
       page,
@@ -156,7 +156,7 @@ test.describe('选项分析 — hero & skill labels', () => {
     await expect(page.getByText('选项分析')).toBeVisible({ timeout: 15000 });
 
     for (const skill of candidates) {
-      await expect(page.getByText(skill, { exact: true }).first()).toBeVisible();
+      await expect(page.getByText(skillChipLabel(skill), { exact: true }).first()).toBeVisible();
     }
   });
 

--- a/web/tests/seo.spec.js
+++ b/web/tests/seo.spec.js
@@ -13,8 +13,8 @@ const PUBLIC_ROUTES = [
   },
   {
     path: '/guides/yanwu',
-    title: '三国谋定天下演武武将排行与强队阵容攻略｜演武参谋',
-    heading: '三国谋定天下演武武将与阵容指南',
+    title: '三国谋定天下演武武将战法排行与强队攻略｜演武参谋',
+    heading: '三国谋定天下演武武将、战法与阵容指南',
   },
   {
     path: '/contributors',

--- a/web/tests/yanwuGuide.spec.js
+++ b/web/tests/yanwuGuide.spec.js
@@ -17,6 +17,13 @@ test.describe('演武攻略', () => {
     );
     await expect(page.getByText('攻略数据由飞将吕布提供', { exact: true }))
       .toHaveCount(1);
+    const updatedDate = database.yanwuGuide.source.updatedAt.slice(0, 10);
+    await expect(page.getByTestId('yanwu-guide-attribution')).toContainText(
+      `数据更新：${updatedDate}`
+    );
+    await expect(page.getByTestId('yanwu-guide-attribution')).not.toContainText(
+      database.yanwuGuide.source.updatedAt
+    );
 
     await expect(page.getByRole('heading', { name: '国家武将排行榜' })).toBeVisible();
     await expect(page.getByRole('heading', { name: '战法排行榜' })).toBeVisible();

--- a/web/tests/yanwuGuide.spec.js
+++ b/web/tests/yanwuGuide.spec.js
@@ -2,23 +2,29 @@ const { test, expect } = require('@playwright/test');
 const { database } = require('./helpers');
 
 test.describe('演武攻略', () => {
-  test('presents all five workbook sections and keeps attribution on this page only', async ({ page }) => {
+  test('presents the imported workbook sections and keeps attribution on this page only', async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 1000 });
     await page.goto('/guides/yanwu');
 
     await expect(
       page.getByRole('heading', {
         level: 1,
-        name: '三国谋定天下演武武将与阵容指南',
+        name: '三国谋定天下演武武将、战法与阵容指南',
       })
     ).toBeVisible({ timeout: 30000 });
     await expect(page.getByTestId('yanwu-guide-attribution')).toContainText(
-      '攻略数据由三谋吕布提供'
+      '攻略数据由飞将吕布提供'
     );
-    await expect(page.getByText('攻略数据由三谋吕布提供', { exact: true }))
+    await expect(page.getByText('攻略数据由飞将吕布提供', { exact: true }))
       .toHaveCount(1);
 
     await expect(page.getByRole('heading', { name: '国家武将排行榜' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '战法排行榜' })).toBeVisible();
+    const rankedSkillCount = Object.values(database.skills).filter(
+      (skill) => skill.ranking && skill.category
+    ).length;
+    await expect(page.getByTestId('guide-skill-rankings').locator('.MuiChip-root'))
+      .toHaveCount(rankedSkillCount);
     await expect(page.getByText('同一档位内的武将不分先后。')).toHaveCount(0);
     const teamLibrary = page.getByTestId('guide-team-library');
     await expect(teamLibrary.getByRole('heading', { name: '强队阵容' })).toBeVisible();
@@ -89,7 +95,7 @@ test.describe('演武攻略', () => {
 
     await page.getByRole('link', { name: '对局推荐' }).click();
     await expect(page).toHaveURL(/\/$/);
-    await expect(page.getByText('攻略数据由三谋吕布提供', { exact: true }))
+    await expect(page.getByText('攻略数据由飞将吕布提供', { exact: true }))
       .toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Intent

Import the supplied seven-sheet 三谋演武-飞将吕布.xlsx into database.json with provider 飞将吕布 and the reviewed current import timestamp; import 98 战法 rankings and categories and expose them as presentation-only metadata in guide and game UI; accept the three reviewed exact aliases; treat all championship rows as S and reuse exact duplicate build payloads while preserving all five groups and fifteen references; resolve matchup labels by normalized build identity; update the repository skill with every discovered layout, metadata, idempotence, contact-filtering, and gitignore gap plus its solution; preserve deterministic dry-run, atomic apply, idempotence, and absence of provider contact data. After checks pass, push only branch codex/import-feijiang-lvbu-workbook to the configured origin git@github.com:liamqma/sanmou-yanwu.git and create its pull request.

## What Changed

- Reworked `data/import_yanwu_workbook.py` (and its tests) to import the seven-sheet `三谋演武-飞将吕布.xlsx` into `web/public/game-data/database.json` under provider 飞将吕布 with the reviewed import timestamp — adding 98 战法 rankings and 6 categories, accepting the three reviewed exact aliases, treating all championship rows as S-rank while reusing exact-duplicate build payloads across the five groups / fifteen references, and resolving matchup labels by normalized build identity; deterministic dry-run, atomic apply, idempotence, and contact-data exclusion are preserved.
- Surfaced the imported skill rankings and categories as presentation-only metadata across the web app — `YanwuGuide`, `Analytics`, `AnalysisGrid`, `api.ts`, `itemMetadata`, `rankings`, and the domain/game types — and formatted the guide's 数据更新 line as a clean date while retaining the full ISO timestamp in the underlying data.
- Updated the `update-game-database-from-csv` skill doc with the discovered layout, metadata, idempotence, contact-filtering, and gitignore gaps plus their solutions, and added the corresponding `.gitignore` entry.

## Risk Assessment

✅ Low: The only new change is a minimal, correctly-implemented and tested display fix that formats the guide timestamp to a date while preserving the full ISO value in data, and the rest of the branch was already reviewed and is unchanged.

## Testing

Ran the importer unit suite (17 passed) and verified the committed database.json artifact matches every required cardinality (98 ranked skills/6 categories, provider 飞将吕布 + ISO timestamp, all-S championships across 5 groups/15 refs, 13 identity-resolved matchups, three aliases, no guide contact leakage); ran the web workspace under Node 22 with typecheck clean and 420 unit tests passing plus 7 targeted e2e tests passing; and captured reviewer-visible screenshots of the new guide 战法排行榜 section, the date-formatted attribution header, and the game 选项分析 showing skill chips as 名·档位. All checks pass and the working tree is clean. Live re-run of the apply/idempotence path was not possible because the source workbook is intentionally gitignored (contains contact data), so the applied artifact was validated directly; the push/PR clause is out of scope for this test step.

- Evidence: Guide 战法排行榜 — 98 ranked skills by category and tier (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KZQS50YSB4HG4AMG42F4P38X/guide-skill-rankings.png</code>)
- Evidence: Guide attribution — 飞将吕布 provider and date-formatted 数据更新 (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KZQS50YSB4HG4AMG42F4P38X/guide-attribution.png</code>)
- Evidence: Game 选项分析 — skill option chips show presentation-only 名·档位 tiers (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KZQS50YSB4HG4AMG42F4P38X/game-skill-option-analysis.png</code>)
<details>
<summary>Evidence: Screenshot capture script (documents how evidence was produced)</summary>

```text
const path = require('path');
const { chromium } = require('@playwright/test');

const WEB = '/Users/lma2/.no-mistakes/worktrees/cddaca7d92a1/01KZQS50YSB4HG4AMG42F4P38X/web';
const helpers = require(path.join(WEB, 'tests/helpers.js'));
const { makeGameState, rankedSkills, heroesWithMeta, anySkills } = helpers;
const EVID = '/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KZQS50YSB4HG4AMG42F4P38X';

const KEY = 'gameProgress';
const VER = 1;

(async () => {
  const browser = await chromium.launch();
  const ctx = await browser.newContext({ viewport: { width: 1440, height: 1200 } });
  const page = await ctx.newPage();

  // 1) Guide page — 战法排行榜 (skill rankings by category/tier)
  await page.goto('http://localhost:3000/guides/yanwu', { waitUntil: 'networkidle' });
  await page.getByRole('heading', { name: '战法排行榜' }).waitFor({ timeout: 30000 });
  const section = page.getByTestId('guide-skill-rankings');
  await section.scrollIntoViewIfNeeded();
  await section.screenshot({ path: path.join(EVID, 'guide-skill-rankings.png') });

  // Also capture the attribution/date header
  await page.getByTestId('yanwu-guide-attribution').screenshot({
    path: path.join(EVID, 'guide-attribution.png'),
  });

  // 2) Game option-analysis — skill round chips show `名 · 档位`
  const team = heroesWithMeta.slice(0, 4);
  const candidates = rankedSkills.slice(0, 9);
  const gameState = makeGameState({ roundNumber: 2, heroes: team, skills: anySkills(8) });
  const inputs = {
    set1: candidates.slice(0, 3),
    set2: candidates.slice(3, 6),
    set3: candidates.slice(6, 9),
  };
  const envelope = JSON.stringify({ version: VER, gameState, currentRoundInputs: inputs });
  await page.addInitScript(({ key, value }) => {
    localStorage.setItem(key, value);
  }, { key: KEY, value: envelope });
  await page.goto('http://localhost:3000/', { waitUntil: 'networkidle' });
  await page.getByRole('button', { name: '获取 AI 推荐' }).click();
  await page.getByText('选项分析').waitFor({ timeout: 20000 });
  await page.waitForTimeout(500);
  await page.screenshot({ path: path.join(EVID, 'game-skill-option-analysis.png'), fullPage: true });

  await browser.close();
  console.log('screenshots written');
})().catch((e) => { console.error(e); process.exit(1); });
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `web/src/pages/YanwuGuide.tsx:208` - The guide&#39;s &#34;数据更新&#34; line now renders the raw ISO-8601 timestamp with time and timezone offset (&#34;2026-08-11T16:07:04+10:00&#34;) directly to end users, where it previously showed a clean date (&#34;2026-07-28&#34;). Pinning the full timestamp in source for idempotence is intentional, but displaying the time/offset is a UX side effect; consider formatting to a date for the public guide (web/src/pages/YanwuGuide.tsx:208).

🔧 Fix: Format guide 数据更新 as date, keep full ISO in data
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest data/test_import_yanwu_workbook.py` — 17 passed (aliases, skill-ranking categories with partial catalog coverage, championship S-rank + exact-duplicate build reuse, matchup resolution by build identity)</code>
- `Direct artifact inspection of web/public/game-data/database.json: 98 ranked skills, 6 categories, paired ranking/category, provider/workbook/attribution/updatedAt, 5 championship groups / 15 refs, all-S championships, 13 matchup buildIds, contact-pattern scan of guide payload`
- <code>`cd web &amp;&amp; pnpm typecheck` (Node 22) — clean</code>
- <code>`cd web &amp;&amp; pnpm test` (Node 22) — 420 passed</code>
- <code>`cd web &amp;&amp; pnpm exec playwright test tests/yanwuGuide.spec.js tests/optionAnalysisLabels.spec.js` — 7 passed (guide 战法排行榜 chip count, date-formatted 数据更新, game 选项分析 skill ranking labels)</code>
- `Manual Playwright screenshot capture against the running dev server for the guide skill-ranking section, the attribution header, and the game option-analysis skill chips`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
