### PR TITLE
feat(web): use evidence-only Team Builder placement gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,17 @@ in the browser:
   roster-strength improvement over the current pool + evidence. The two-support-
   skill pick is chosen as a **joint pair** (each skill's presence + the best
   feasible hero routing + the within-hero skill-pair bonus when both land on one
-  hero), not two independent top-1 picks. The Team Builder uses a conservative,
-  confidence-first policy. A hero must independently clear the atomic hero
+  hero), not two independent top-1 picks. The Team Builder uses a
+  positive-evidence policy. A hero must independently clear the atomic hero
   (`H`) gate, and every relationship inside a pair/trio must independently clear
-  the hero-pair (`HP`) gate. Each gate requires twice the fitted model's support
-  floor and at least +0.1 display points, so one excellent hero cannot rescue a
-  weak partner. If a qualified group matches two or three members of a known
-  team in `web/public/game-data/database.json`, its formation and canonical hero
-  slots are preserved; guide data never bypasses the model gates. A skill must
-  independently clear both its atomic skill (`S`) and hero-skill (`HS`) gates.
+  the hero-pair (`HP`) gate. Each gate uses the fitted model's support floor
+  (currently 5 battles for atomic hero/skill features and 8 for pair features)
+  and requires a strictly positive raw model contribution, so one excellent
+  hero cannot rescue a weak partner. If a qualified group matches two or three
+  members of a known team in `web/public/game-data/database.json`, its formation
+  and canonical hero slots are preserved; guide data never bypasses the model
+  gates. A skill must independently clear both its atomic skill (`S`) and
+  hero-skill (`HS`) gates.
   Positive within-hero skill-pair (`SP`) evidence may rank qualified choices,
   while confident negative `SP` evidence blocks the pairing. Owned guide skills
   keep their canonical slots only after passing the same gates. Unsupported
@@ -109,8 +111,9 @@ in the browser:
   Function usage and keeps the loading UI responsive. Players can then drag,
   tap, or use the keyboard to rearrange its three teams. The UI shows each
   team's live **评分** and compact positive evidence (武将配合 / 武将与战法 /
-  战法搭配, each with 加分 and reference battle counts); displayed evidence uses
-  the same conservative threshold and there is no aggregate 总评分.
+  战法搭配, each with 加分 and reference battle counts); displayed evidence keeps
+  a +0.1 visibility floor so tiny accepted gains are not rendered as “+0.0”, and
+  there is no aggregate 总评分.
 
 ### Recommendation evaluation
 

--- a/README.md
+++ b/README.md
@@ -91,19 +91,20 @@ in the browser:
   skill pick is chosen as a **joint pair** (each skill's presence + the best
   feasible hero routing + the within-hero skill-pair bonus when both land on one
   hero), not two independent top-1 picks. The Team Builder uses a
-  positive-evidence policy. A hero must independently clear the atomic hero
+  evidence-only policy. A hero must independently clear the atomic hero
   (`H`) gate, and every relationship inside a pair/trio must independently clear
   the hero-pair (`HP`) gate. Each gate uses the fitted model's support floor
-  (currently 5 battles for atomic hero/skill features and 8 for pair features)
-  and requires a strictly positive raw model contribution, so one excellent
-  hero cannot rescue a weak partner. If a qualified group matches two or three
+  (currently 5 battles for atomic hero/skill features and 8 for pair features).
+  Positive, zero, and negative fitted weights remain eligible and affect
+  ranking; missing or under-supported features still fail, so one well-supported
+  hero cannot rescue an unobserved partner. If a qualified group matches two or three
   members of a known team in `web/public/game-data/database.json`, its formation
   and canonical hero slots are preserved; guide data never bypasses the model
   gates. A skill must independently clear both its atomic skill (`S`) and
   hero-skill (`HS`) gates.
-  Positive within-hero skill-pair (`SP`) evidence may rank qualified choices,
-  while confident negative `SP` evidence blocks the pairing. Owned guide skills
-  keep their canonical slots only after passing the same gates. Unsupported
+  Supported within-hero skill-pair (`SP`) evidence, including negative weights,
+  ranks qualified choices without vetoing the pairing. Owned guide skills keep
+  their canonical slots only after passing the same gates. Unsupported
   heroes and skills stay in the warehouse for manual placement instead of being
   forced into a complete 9-hero/18-skill result.
   The deterministic search runs in a client Web Worker, with a yielding

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ in the browser:
   roster-strength improvement over the current pool + evidence. The two-support-
   skill pick is chosen as a **joint pair** (each skill's presence + the best
   feasible hero routing + the within-hero skill-pair bonus when both land on one
-  hero), not two independent top-1 picks. The Team Builder uses a
+  hero), not two independent top-1 picks. The Team Builder uses an
   evidence-only policy. A hero must independently clear the atomic hero
   (`H`) gate, and every relationship inside a pair/trio must independently clear
   the hero-pair (`HP`) gate. Each gate uses the fitted model's support floor

--- a/agent/README.md
+++ b/agent/README.md
@@ -2,7 +2,7 @@
 
 Local TypeScript service for Sanmou's LangGraph team recommendation. One public
 `recommend` workflow fills the hero, formation/row, and skill blanks left by
-the positive-evidence browser-side team builder, then reviews the completed lineup.
+the evidence-only browser-side team builder, then reviews the completed lineup.
 Retrieval and validation are deterministic; high-effort model nodes compare
 skill semantics, camp bonuses, bonds, formations, known teams, and learned
 battle evidence.

--- a/agent/README.md
+++ b/agent/README.md
@@ -2,7 +2,7 @@
 
 Local TypeScript service for Sanmou's LangGraph team recommendation. One public
 `recommend` workflow fills the hero, formation/row, and skill blanks left by
-the conservative browser-side team builder, then reviews the completed lineup.
+the positive-evidence browser-side team builder, then reviews the completed lineup.
 Retrieval and validation are deterministic; high-effort model nodes compare
 skill semantics, camp bonuses, bonds, formations, known teams, and learned
 battle evidence.

--- a/web/README.md
+++ b/web/README.md
@@ -24,12 +24,15 @@ the model data is generated and community reports are imported.
   team library, five championship groups, 13×13 matchup explorer, and workbook
   analysis. This full guide is the sole UI location for the 飞将吕布 attribution.
 - **Manual Editing**: Edit team composition manually at any time
-- **Team Builder**: Start from one conservative, confidence-first three-team
+- **Team Builder**: Start from one positive-evidence three-team
   recommendation. Every placed hero must independently pass its `H` gate and
   every relationship in its pair/trio must pass `HP`; every skill must pass both
-  `S` and `HS`. Each gate needs twice the fitted support floor and +0.1 display
-  gain. Positive `SP` may rank otherwise-qualified skills, while confident
-  negative `SP` blocks the pair. A qualified two- or three-hero guide core keeps
+  `S` and `HS`. Each gate needs the fitted support floor (5 battles for atomic
+  hero/skill features, 8 for pair features) and a strictly positive model
+  contribution; displayed evidence keeps a +0.1 visibility floor so tiny
+  accepted gains are not rendered as +0.0. Positive `SP` may rank
+  otherwise-qualified skills, while confident negative `SP` blocks the pair. A
+  qualified two- or three-hero guide core keeps
   its formation and canonical slots, including gaps, but guide data never
   bypasses these gates. Unsupported positions stay blank. The deterministic
   search runs in a client Web Worker (with a cooperative fallback and memory
@@ -177,11 +180,11 @@ The draft has ten rounds. A one-click win gate controls progression from Round
 6 to 7 and Round 8 to 9. The existing support pick remains optional after Round
 6, and any support selections carry through the later rounds. A completed
 supported draft can therefore contain up to 15 heroes and 28 skills. Team
-Builder recommendations consider that full pool conservatively. Each hero and
-skill must pass its own atomic and relationship gates at twice the model's
-configured support floor and +0.1 display gain. A qualified two- or three-hero
-`database.json` core keeps its formation and canonical slots, while unsupported
-hero and skill positions remain blank.
+Builder recommendations consider that full pool with a positive-evidence
+policy. Each hero and skill must pass its own atomic and relationship gates at
+the model's configured support floor and contribute a strictly positive weight.
+A qualified two- or three-hero `database.json` core keeps its formation and
+canonical slots, while unsupported hero and skill positions remain blank.
 
 - **GameBoard**: Main game container managing the draft rounds
 - **RoundInfo**: Display current round information with stepper
@@ -195,7 +198,7 @@ hero and skill positions remain blank.
   highlights the highest as 玩家选择最高 (independently from the AI 推荐 card), and — only when the
   two tops differ by a meaningful margin — shows a short non-causal A/B/C disagreement note
 - **FormationWorkbench**: The `/team-builder` page's light, game-layout-inspired
-  three-team editor. It seeds the conservative confidence-first recommendation,
+  three-team editor. It seeds the positive-evidence recommendation,
   leaves unsupported positions blank, keeps live per-team model scores, uses
   matched formations and canonical slots from qualified `database.json` cores,
   and supports drag/drop plus tap-to-place on mobile.

--- a/web/README.md
+++ b/web/README.md
@@ -24,14 +24,15 @@ the model data is generated and community reports are imported.
   team library, five championship groups, 13×13 matchup explorer, and workbook
   analysis. This full guide is the sole UI location for the 飞将吕布 attribution.
 - **Manual Editing**: Edit team composition manually at any time
-- **Team Builder**: Start from one positive-evidence three-team
+- **Team Builder**: Start from one evidence-only three-team
   recommendation. Every placed hero must independently pass its `H` gate and
   every relationship in its pair/trio must pass `HP`; every skill must pass both
   `S` and `HS`. Each gate needs the fitted support floor (5 battles for atomic
-  hero/skill features, 8 for pair features) and a strictly positive model
-  contribution; displayed evidence keeps a +0.1 visibility floor so tiny
-  accepted gains are not rendered as +0.0. Positive `SP` may rank
-  otherwise-qualified skills, while confident negative `SP` blocks the pair. A
+  hero/skill features, 8 for pair features). Positive, zero, and negative
+  fitted weights remain eligible and affect ranking; displayed evidence keeps a
+  +0.1 visibility floor so non-positive and tiny gains are not shown as positive
+  explanations. Supported `SP`, including negative weights, ranks
+  otherwise-qualified skills without vetoing the pair. A
   qualified two- or three-hero guide core keeps
   its formation and canonical slots, including gaps, but guide data never
   bypasses these gates. Unsupported positions stay blank. The deterministic
@@ -180,9 +181,10 @@ The draft has ten rounds. A one-click win gate controls progression from Round
 6 to 7 and Round 8 to 9. The existing support pick remains optional after Round
 6, and any support selections carry through the later rounds. A completed
 supported draft can therefore contain up to 15 heroes and 28 skills. Team
-Builder recommendations consider that full pool with a positive-evidence
-policy. Each hero and skill must pass its own atomic and relationship gates at
-the model's configured support floor and contribute a strictly positive weight.
+Builder recommendations consider that full pool with an evidence-only policy.
+Each hero and skill must pass its own atomic and relationship gates at the
+model's configured support floor; every fitted weight remains eligible and
+affects ranking regardless of sign.
 A qualified two- or three-hero `database.json` core keeps its formation and
 canonical slots, while unsupported hero and skill positions remain blank.
 
@@ -198,7 +200,7 @@ canonical slots, while unsupported hero and skill positions remain blank.
   highlights the highest as 玩家选择最高 (independently from the AI 推荐 card), and — only when the
   two tops differ by a meaningful margin — shows a short non-causal A/B/C disagreement note
 - **FormationWorkbench**: The `/team-builder` page's light, game-layout-inspired
-  three-team editor. It seeds the positive-evidence recommendation,
+  three-team editor. It seeds the evidence-only recommendation,
   leaves unsupported positions blank, keeps live per-team model scores, uses
   matched formations and canonical slots from qualified `database.json` cores,
   and supports drag/drop plus tap-to-place on mobile.

--- a/web/src/pages/TeamBuilder.tsx
+++ b/web/src/pages/TeamBuilder.tsx
@@ -576,7 +576,7 @@ const TeamBuilder = () => {
         >
           <Box>
             <Typography variant="body1" fontWeight={700}>
-              只编入证据与强度都达标的武将和战法；匹配到的阵容核心会保留原位置。
+              只编入达到模型最低证据量且强度为正的武将和战法；匹配到的阵容核心会保留原位置。
             </Typography>
           </Box>
           <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap">

--- a/web/src/pages/TeamBuilder.tsx
+++ b/web/src/pages/TeamBuilder.tsx
@@ -576,7 +576,7 @@ const TeamBuilder = () => {
         >
           <Box>
             <Typography variant="body1" fontWeight={700}>
-              只编入达到模型最低证据量且强度为正的武将和战法；匹配到的阵容核心会保留原位置。
+              只编入自身与搭配都达到模型最低证据量的武将和战法；权重只影响排序，不阻止填入。
             </Typography>
           </Box>
           <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap">

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -903,7 +903,7 @@ describe('recommendTeams — global formation optimization', () => {
   });
 });
 
-describe('recommendHybridTeams — confidence-first partial placement', () => {
+describe('recommendHybridTeams — positive-evidence partial placement', () => {
   const heroes = Array.from({ length: 9 }, (_, index) => `h${index}`);
   const skills = Array.from({ length: 18 }, (_, index) => `s${index}`);
   const slotsFor = (offset: number): [
@@ -1021,6 +1021,70 @@ describe('recommendHybridTeams — confidence-first partial placement', () => {
     ]);
   });
 
+  test('places features at the fitted support floors with any positive weight', () => {
+    const data = makeData({
+      weights: {
+        'H|h0': 0.001,
+        'H|h1': 0.001,
+        'H|h2': 0.001,
+        'HP|h0|h1': 0.001,
+        'HP|h0|h2': 0.001,
+        'HP|h1|h2': 0.001,
+        'S|s0': 0.001,
+        'HS|h0|s0': 0.001,
+        'S|s1': 0,
+        'HS|h0|s1': 1,
+        'H|h3': 1,
+        'H|h4': 1,
+        'HP|h3|h4': 1,
+      },
+      support: {
+        'H|h0': 5,
+        'H|h1': 5,
+        'H|h2': 5,
+        'HP|h0|h1': 8,
+        'HP|h0|h2': 8,
+        'HP|h1|h2': 8,
+        'S|s0': 5,
+        'HS|h0|s0': 8,
+        'S|s1': 5,
+        'HS|h0|s1': 8,
+        'H|h3': 4,
+        'H|h4': 5,
+        'HP|h3|h4': 8,
+      },
+      n_features: 13,
+    });
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      []
+    );
+    const placedHeroes = result.options[0].teams.flatMap(
+      (team) => team.heroes
+    );
+    const h0 = placedHeroes.find(({ name }) => name === 'h0');
+
+    expect(placedHeroes.map(({ name }) => name).sort()).toEqual([
+      'h0',
+      'h1',
+      'h2',
+    ]);
+    expect(h0?.skills).toContain('s0');
+    expect(h0?.skills).not.toContain('s1');
+    expect(placedHeroes.map(({ name }) => name)).not.toContain('h3');
+    expect(placedHeroes.map(({ name }) => name)).not.toContain('h4');
+    expect(
+      result.options[0].teams.flatMap(({ evidence }) =>
+        Object.values(evidence).flat()
+      )
+    ).toEqual([]);
+  });
+
   test('does not let a strong hero rescue a bad guide partner', () => {
     const data = makeData({
       weights: {
@@ -1049,7 +1113,7 @@ describe('recommendHybridTeams — confidence-first partial placement', () => {
     expect(result.options[0].teams.every(({ heroes }) => heroes.length === 0)).toBe(true);
   });
 
-  test('leaves a low-support hero pair out even when its weight is large', () => {
+  test('leaves a hero pair below the fitted support floor out even when its weight is large', () => {
     const data = makeData({
       weights: {
         'H|h3': 0.4,
@@ -1059,7 +1123,7 @@ describe('recommendHybridTeams — confidence-first partial placement', () => {
       support: {
         'H|h3': 10,
         'H|h4': 10,
-        'HP|h3|h4': 15,
+        'HP|h3|h4': 7,
       },
       n_features: 3,
     });
@@ -1088,7 +1152,7 @@ describe('recommendHybridTeams — confidence-first partial placement', () => {
         'HS|h0|s1': 3,
         'S|s2': 0.3,
         'HS|h0|s2': 0.4,
-        'SP|h0|s0|s2': -1,
+        'SP|h0|s0|s2': -0.001,
       },
       support: {
         'H|h0': 10,
@@ -1100,7 +1164,7 @@ describe('recommendHybridTeams — confidence-first partial placement', () => {
         'HS|h0|s1': 100,
         'S|s2': 10,
         'HS|h0|s2': 16,
-        'SP|h0|s0|s2': 16,
+        'SP|h0|s0|s2': 8,
       },
       n_features: 10,
     });
@@ -1145,16 +1209,13 @@ describe('recommendHybridTeams — confidence-first partial placement', () => {
     const isConfident = (featureId: string) => {
       const family = featureId.split('|')[0];
       const minimumSupport =
-        2 *
-        (family === 'H' || family === 'S'
+        family === 'H' || family === 'S'
           ? recommendationData.model.min_support_single
-          : recommendationData.model.min_support_pair);
+          : recommendationData.model.min_support_pair;
       return (
         (recommendationData.model.support[featureId] ?? 0) >=
           minimumSupport &&
-        Math.round((recommendationData.model.weights[featureId] ?? 0) * 100) /
-          10 >=
-          0.1
+        (recommendationData.model.weights[featureId] ?? 0) > 0
       );
     };
 

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -903,7 +903,7 @@ describe('recommendTeams — global formation optimization', () => {
   });
 });
 
-describe('recommendHybridTeams — positive-evidence partial placement', () => {
+describe('recommendHybridTeams — evidence-only partial placement', () => {
   const heroes = Array.from({ length: 9 }, (_, index) => `h${index}`);
   const skills = Array.from({ length: 18 }, (_, index) => `s${index}`);
   const slotsFor = (offset: number): [
@@ -1021,19 +1021,19 @@ describe('recommendHybridTeams — positive-evidence partial placement', () => {
     ]);
   });
 
-  test('places features at the fitted support floors with any positive weight', () => {
+  test('places positive, zero, and negative features at the fitted support floors', () => {
     const data = makeData({
       weights: {
-        'H|h0': 0.001,
-        'H|h1': 0.001,
-        'H|h2': 0.001,
-        'HP|h0|h1': 0.001,
-        'HP|h0|h2': 0.001,
-        'HP|h1|h2': 0.001,
-        'S|s0': 0.001,
-        'HS|h0|s0': 0.001,
+        'H|h0': -0.5,
+        'H|h1': 0,
+        'H|h2': -0.2,
+        'HP|h0|h1': -0.1,
+        'HP|h0|h2': 0,
+        'HP|h1|h2': -0.2,
+        'S|s0': -0.3,
+        'HS|h0|s0': -0.2,
         'S|s1': 0,
-        'HS|h0|s1': 1,
+        'HS|h0|s1': 0,
         'H|h3': 1,
         'H|h4': 1,
         'HP|h3|h4': 1,
@@ -1074,8 +1074,7 @@ describe('recommendHybridTeams — positive-evidence partial placement', () => {
       'h1',
       'h2',
     ]);
-    expect(h0?.skills).toContain('s0');
-    expect(h0?.skills).not.toContain('s1');
+    expect(h0?.skills).toEqual(expect.arrayContaining(['s0', 's1']));
     expect(placedHeroes.map(({ name }) => name)).not.toContain('h3');
     expect(placedHeroes.map(({ name }) => name)).not.toContain('h4');
     expect(
@@ -1085,7 +1084,7 @@ describe('recommendHybridTeams — positive-evidence partial placement', () => {
     ).toEqual([]);
   });
 
-  test('does not let a strong hero rescue a bad guide partner', () => {
+  test('uses negative fitted weights for ranking without blocking a supported guide pair', () => {
     const data = makeData({
       weights: {
         'H|h0': 10,
@@ -1110,7 +1109,11 @@ describe('recommendHybridTeams — positive-evidence partial placement', () => {
       [guide]
     );
 
-    expect(result.options[0].teams.every(({ heroes }) => heroes.length === 0)).toBe(true);
+    expect(result.options[0].teams[0].heroes.map(({ name }) => name)).toEqual([
+      'h0',
+      'h1',
+    ]);
+    expect(result.options[0].teams[0].knownTeam?.id).toBe('masked');
   });
 
   test('leaves a hero pair below the fitted support floor out even when its weight is large', () => {
@@ -1140,7 +1143,7 @@ describe('recommendHybridTeams — positive-evidence partial placement', () => {
     expect(result.options[0].teams.every(({ heroes }) => heroes.length === 0)).toBe(true);
   });
 
-  test('requires both S and HS confidence and rejects a negative skill pair', () => {
+  test('requires both S and HS support and uses negative SP as a ranking penalty', () => {
     const data = makeData({
       weights: {
         'H|h0': 0.4,
@@ -1149,10 +1152,10 @@ describe('recommendHybridTeams — positive-evidence partial placement', () => {
         'S|s0': 0.3,
         'HS|h0|s0': 0.5,
         'S|s1': -0.2,
-        'HS|h0|s1': 3,
+        'HS|h0|s1': -0.1,
         'S|s2': 0.3,
         'HS|h0|s2': 0.4,
-        'SP|h0|s0|s2': -0.001,
+        'SP|h0|s0|s2': -0.2,
       },
       support: {
         'H|h0': 10,
@@ -1186,12 +1189,11 @@ describe('recommendHybridTeams — positive-evidence partial placement', () => {
       ({ name }) => name === 'h0'
     );
 
-    expect(h0?.skillSlots).toEqual(['s0', null]);
+    expect(h0?.skillSlots).toEqual(['s0', 's2']);
     expect(h0?.skills).not.toContain('s1');
-    expect(h0?.skills).not.toContain('s2');
   });
 
-  test('real model-only fallback never places a relationship below the confidence gate', () => {
+  test('real model-only fallback never places a relationship below the evidence gate', () => {
     const heroMeta = Object.fromEntries(
       TEN_ROUND_HERO_POOL.map((name) => [
         name,
@@ -1213,9 +1215,7 @@ describe('recommendHybridTeams — positive-evidence partial placement', () => {
           ? recommendationData.model.min_support_single
           : recommendationData.model.min_support_pair;
       return (
-        (recommendationData.model.support[featureId] ?? 0) >=
-          minimumSupport &&
-        (recommendationData.model.weights[featureId] ?? 0) > 0
+        (recommendationData.model.support[featureId] ?? 0) >= minimumSupport
       );
     };
 

--- a/web/src/services/__tests__/teamBuilderMessaging.test.ts
+++ b/web/src/services/__tests__/teamBuilderMessaging.test.ts
@@ -28,7 +28,7 @@ describe('summarizeTeamBuilderRecommendation', () => {
   test('omits the success message when no team is complete', () => {
     expect(summarizeTeamBuilderRecommendation([team(3, 1)])).toEqual({
       successMessage: null,
-      warningMessage: '部分武将或战法未通过证据与强度门槛，已保留空位。',
+      warningMessage: '部分武将或战法未通过证据量门槛，已保留空位。',
     });
   });
 
@@ -37,7 +37,7 @@ describe('summarizeTeamBuilderRecommendation', () => {
       summarizeTeamBuilderRecommendation([team(2), team(3), team(3)])
     ).toEqual({
       successMessage: '已编入 2 支完整队伍',
-      warningMessage: '部分武将或战法未通过证据与强度门槛，已保留空位。',
+      warningMessage: '部分武将或战法未通过证据量门槛，已保留空位。',
     });
   });
 
@@ -46,7 +46,7 @@ describe('summarizeTeamBuilderRecommendation', () => {
       summarizeTeamBuilderRecommendation([team(3, 1), team(3), team(3)])
     ).toEqual({
       successMessage: '已编入 2 支完整队伍',
-      warningMessage: '部分战法未通过证据与强度门槛，已保留空位。',
+      warningMessage: '部分战法未通过证据量门槛，已保留空位。',
     });
   });
 
@@ -84,7 +84,7 @@ describe('summarizeTeamBuilderRecommendation', () => {
 
     expect(summarizeTeamBuilderRecommendation([partial])).toEqual({
       successMessage: null,
-      warningMessage: '部分武将或战法未通过证据与强度门槛，已保留空位。',
+      warningMessage: '部分武将或战法未通过证据量门槛，已保留空位。',
     });
   });
 });

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -2303,11 +2303,11 @@ export const isConfidentDisplayFeature = (
   support >= minimumSupport &&
   displayScore(weight) >= TEAM_BUILDER_VISIBLE_DISPLAY_GAIN;
 
-const isPositiveTeamBuilderFeature = (
-  weight: number,
+const isSupportedTeamBuilderFeature = (
+  _weight: number,
   support: number,
   minimumSupport: number
-): boolean => support >= minimumSupport && weight > 0;
+): boolean => support >= minimumSupport;
 
 function confidentFeature(
   m: PairedModel,
@@ -2316,24 +2316,13 @@ function confidentFeature(
   const weight = weightOf(m, featureId);
   const support = supportOf(m, featureId);
   const family = featureId.split('|')[0];
-  return isPositiveTeamBuilderFeature(
+  return isSupportedTeamBuilderFeature(
     weight,
     support,
     teamBuilderConfidenceSupport(m, family)
   )
     ? { weight, support }
     : null;
-}
-
-function isConfidentNegativeFeature(
-  m: PairedModel,
-  featureId: string
-): boolean {
-  const family = featureId.split('|')[0];
-  return (
-    supportOf(m, featureId) >= teamBuilderConfidenceSupport(m, family) &&
-    weightOf(m, featureId) < 0
-  );
 }
 
 interface ConfidentHeroGroup {
@@ -2664,17 +2653,7 @@ function assignConservativeSkills(
           heroSkillId(hero, skill)
         );
         if (!skillFeature || !heroSkillFeature) continue;
-        if (
-          [...current].some((other) =>
-            isConfidentNegativeFeature(
-              m,
-              skillPairId(hero, skill, other)
-            )
-          )
-        ) {
-          continue;
-        }
-        const positivePairs = [...current]
+        const supportedPairs = [...current]
           .map((other) => confidentFeature(m, skillPairId(hero, skill, other)))
           .filter((feature): feature is ConfidentFeature => feature !== null);
         candidates.push({
@@ -2683,11 +2662,11 @@ function assignConservativeSkills(
           gain:
             skillFeature.weight +
             heroSkillFeature.weight +
-            positivePairs.reduce((sum, feature) => sum + feature.weight, 0),
+            supportedPairs.reduce((sum, feature) => sum + feature.weight, 0),
           support:
             skillFeature.support +
             heroSkillFeature.support +
-            positivePairs.reduce((sum, feature) => sum + feature.support, 0),
+            supportedPairs.reduce((sum, feature) => sum + feature.support, 0),
           key: `${hero}|HS|${skill}`,
         });
       }
@@ -2709,17 +2688,9 @@ function assignConservativeSkills(
           additions.length > openSlots ||
           additions.some((skill) => {
             if (usedSkills.has(skill)) return true;
-            if (
+            return (
               confidentFeature(m, skillId(skill)) === null ||
               confidentFeature(m, heroSkillId(hero, skill)) === null
-            ) {
-              return true;
-            }
-            return [...current].some((other) =>
-              isConfidentNegativeFeature(
-                m,
-                skillPairId(hero, skill, other)
-              )
             );
           })
         ) {
@@ -2790,10 +2761,11 @@ function buildConfidentTeamEvidence(
 }
 
 /**
- * Positive-evidence Team Builder policy. Every placed hero or skill must clear
- * the model's fitted support floor and contribute a strictly positive weight;
- * guide data can then preserve a qualified 2/3 or 3/3 core's canonical slots
- * and formation, but never bypasses those gates.
+ * Evidence-only Team Builder policy. Every placed hero, skill, and relationship
+ * must clear the model's fitted support floor. Positive, zero, and negative
+ * weights all remain eligible and affect ranking; guide data can then preserve
+ * a qualified 2/3 or 3/3 core's canonical slots and formation, but never
+ * bypasses those evidence gates.
  */
 function recommendConservativeHybridTeams(
   heroPool: string[],
@@ -2916,9 +2888,9 @@ function recommendConservativeHybridTeams(
 }
 
 /**
- * Positive-evidence Team Builder recommendation. Guide pairs/trios annotate
+ * Evidence-only Team Builder recommendation. Guide pairs/trios annotate
  * already-qualified model groups and preserve their canonical positions;
- * unsupported or non-positive positions stay blank.
+ * unsupported positions stay blank.
  */
 export function recommendHybridTeams(
   heroPool: string[],

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -685,11 +685,11 @@ const TOP_TWO_BAND = 2.5;
  */
 export const PARTITION_EVAL_CAP = 1920;
 
-/** Conservative Team Builder placements require twice the fitted support floor. */
-export const TEAM_BUILDER_SUPPORT_MULTIPLIER = 2;
+/** Team Builder placements use every feature that cleared the fitted support floor. */
+export const TEAM_BUILDER_SUPPORT_MULTIPLIER = 1;
 
-/** Smallest contribution that is visible as +0.1 in the player-facing scale. */
-export const TEAM_BUILDER_CONFIDENT_DISPLAY_GAIN = 0.1;
+/** Smallest contribution shown as positive evidence in the player-facing scale. */
+export const TEAM_BUILDER_VISIBLE_DISPLAY_GAIN = 0.1;
 
 /** Hard bound on confidence-gated hero groups considered by the partial policy. */
 export const TEAM_BUILDER_GROUP_CANDIDATE_CAP = 320;
@@ -2301,7 +2301,13 @@ export const isConfidentDisplayFeature = (
   minimumSupport: number
 ): boolean =>
   support >= minimumSupport &&
-  displayScore(weight) >= TEAM_BUILDER_CONFIDENT_DISPLAY_GAIN;
+  displayScore(weight) >= TEAM_BUILDER_VISIBLE_DISPLAY_GAIN;
+
+const isPositiveTeamBuilderFeature = (
+  weight: number,
+  support: number,
+  minimumSupport: number
+): boolean => support >= minimumSupport && weight > 0;
 
 function confidentFeature(
   m: PairedModel,
@@ -2310,7 +2316,7 @@ function confidentFeature(
   const weight = weightOf(m, featureId);
   const support = supportOf(m, featureId);
   const family = featureId.split('|')[0];
-  return isConfidentDisplayFeature(
+  return isPositiveTeamBuilderFeature(
     weight,
     support,
     teamBuilderConfidenceSupport(m, family)
@@ -2326,8 +2332,7 @@ function isConfidentNegativeFeature(
   const family = featureId.split('|')[0];
   return (
     supportOf(m, featureId) >= teamBuilderConfidenceSupport(m, family) &&
-    displayScore(weightOf(m, featureId)) <=
-      -TEAM_BUILDER_CONFIDENT_DISPLAY_GAIN
+    weightOf(m, featureId) < 0
   );
 }
 
@@ -2762,7 +2767,11 @@ function buildConfidentTeamEvidence(
       (family === F_HERO_PAIR ||
         family === F_HERO_SKILL ||
         family === F_SKILL_PAIR) &&
-      confidentFeature(m, featureId) !== null
+      isConfidentDisplayFeature(
+        weightOf(m, featureId),
+        supportOf(m, featureId),
+        teamBuilderConfidenceSupport(m, family)
+      )
   );
   const pick = (family: string): EvidenceItem[] =>
     active
@@ -2781,9 +2790,10 @@ function buildConfidentTeamEvidence(
 }
 
 /**
- * Conservative Team Builder policy. Model confidence decides which heroes and
- * skills may be placed; guide data can then preserve a qualified 2/3 or 3/3
- * core's canonical slots and formation, but never bypasses those gates.
+ * Positive-evidence Team Builder policy. Every placed hero or skill must clear
+ * the model's fitted support floor and contribute a strictly positive weight;
+ * guide data can then preserve a qualified 2/3 or 3/3 core's canonical slots
+ * and formation, but never bypasses those gates.
  */
 function recommendConservativeHybridTeams(
   heroPool: string[],
@@ -2906,9 +2916,9 @@ function recommendConservativeHybridTeams(
 }
 
 /**
- * Confidence-first Team Builder recommendation. Guide pairs/trios annotate
+ * Positive-evidence Team Builder recommendation. Guide pairs/trios annotate
  * already-qualified model groups and preserve their canonical positions;
- * unsupported positions stay blank.
+ * unsupported or non-positive positions stay blank.
  */
 export function recommendHybridTeams(
   heroPool: string[],

--- a/web/src/services/teamBuilderMessaging.ts
+++ b/web/src/services/teamBuilderMessaging.ts
@@ -40,7 +40,7 @@ export const summarizeTeamBuilderRecommendation = (
     successMessage:
       completeTeams > 0 ? `已编入 ${completeTeams} 支完整队伍` : null,
     warningMessage: missingItems
-      ? `部分${missingItems}未通过证据与强度门槛，已保留空位。`
+      ? `部分${missingItems}未通过证据量门槛，已保留空位。`
       : null,
   };
 };

--- a/web/src/services/teamFormationCache.ts
+++ b/web/src/services/teamFormationCache.ts
@@ -10,7 +10,7 @@ export function teamFormationCacheKey(
   teamComps: TeamComp[]
 ): string {
   return JSON.stringify({
-    policy: 'positive-evidence-v2',
+    policy: 'evidence-only-v3',
     poolKey,
     catalog: recommendationData.catalog.catalog_version,
     corpus: recommendationData.battle_counts.corpus_version,

--- a/web/src/services/teamFormationCache.ts
+++ b/web/src/services/teamFormationCache.ts
@@ -10,7 +10,7 @@ export function teamFormationCacheKey(
   teamComps: TeamComp[]
 ): string {
   return JSON.stringify({
-    policy: 'conservative-evidence-v1',
+    policy: 'positive-evidence-v2',
     poolKey,
     catalog: recommendationData.catalog.catalog_version,
     corpus: recommendationData.battle_counts.corpus_version,

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -576,14 +576,14 @@ test.describe('Team Builder best default', () => {
     await expect(page.getByTestId('formation-select-0')).not.toHaveValue('');
   });
 
-  test('seeds exactly one conservative editable three-team formation', async ({
+  test('seeds exactly one positive-evidence editable three-team formation', async ({
     page,
   }) => {
     await openBuilder(page);
 
     await expect(
       page.getByText(
-        '只编入证据与强度都达标的武将和战法；匹配到的阵容核心会保留原位置。',
+        '只编入达到模型最低证据量且强度为正的武将和战法；匹配到的阵容核心会保留原位置。',
         { exact: true }
       )
     ).toBeVisible();

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -576,14 +576,14 @@ test.describe('Team Builder best default', () => {
     await expect(page.getByTestId('formation-select-0')).not.toHaveValue('');
   });
 
-  test('seeds exactly one positive-evidence editable three-team formation', async ({
+  test('seeds exactly one evidence-only editable three-team formation', async ({
     page,
   }) => {
     await openBuilder(page);
 
     await expect(
       page.getByText(
-        '只编入达到模型最低证据量且强度为正的武将和战法；匹配到的阵容核心会保留原位置。',
+        '只编入自身与搭配都达到模型最低证据量的武将和战法；权重只影响排序，不阻止填入。',
         { exact: true }
       )
     ).toBeVisible();
@@ -596,7 +596,7 @@ test.describe('Team Builder best default', () => {
       page.getByRole('button', { name: '恢复阵容库推荐' })
     ).toHaveCount(0);
     await expect(page.getByTestId('recommendation-warning')).toHaveText(
-      '部分武将或战法未通过证据与强度门槛，已保留空位。'
+      '部分战法未通过证据量门槛，已保留空位。'
     );
     await expect(page.getByRole('button', { name: '清空编排' })).toHaveCount(0);
     await expect(
@@ -614,13 +614,12 @@ test.describe('Team Builder best default', () => {
     const placedHeroCount = await page
       .locator('[data-testid^="hero-camp-"]')
       .count();
-    expect(placedHeroCount).toBeGreaterThan(0);
-    expect(placedHeroCount).toBeLessThan(9);
+    expect(placedHeroCount).toBe(9);
     await expect(
       page
         .getByRole('region', { name: '武将仓库' })
         .getByRole('button', { name: /^选择武将 / })
-    ).toHaveCount(9 - placedHeroCount);
+    ).toHaveCount(0);
 
     const body = await page.locator('body').innerText();
     expect(body).not.toContain('总评分');
@@ -739,7 +738,7 @@ test.describe('Team Builder mobile placement', () => {
       .poll(() => poolHeroButtons.count(), { timeout: 30000 })
       .toBeGreaterThanOrEqual(8);
     await expect(page.getByTestId('recommendation-warning')).toHaveText(
-      '部分武将或战法未通过证据与强度门槛，已保留空位。'
+      '部分战法未通过证据量门槛，已保留空位。'
     );
     await expect(page.getByTestId('recommendation-warning')).toHaveClass(
       /MuiAlert-standardWarning/


### PR DESCRIPTION
## Intent

Update the existing Team Builder pull request with the user-approved aggressive evidence-only policy: keep model support floors at 5 battles for atomic H and S features and 8 battles for HP, HS, and SP pair features; allow fitted positive, zero, and negative weights to pass placement gates and use their signed raw weights for ranking; remove the negative SP hard veto while retaining negative SP as a ranking penalty; keep missing or under-supported required features ineligible so unsupported spots remain blank; keep visible evidence explanations restricted to positive gains of at least +0.1; add no UI control; update tests, cache version, user copy, and documentation; validate, push, update PR 87, and monitor CI.

## What Changed

- Reworked the Team Builder gating in `recommendationEngine.ts` to an evidence-only policy: heroes must independently clear the atomic `H` gate and every pair/trio relationship must clear the `HP` gate (support floors stay at 5 battles for atomic `H`/`S` and 8 for `HP`/`HS`/`SP`); fitted positive, zero, and negative weights now all pass and rank by their signed raw weight.
- Dropped the negative `SP` hard veto so a negative within-hero skill-pair now only penalizes ranking instead of vetoing a supported pairing, while missing or under-supported required features remain ineligible and leave slots blank; visible evidence stays restricted to positive gains of at least +0.1.
- Bumped `teamFormationCache` version, updated Team Builder user copy/messaging (`TeamBuilder.tsx`, `teamBuilderMessaging.ts`), refreshed the Vitest/Playwright suites for the new gate behavior, and synced README/web/agent docs — no new UI control added.

## Risk Assessment

✅ Low: A well-bounded, user-approved behavior change that swaps the Team Builder placement gate to support-only floors with signed-weight ranking, with matching unit/e2e/doc/cache-version updates and no dangling references or termination/consistency risks.

## Testing

Ran the web workspace's scoped checks (pnpm typecheck clean; 421 Vitest unit tests pass, including the intent-specific evidence-only placement/ranking cases) plus the Playwright Team Builder e2e, then captured reviewer-visible visual evidence by seeding the full pool and screenshotting the live /team-builder surface. The screenshot demonstrates the evidence-only policy end-to-end: the new banner copy "只编入自身与搭配都达到模型最低证据量的武将和战法；权重只影响排序，不阻止填入。", the new warning "部分战法未通过证据量门槛，已保留空位。", all 9 heroes placed across three teams (武将仓库 reads "所有武将均已编入队伍"), positive-only 加分/参考 evidence rows, and an under-supported skill (以静制动) left in the warehouse with a blank 战法 slot. Transient test-results and the temporary capture spec were removed, leaving the working tree clean. Everything passed; no findings. Note: the intent's "push / update PR 87 / monitor CI" steps belong to the no-mistakes push stage, not this test step, so they were out of scope here.

- Evidence: Team Builder evidence-only rendered result (all 9 heroes placed, new copy, positive-only evidence) (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KZWN2T9BA61YHAN44161TYS4/team-builder-evidence-only.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; pnpm typecheck` (Go-native tsc) — clean</code>
- <code>`cd web &amp;&amp; pnpm test` (Vitest) — 421 tests across 38 files pass, including the rewritten `recommendationEngine.test.ts` cases for placing positive/zero/negative features at the support floors, using negative SP as a ranking penalty without vetoing a supported guide pair, and dropping below-floor pairs</code>
- <code>`pnpm exec playwright test tests/buildATeam.spec.js -g &#34;evidence-only editable three-team formation&#34;` — passes, asserting the new banner/warning copy and all-9-heroes placement</code>
- <code>Manual Playwright capture: seeded the complete 9-hero/18-skill pool, opened /team-builder, and screenshotted the rendered result (PLACED_HERO_COUNT=9, 9 evidence rows, warning text `部分战法未通过证据量门槛，已保留空位。`)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
