### PR TITLE
feat(agent): migrate model calls to Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,9 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
     `database.json`/`recommendation_data.json` and the game state/reducer.
   - `src/data.ts` — the central typed boundary that imports and casts the bundled JSON once.
 - `agent/` — local TypeScript HTTP/CLI runtime for model-backed experiments.
-  It uses an OpenAI-compatible provider boundary, is never required by the
-  public static site, and hosts one parent LangGraph recommendation workflow.
+  It uses an OpenAI-compatible Responses API provider boundary, is never
+  required by the public static site, and hosts one parent LangGraph
+  recommendation workflow.
   Its internal hero, formation/row, and skill subgraphs fill only null values,
   preserve every already-filled value, and then run a read-only team review.
   Already-complete inputs route directly to that review. Its loopback HTTP

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -10,7 +10,7 @@ SANMOU_AGENT_ALLOWED_ORIGINS=https://sanmouyanwu.com,http://localhost:3000,http:
 AI_BASE_URL=http://127.0.0.1:8787/v1
 AI_MODEL=gpt-5.6-sol
 SANMOU_REASONING_EFFORT=xhigh
-AI_TIMEOUT_MS=270000
+AI_TIMEOUT_MS=600000
 
 # Optional bearer token when required by the configured provider.
 # AI_API_KEY=

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -6,11 +6,11 @@ SANMOU_AGENT_PORT=8790
 # Generic /v1/chat remains unavailable to browser CORS requests.
 SANMOU_AGENT_ALLOWED_ORIGINS=https://sanmouyanwu.com,http://localhost:3000,http://127.0.0.1:3000,http://localhost:4173,http://127.0.0.1:4173
 
-# OpenAI-compatible model provider endpoint.
+# OpenAI-compatible Responses API provider endpoint.
 AI_BASE_URL=http://127.0.0.1:8787/v1
 AI_MODEL=gpt-5.6-sol
-SANMOU_REASONING_EFFORT=high
-AI_TIMEOUT_MS=60000
+SANMOU_REASONING_EFFORT=xhigh
+AI_TIMEOUT_MS=270000
 
 # Optional bearer token when required by the configured provider.
 # AI_API_KEY=

--- a/agent/README.md
+++ b/agent/README.md
@@ -3,13 +3,13 @@
 Local TypeScript service for Sanmou's LangGraph team recommendation. One public
 `recommend` workflow fills the hero, formation/row, and skill blanks left by
 the evidence-only browser-side team builder, then reviews the completed lineup.
-Retrieval and validation are deterministic; high-effort model nodes compare
+Retrieval and validation are deterministic; highest-effort model nodes compare
 skill semantics, camp bonuses, bonds, formations, known teams, and learned
 battle evidence.
 
-The agent talks to any OpenAI-compatible model provider configured through
-environment variables. Provider authentication and startup are intentionally
-kept outside this repository.
+The agent talks to an OpenAI-compatible Responses API provider configured
+through environment variables. Provider authentication and startup are
+intentionally kept outside this repository.
 
 ## Runtime architecture
 
@@ -20,7 +20,7 @@ CLI, local HTTP caller, or enabled browser experiment
 Sanmou Agent (127.0.0.1:8790)
           |
           v
-OpenAI-compatible provider (127.0.0.1:8787/v1)
+OpenAI-compatible Responses provider (127.0.0.1:8787/v1)
 ```
 
 The public Sanmou website does not start this service and consumes no model
@@ -29,8 +29,8 @@ tokens.
 The HTTP server binds only to loopback. Browser access is restricted to the
 health endpoints and `POST /v1/team-recommendations`; the generic `/v1/chat`
 endpoint remains available only to callers that do not send a browser
-`Origin`. The OpenAI-compatible provider is never called directly by the web
-app.
+`Origin`. The OpenAI-compatible Responses provider is never called directly by
+the web app.
 
 ## Team recommendation graph
 
@@ -142,15 +142,15 @@ pnpm install --frozen-lockfile
 cp .env.example .env
 ```
 
-Start the configured OpenAI-compatible provider separately, then verify the
-model connection directly from the agent client:
+Start the configured OpenAI-compatible Responses provider separately, then
+verify the model connection directly from the agent client:
 
 ```bash
 pnpm smoke
 ```
 
-The default model is `gpt-5.6-sol`. Change `AI_MODEL` in `.env` to compare
-another model.
+The default model is `gpt-5.6-sol` with `xhigh` reasoning effort. Change
+`AI_MODEL` or `SANMOU_REASONING_EFFORT` in `.env` to compare another setup.
 
 ## Run the local HTTP server
 
@@ -201,7 +201,7 @@ curl --silent --show-error --fail-with-body \
     "messages": [
       {"role": "user", "content": "Reply with exactly: agent-http-ok"}
     ],
-    "reasoningEffort": "high",
+    "reasoningEffort": "xhigh",
     "maxCompletionTokens": 64
   }'
 ```
@@ -237,10 +237,10 @@ experiment.
 | `SANMOU_AGENT_HOST` | `127.0.0.1` | Local server bind address |
 | `SANMOU_AGENT_PORT` | `8790` | Local server port |
 | `SANMOU_AGENT_ALLOWED_ORIGINS` | production site plus local dev/preview origins | Exact browser origins allowed to call health and team recommendations |
-| `AI_BASE_URL` | `http://127.0.0.1:8787/v1` | OpenAI-compatible provider base URL |
+| `AI_BASE_URL` | `http://127.0.0.1:8787/v1` | OpenAI-compatible Responses provider base URL |
 | `AI_MODEL` | `gpt-5.6-sol` | Default model ID |
-| `SANMOU_REASONING_EFFORT` | `high` | Effort for hero, formation/row, skill, and review reasoning nodes |
-| `AI_TIMEOUT_MS` | `60000` | Provider request timeout |
+| `SANMOU_REASONING_EFFORT` | `xhigh` | Responses API effort for hero, formation/row, skill, and review reasoning nodes |
+| `AI_TIMEOUT_MS` | `270000` | Provider request timeout; allows for buffered xhigh responses |
 | `AI_API_KEY` | unset | Optional bearer token for other providers |
 
 Do not put provider credentials in the React app or a `VITE_*` variable. Keep

--- a/agent/README.md
+++ b/agent/README.md
@@ -240,7 +240,7 @@ experiment.
 | `AI_BASE_URL` | `http://127.0.0.1:8787/v1` | OpenAI-compatible Responses provider base URL |
 | `AI_MODEL` | `gpt-5.6-sol` | Default model ID |
 | `SANMOU_REASONING_EFFORT` | `xhigh` | Responses API effort for hero, formation/row, skill, and review reasoning nodes |
-| `AI_TIMEOUT_MS` | `270000` | Provider request timeout; allows for buffered xhigh responses |
+| `AI_TIMEOUT_MS` | `600000` | Provider request timeout; allows for buffered xhigh responses |
 | `AI_API_KEY` | unset | Optional bearer token for other providers |
 
 Do not put provider credentials in the React app or a `VITE_*` variable. Keep

--- a/agent/README.md
+++ b/agent/README.md
@@ -8,7 +8,12 @@ skill semantics, camp bonuses, bonds, formations, known teams, and learned
 battle evidence.
 
 The agent talks to an OpenAI-compatible Responses API provider configured
-through environment variables. Provider authentication and startup are
+through environment variables. The adapter posts to
+`<AI_BASE_URL>/responses`, always disables upstream storage with `store: false`,
+and maps the local `messages`, `reasoningEffort`, and `maxCompletionTokens`
+contract to Responses `input`, `reasoning.effort`, and `max_output_tokens`. It
+normalizes `output_text`, response status, and token usage back into the same
+local completion contract. Provider authentication and startup are
 intentionally kept outside this repository.
 
 ## Runtime architecture
@@ -149,8 +154,9 @@ verify the model connection directly from the agent client:
 pnpm smoke
 ```
 
-The default model is `gpt-5.6-sol` with `xhigh` reasoning effort. Change
-`AI_MODEL` or `SANMOU_REASONING_EFFORT` in `.env` to compare another setup.
+The agent and every model-backed recommendation and review stage default to
+`gpt-5.6-sol` with literal `xhigh` reasoning effort. Change `AI_MODEL` or
+`SANMOU_REASONING_EFFORT` in `.env` to compare another setup.
 
 ## Run the local HTTP server
 

--- a/agent/src/cli.ts
+++ b/agent/src/cli.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { loadLocalEnvironment, readAgentConfig } from './config.js';
 import { ChatModelError } from './model.js';
-import { OpenAICompatibleChatModel } from './openAiCompatibleChatModel.js';
+import { OpenAICompatibleResponsesModel } from './openAiCompatibleResponsesModel.js';
 import { loadGameKnowledge } from './team/gameData.js';
 import { runTeamRecommendation } from './team/teamRecommendationGraph.js';
 import { teamRecommendationInputSchema } from './team/teamRecommendationSchemas.js';
@@ -25,9 +25,10 @@ function printUsage(): void {
 async function runSmoke(): Promise<void> {
   loadLocalEnvironment();
   const config = readAgentConfig();
-  const model = new OpenAICompatibleChatModel(config.model);
+  const model = new OpenAICompatibleResponsesModel(config.model);
   const result = await model.complete({
     messages: [{ role: 'user', content: 'Reply with exactly: agent-smoke-ok' }],
+    reasoningEffort: config.reasoningEffort,
     maxCompletionTokens: 64,
   });
   console.log(
@@ -52,7 +53,7 @@ async function runRecommend(inputPath: string | undefined): Promise<void> {
     readFile(resolve(process.cwd(), inputPath), 'utf8'),
   ]);
   const input = teamRecommendationInputSchema.parse(JSON.parse(rawInput) as unknown);
-  const model = new OpenAICompatibleChatModel(config.model);
+  const model = new OpenAICompatibleResponsesModel(config.model);
   const result = await runTeamRecommendation(input, {
     model,
     knowledge,

--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -15,7 +15,7 @@ const environmentSchema = z.object({
   SANMOU_REASONING_EFFORT: z
     .enum(['low', 'medium', 'high', 'xhigh'])
     .default('xhigh'),
-  AI_TIMEOUT_MS: z.coerce.number().int().min(1).max(300_000).default(270_000),
+  AI_TIMEOUT_MS: z.coerce.number().int().min(1).max(600_000).default(600_000),
   AI_API_KEY: z.string().min(1).optional(),
 });
 

--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -12,8 +12,10 @@ const environmentSchema = z.object({
     ),
   AI_BASE_URL: z.url().default('http://127.0.0.1:8787/v1'),
   AI_MODEL: z.string().min(1).default('gpt-5.6-sol'),
-  SANMOU_REASONING_EFFORT: z.enum(['low', 'medium', 'high']).default('high'),
-  AI_TIMEOUT_MS: z.coerce.number().int().min(1).max(300_000).default(60_000),
+  SANMOU_REASONING_EFFORT: z
+    .enum(['low', 'medium', 'high', 'xhigh'])
+    .default('xhigh'),
+  AI_TIMEOUT_MS: z.coerce.number().int().min(1).max(300_000).default(270_000),
   AI_API_KEY: z.string().min(1).optional(),
 });
 
@@ -44,7 +46,7 @@ export interface AgentConfig {
     timeoutMs: number;
     apiKey?: string;
   };
-  reasoningEffort: 'low' | 'medium' | 'high';
+  reasoningEffort: 'low' | 'medium' | 'high' | 'xhigh';
 }
 
 export function loadLocalEnvironment(path = resolve(process.cwd(), '.env')): void {

--- a/agent/src/httpSchemas.ts
+++ b/agent/src/httpSchemas.ts
@@ -9,7 +9,7 @@ export const agentChatRequestSchema = z
   .object({
     messages: z.array(chatMessageSchema).min(1),
     model: z.string().min(1).optional(),
-    reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+    reasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
     maxCompletionTokens: z.number().int().min(1).max(100_000).optional(),
     temperature: z.number().min(-2).max(2).optional(),
   })

--- a/agent/src/httpServer.ts
+++ b/agent/src/httpServer.ts
@@ -151,12 +151,11 @@ async function handleRequest(
     }
 
     const parsed = agentChatRequestSchema.parse(body);
+    const reasoningEffort = parsed.reasoningEffort ?? options.reasoningEffort;
     const completion = await options.model.complete({
       messages: parsed.messages,
       ...(parsed.model === undefined ? {} : { model: parsed.model }),
-      ...(parsed.reasoningEffort === undefined
-        ? {}
-        : { reasoningEffort: parsed.reasoningEffort }),
+      ...(reasoningEffort === undefined ? {} : { reasoningEffort }),
       ...(parsed.maxCompletionTokens === undefined
         ? {}
         : { maxCompletionTokens: parsed.maxCompletionTokens }),

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -11,9 +11,9 @@ export {
   type TokenUsage,
 } from './model.js';
 export {
-  OpenAICompatibleChatModel,
-  type OpenAICompatibleChatModelOptions,
-} from './openAiCompatibleChatModel.js';
+  OpenAICompatibleResponsesModel,
+  type OpenAICompatibleResponsesModelOptions,
+} from './openAiCompatibleResponsesModel.js';
 export { loadGameKnowledge, type GameKnowledge } from './team/gameData.js';
 export {
   createFormationCompletionSubgraph,

--- a/agent/src/model.ts
+++ b/agent/src/model.ts
@@ -5,7 +5,7 @@ export interface ChatMessage {
   content: string;
 }
 
-export type ReasoningEffort = 'low' | 'medium' | 'high';
+export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
 
 export interface ChatCompletionRequest {
   messages: ChatMessage[];

--- a/agent/src/openAiCompatibleResponsesModel.ts
+++ b/agent/src/openAiCompatibleResponsesModel.ts
@@ -31,6 +31,12 @@ const upstreamResponseSchema = z.object({
     })
     .nullable()
     .optional(),
+  error: z
+    .object({
+      message: z.string(),
+    })
+    .nullable()
+    .optional(),
   usage: z.unknown().optional(),
 });
 
@@ -183,7 +189,8 @@ export class OpenAICompatibleResponsesModel implements ChatModel {
     }
     if (parsed.data.status !== 'completed' && parsed.data.status !== 'incomplete') {
       throw new ChatModelError(
-        `Model provider returned response status ${parsed.data.status}`,
+        parsed.data.error?.message ??
+          `Model provider returned response status ${parsed.data.status}`,
         {
           statusCode: response.status,
           details: body,

--- a/agent/src/openAiCompatibleResponsesModel.ts
+++ b/agent/src/openAiCompatibleResponsesModel.ts
@@ -10,16 +10,27 @@ import {
 const upstreamResponseSchema = z.object({
   id: z.string().default(''),
   model: z.string().default(''),
-  choices: z
-    .array(
-      z.object({
-        message: z.object({
-          content: z.string().nullable(),
-        }),
-        finish_reason: z.string().nullable().optional(),
-      })
-    )
-    .min(1),
+  status: z.string(),
+  output_text: z.string().optional(),
+  output: z.array(
+    z.object({
+      type: z.string(),
+      content: z
+        .array(
+          z.object({
+            type: z.string(),
+            text: z.string().optional(),
+          })
+        )
+        .optional(),
+    })
+  ),
+  incomplete_details: z
+    .object({
+      reason: z.string().optional(),
+    })
+    .nullable()
+    .optional(),
   usage: z.unknown().optional(),
 });
 
@@ -30,8 +41,8 @@ function isNonnegativeInteger(value: unknown): value is number {
 function normalizeUsage(raw: unknown): TokenUsage | null {
   if (raw === null || typeof raw !== 'object') return null;
   const record = raw as Record<string, unknown>;
-  const promptTokens = record.prompt_tokens;
-  const completionTokens = record.completion_tokens;
+  const promptTokens = record.input_tokens;
+  const completionTokens = record.output_tokens;
   const totalTokens = record.total_tokens;
   if (
     isNonnegativeInteger(promptTokens) &&
@@ -43,7 +54,31 @@ function normalizeUsage(raw: unknown): TokenUsage | null {
   return null;
 }
 
-export interface OpenAICompatibleChatModelOptions {
+function extractOutputText(response: z.infer<typeof upstreamResponseSchema>): string | null {
+  if (response.output_text !== undefined) {
+    return response.output_text.length === 0 ? null : response.output_text;
+  }
+
+  const textParts = response.output.flatMap((item) =>
+    item.type === 'message'
+      ? (item.content ?? [])
+          .filter((part) => part.type === 'output_text')
+          .flatMap((part) => (part.text === undefined ? [] : [part.text]))
+      : []
+  );
+  const content = textParts.join('');
+  return content.length === 0 ? null : content;
+}
+
+function finishReason(response: z.infer<typeof upstreamResponseSchema>): string | null {
+  if (response.status === 'completed') return 'stop';
+  if (response.status === 'incomplete') {
+    return response.incomplete_details?.reason ?? 'incomplete';
+  }
+  return response.status.length === 0 ? null : response.status;
+}
+
+export interface OpenAICompatibleResponsesModelOptions {
   baseUrl: string;
   model: string;
   timeoutMs: number;
@@ -79,16 +114,16 @@ async function parseJsonResponse(response: Response): Promise<unknown> {
   }
 }
 
-export class OpenAICompatibleChatModel implements ChatModel {
+export class OpenAICompatibleResponsesModel implements ChatModel {
   private readonly endpoint: URL;
   private readonly defaultModel: string;
   private readonly timeoutMs: number;
   private readonly apiKey: string | undefined;
   private readonly fetchImplementation: typeof fetch;
 
-  constructor(options: OpenAICompatibleChatModelOptions) {
+  constructor(options: OpenAICompatibleResponsesModelOptions) {
     const baseUrl = options.baseUrl.endsWith('/') ? options.baseUrl : `${options.baseUrl}/`;
-    this.endpoint = new URL('chat/completions', baseUrl);
+    this.endpoint = new URL('responses', baseUrl);
     this.defaultModel = options.model;
     this.timeoutMs = options.timeoutMs;
     this.apiKey = options.apiKey;
@@ -101,6 +136,7 @@ export class OpenAICompatibleChatModel implements ChatModel {
     };
     if (this.apiKey !== undefined) headers.authorization = `Bearer ${this.apiKey}`;
 
+    const requestedModel = request.model ?? this.defaultModel;
     let response: Response;
     try {
       response = await this.fetchImplementation(this.endpoint, {
@@ -108,14 +144,15 @@ export class OpenAICompatibleChatModel implements ChatModel {
         headers,
         signal: AbortSignal.timeout(this.timeoutMs),
         body: JSON.stringify({
-          model: request.model ?? this.defaultModel,
-          messages: request.messages,
+          model: requestedModel,
+          input: request.messages,
+          store: false,
           ...(request.reasoningEffort === undefined
             ? {}
-            : { reasoning_effort: request.reasoningEffort }),
+            : { reasoning: { effort: request.reasoningEffort } }),
           ...(request.maxCompletionTokens === undefined
             ? {}
-            : { max_completion_tokens: request.maxCompletionTokens }),
+            : { max_output_tokens: request.maxCompletionTokens }),
           ...(request.temperature === undefined
             ? {}
             : { temperature: request.temperature }),
@@ -144,23 +181,28 @@ export class OpenAICompatibleChatModel implements ChatModel {
         details: parsed.error.issues,
       });
     }
-    const choice = parsed.data.choices[0];
-    if (choice === undefined) {
-      throw new ChatModelError('Model provider returned no completion choices', {
-        statusCode: response.status,
-      });
+    if (parsed.data.status !== 'completed' && parsed.data.status !== 'incomplete') {
+      throw new ChatModelError(
+        `Model provider returned response status ${parsed.data.status}`,
+        {
+          statusCode: response.status,
+          details: body,
+        }
+      );
     }
-    const content = choice.message.content;
+
+    const content = extractOutputText(parsed.data);
     if (content === null) {
       throw new ChatModelError('Model provider returned no text content', {
         statusCode: response.status,
+        details: body,
       });
     }
     return {
       id: parsed.data.id,
-      model: parsed.data.model,
+      model: parsed.data.model || requestedModel,
       content,
-      finishReason: choice.finish_reason ?? null,
+      finishReason: finishReason(parsed.data),
       usage: normalizeUsage(parsed.data.usage),
     };
   }

--- a/agent/src/server.ts
+++ b/agent/src/server.ts
@@ -1,6 +1,6 @@
 import { createAgentHttpServer } from './httpServer.js';
 import { loadLocalEnvironment, readAgentConfig } from './config.js';
-import { OpenAICompatibleChatModel } from './openAiCompatibleChatModel.js';
+import { OpenAICompatibleResponsesModel } from './openAiCompatibleResponsesModel.js';
 import { loadGameKnowledge } from './team/gameData.js';
 import type { TeamReviewAttemptDiagnostic } from './team/teamReviewSubgraph.js';
 
@@ -10,7 +10,7 @@ function logReviewAttempt(diagnostic: TeamReviewAttemptDiagnostic): void {
 
 loadLocalEnvironment();
 const config = readAgentConfig();
-const model = new OpenAICompatibleChatModel(config.model);
+const model = new OpenAICompatibleResponsesModel(config.model);
 const knowledge = await loadGameKnowledge();
 const server = createAgentHttpServer({
   model,

--- a/agent/src/team/formationCompletionSubgraph.ts
+++ b/agent/src/team/formationCompletionSubgraph.ts
@@ -189,7 +189,7 @@ function applyDecisions(
 export function createFormationCompletionSubgraph(
   options: FormationCompletionSubgraphOptions
 ) {
-  const reasoningEffort = options.reasoningEffort ?? 'high';
+  const reasoningEffort = options.reasoningEffort ?? 'xhigh';
 
   const prepareNode: GraphNode<typeof FormationCompletionState> = (state) => {
     assertCatalogBackedInput(state.input, options.knowledge);

--- a/agent/src/team/heroCompletionSubgraph.ts
+++ b/agent/src/team/heroCompletionSubgraph.ts
@@ -136,7 +136,7 @@ function validateAssignments(
 }
 
 export function createHeroCompletionSubgraph(options: HeroCompletionSubgraphOptions) {
-  const reasoningEffort = options.reasoningEffort ?? 'high';
+  const reasoningEffort = options.reasoningEffort ?? 'xhigh';
   const maxReasoningAttempts =
     options.maxReasoningAttempts ?? DEFAULT_MAX_REASONING_ATTEMPTS;
   if (!Number.isInteger(maxReasoningAttempts) || maxReasoningAttempts < 1) {

--- a/agent/src/team/skillCompletionSubgraph.ts
+++ b/agent/src/team/skillCompletionSubgraph.ts
@@ -192,10 +192,7 @@ export function createSkillCompletionSubgraph(options: SkillCompletionSubgraphOp
   const reasonNode: GraphNode<typeof SkillCompletionState> = async (state) => {
     if (state.context === undefined) throw new Error('Skill context was not prepared');
     try {
-      const targetCount = findEmptySkillPositions(state.input).length;
-      const maxCompletionTokens =
-        options.maxCompletionTokens ??
-        Math.min(16384, Math.max(8192, targetCount * 768));
+      const maxCompletionTokens = options.maxCompletionTokens ?? 32_768;
       const completion = await options.model.complete({
         messages: [
           {

--- a/agent/src/team/skillCompletionSubgraph.ts
+++ b/agent/src/team/skillCompletionSubgraph.ts
@@ -157,7 +157,7 @@ function applyAssignments(
 }
 
 export function createSkillCompletionSubgraph(options: SkillCompletionSubgraphOptions) {
-  const reasoningEffort = options.reasoningEffort ?? 'high';
+  const reasoningEffort = options.reasoningEffort ?? 'xhigh';
 
   const prepareNode: GraphNode<typeof SkillCompletionState> = (state) => {
     const targets = findEmptySkillPositions(state.input);

--- a/agent/src/team/teamReviewSubgraph.ts
+++ b/agent/src/team/teamReviewSubgraph.ts
@@ -343,7 +343,7 @@ function completeResult(
 }
 
 export function createTeamReviewSubgraph(options: TeamReviewSubgraphOptions) {
-  const reasoningEffort = options.reasoningEffort ?? 'high';
+  const reasoningEffort = options.reasoningEffort ?? 'xhigh';
   const maxReviewAttempts = options.maxReviewAttempts ?? DEFAULT_MAX_REVIEW_ATTEMPTS;
   if (!Number.isInteger(maxReviewAttempts) || maxReviewAttempts < 1) {
     throw new Error('maxReviewAttempts must be a positive integer');

--- a/agent/src/team/teamReviewSubgraph.ts
+++ b/agent/src/team/teamReviewSubgraph.ts
@@ -373,7 +373,7 @@ export function createTeamReviewSubgraph(options: TeamReviewSubgraphOptions) {
           },
         ],
         reasoningEffort,
-        maxCompletionTokens: options.maxCompletionTokens ?? 8192,
+        maxCompletionTokens: options.maxCompletionTokens ?? 32_768,
       });
       finishReason = completion.finishReason;
       usage = completion.usage;

--- a/agent/tests/config.test.ts
+++ b/agent/tests/config.test.ts
@@ -15,11 +15,11 @@ describe('readAgentConfig', () => {
         'http://localhost:4173',
         'http://127.0.0.1:4173',
       ],
-      reasoningEffort: 'high',
+      reasoningEffort: 'xhigh',
       model: {
         baseUrl: 'http://127.0.0.1:8787/v1',
         model: 'gpt-5.6-sol',
-        timeoutMs: 60_000,
+        timeoutMs: 270_000,
       },
     });
   });

--- a/agent/tests/config.test.ts
+++ b/agent/tests/config.test.ts
@@ -19,7 +19,7 @@ describe('readAgentConfig', () => {
       model: {
         baseUrl: 'http://127.0.0.1:8787/v1',
         model: 'gpt-5.6-sol',
-        timeoutMs: 270_000,
+        timeoutMs: 600_000,
       },
     });
   });

--- a/agent/tests/formationCompletionSubgraph.test.ts
+++ b/agent/tests/formationCompletionSubgraph.test.ts
@@ -61,7 +61,7 @@ describe('formation completion context', () => {
 });
 
 describe('formation completion LangGraph subgraph', () => {
-  it('fills only missing layout values with high reasoning effort', async () => {
+  it('fills only missing layout values with xhigh reasoning effort', async () => {
     const model = new FakeChatModel(validDecision);
     const result = await runFormationCompletion(incompleteLayout, {
       model,
@@ -83,7 +83,7 @@ describe('formation completion LangGraph subgraph', () => {
     ]);
     expect(model.requests).toHaveLength(1);
     expect(model.requests[0]).toMatchObject({
-      reasoningEffort: 'high',
+      reasoningEffort: 'xhigh',
       maxCompletionTokens: 4096,
     });
   });

--- a/agent/tests/httpServer.test.ts
+++ b/agent/tests/httpServer.test.ts
@@ -82,7 +82,7 @@ describe('agent HTTP server', () => {
     expect(model.requests).toEqual([]);
   });
 
-  it('validates and forwards a chat request', async () => {
+  it('validates a chat request and applies the configured reasoning effort', async () => {
     const model = new FakeChatModel();
     const { baseUrl } = await startServer(model);
 
@@ -91,7 +91,6 @@ describe('agent HTTP server', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         messages: [{ role: 'user', content: 'hello' }],
-        reasoningEffort: 'high',
         maxCompletionTokens: 64,
       }),
     });

--- a/agent/tests/openAiCompatibleResponsesModel.test.ts
+++ b/agent/tests/openAiCompatibleResponsesModel.test.ts
@@ -164,9 +164,19 @@ describe('OpenAICompatibleResponsesModel', () => {
     });
   });
 
-  it('rejects a successful HTTP response with a failed Responses status', async () => {
+  it('preserves the provider error from a failed Responses status', async () => {
+    const failedBody = completedResponse({
+      status: 'failed',
+      output: [],
+      error: {
+        code: 'model_error',
+        message: 'unsupported request',
+        type: 'invalid_request_error',
+      },
+      provider_metadata: { request_id: 'request-1' },
+    });
     const fetchImplementation = vi.fn<typeof fetch>(async () =>
-      new Response(JSON.stringify(completedResponse({ status: 'failed', output: [] })), {
+      new Response(JSON.stringify(failedBody), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       })
@@ -178,12 +188,15 @@ describe('OpenAICompatibleResponsesModel', () => {
       fetchImplementation,
     });
 
-    await expect(
-      model.complete({ messages: [{ role: 'user', content: 'hi' }] })
-    ).rejects.toMatchObject({
-      message: 'Model provider returned response status failed',
+    const error = await model
+      .complete({ messages: [{ role: 'user', content: 'hi' }] })
+      .catch((cause: unknown) => cause);
+
+    expect(error).toMatchObject({
+      message: 'unsupported request',
       statusCode: 200,
     });
+    expect((error as { details: unknown }).details).toEqual(failedBody);
   });
 
   it('preserves a provider error message and status', async () => {

--- a/agent/tests/openAiCompatibleResponsesModel.test.ts
+++ b/agent/tests/openAiCompatibleResponsesModel.test.ts
@@ -1,29 +1,47 @@
 import { describe, expect, it, vi } from 'vitest';
-import { OpenAICompatibleChatModel } from '../src/openAiCompatibleChatModel.js';
+import { OpenAICompatibleResponsesModel } from '../src/openAiCompatibleResponsesModel.js';
 
-describe('OpenAICompatibleChatModel', () => {
-  it('maps the generic request and normalizes the completion', async () => {
+function completedResponse(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'response-1',
+    model: 'resolved-model',
+    status: 'completed',
+    output: [
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'hello', annotations: [] }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('OpenAICompatibleResponsesModel', () => {
+  it('maps the generic request to Responses API and normalizes the response', async () => {
     const fetchImplementation = vi.fn<typeof fetch>(async () =>
       new Response(
-        JSON.stringify({
-          id: 'completion-1',
-          model: 'resolved-model',
-          choices: [
-            {
-              message: { content: 'hello' },
-              finish_reason: 'stop',
+        JSON.stringify(
+          completedResponse({
+            output: [
+              { type: 'reasoning', summary: [{ type: 'summary_text', text: 'Think.' }] },
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'hello', annotations: [] }],
+              },
+            ],
+            usage: {
+              input_tokens: 4,
+              output_tokens: 2,
+              total_tokens: 6,
             },
-          ],
-          usage: {
-            prompt_tokens: 4,
-            completion_tokens: 2,
-            total_tokens: 6,
-          },
-        }),
+          })
+        ),
         { status: 200, headers: { 'content-type': 'application/json' } }
       )
     );
-    const model = new OpenAICompatibleChatModel({
+    const model = new OpenAICompatibleResponsesModel({
       baseUrl: 'http://provider.test/v1',
       model: 'default-model',
       timeoutMs: 1000,
@@ -33,13 +51,13 @@ describe('OpenAICompatibleChatModel', () => {
 
     const completion = await model.complete({
       messages: [{ role: 'user', content: 'hi' }],
-      reasoningEffort: 'high',
+      reasoningEffort: 'xhigh',
       maxCompletionTokens: 50,
       temperature: 0,
     });
 
     expect(completion).toEqual({
-      id: 'completion-1',
+      id: 'response-1',
       model: 'resolved-model',
       content: 'hello',
       finishReason: 'stop',
@@ -51,32 +69,29 @@ describe('OpenAICompatibleChatModel', () => {
     });
     expect(fetchImplementation).toHaveBeenCalledOnce();
     const [url, init] = fetchImplementation.mock.calls[0]!;
-    expect(String(url)).toBe('http://provider.test/v1/chat/completions');
+    expect(String(url)).toBe('http://provider.test/v1/responses');
     expect(init?.headers).toEqual({
       authorization: 'Bearer test-key',
       'content-type': 'application/json',
     });
     expect(JSON.parse(String(init?.body))).toEqual({
       model: 'default-model',
-      messages: [{ role: 'user', content: 'hi' }],
-      reasoning_effort: 'high',
-      max_completion_tokens: 50,
+      input: [{ role: 'user', content: 'hi' }],
+      store: false,
+      reasoning: { effort: 'xhigh' },
+      max_output_tokens: 50,
       temperature: 0,
     });
   });
 
-  it('keeps a valid completion when upstream usage is missing', async () => {
+  it('uses top-level output_text and keeps a valid response when usage is missing', async () => {
     const fetchImplementation = vi.fn<typeof fetch>(async () =>
       new Response(
-        JSON.stringify({
-          id: 'completion-2',
-          model: 'resolved-model',
-          choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }],
-        }),
+        JSON.stringify(completedResponse({ output_text: 'top-level text' })),
         { status: 200, headers: { 'content-type': 'application/json' } }
       )
     );
-    const model = new OpenAICompatibleChatModel({
+    const model = new OpenAICompatibleResponsesModel({
       baseUrl: 'http://provider.test/v1',
       model: 'default-model',
       timeoutMs: 1000,
@@ -88,9 +103,9 @@ describe('OpenAICompatibleChatModel', () => {
     });
 
     expect(completion).toEqual({
-      id: 'completion-2',
+      id: 'response-1',
       model: 'resolved-model',
-      content: 'hello',
+      content: 'top-level text',
       finishReason: 'stop',
       usage: null,
     });
@@ -99,16 +114,13 @@ describe('OpenAICompatibleChatModel', () => {
   it('drops partial or non-integer usage without inventing counts', async () => {
     const fetchImplementation = vi.fn<typeof fetch>(async () =>
       new Response(
-        JSON.stringify({
-          id: 'completion-3',
-          model: 'resolved-model',
-          choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }],
-          usage: { prompt_tokens: 4, completion_tokens: 2.5 },
-        }),
+        JSON.stringify(
+          completedResponse({ usage: { input_tokens: 4, output_tokens: 2.5 } })
+        ),
         { status: 200, headers: { 'content-type': 'application/json' } }
       )
     );
-    const model = new OpenAICompatibleChatModel({
+    const model = new OpenAICompatibleResponsesModel({
       baseUrl: 'http://provider.test/v1',
       model: 'default-model',
       timeoutMs: 1000,
@@ -123,19 +135,19 @@ describe('OpenAICompatibleChatModel', () => {
     expect(completion.usage).toBeNull();
   });
 
-  it('normalizes complete valid usage', async () => {
+  it('preserves incomplete response text and reports its reason', async () => {
     const fetchImplementation = vi.fn<typeof fetch>(async () =>
       new Response(
-        JSON.stringify({
-          id: 'completion-4',
-          model: 'resolved-model',
-          choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }],
-          usage: { prompt_tokens: 7, completion_tokens: 3, total_tokens: 10 },
-        }),
+        JSON.stringify(
+          completedResponse({
+            status: 'incomplete',
+            incomplete_details: { reason: 'max_output_tokens' },
+          })
+        ),
         { status: 200, headers: { 'content-type': 'application/json' } }
       )
     );
-    const model = new OpenAICompatibleChatModel({
+    const model = new OpenAICompatibleResponsesModel({
       baseUrl: 'http://provider.test/v1',
       model: 'default-model',
       timeoutMs: 1000,
@@ -146,10 +158,31 @@ describe('OpenAICompatibleChatModel', () => {
       messages: [{ role: 'user', content: 'hi' }],
     });
 
-    expect(completion.usage).toEqual({
-      promptTokens: 7,
-      completionTokens: 3,
-      totalTokens: 10,
+    expect(completion).toMatchObject({
+      content: 'hello',
+      finishReason: 'max_output_tokens',
+    });
+  });
+
+  it('rejects a successful HTTP response with a failed Responses status', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () =>
+      new Response(JSON.stringify(completedResponse({ status: 'failed', output: [] })), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const model = new OpenAICompatibleResponsesModel({
+      baseUrl: 'http://provider.test/v1',
+      model: 'test-model',
+      timeoutMs: 1000,
+      fetchImplementation,
+    });
+
+    await expect(
+      model.complete({ messages: [{ role: 'user', content: 'hi' }] })
+    ).rejects.toMatchObject({
+      message: 'Model provider returned response status failed',
+      statusCode: 200,
     });
   });
 
@@ -160,7 +193,7 @@ describe('OpenAICompatibleChatModel', () => {
         { status: 429, headers: { 'content-type': 'application/json' } }
       )
     );
-    const model = new OpenAICompatibleChatModel({
+    const model = new OpenAICompatibleResponsesModel({
       baseUrl: 'http://provider.test/v1',
       model: 'test-model',
       timeoutMs: 1000,

--- a/agent/tests/skillCompletionSubgraph.test.ts
+++ b/agent/tests/skillCompletionSubgraph.test.ts
@@ -73,7 +73,7 @@ describe('skill completion LangGraph subgraph', () => {
     expect(result.teams[0]?.heroes[1]).toEqual(oneSkillBlankInput.teams[0]?.heroes[1]);
     expect(model.requests[0]).toMatchObject({
       reasoningEffort: 'xhigh',
-      maxCompletionTokens: 8192,
+      maxCompletionTokens: 32_768,
     });
     expect(model.requests[0]?.messages[1]?.content).toContain('兵刃伤害 versus 谋略伤害');
   });

--- a/agent/tests/skillCompletionSubgraph.test.ts
+++ b/agent/tests/skillCompletionSubgraph.test.ts
@@ -61,7 +61,7 @@ describe('skill completion context', () => {
 });
 
 describe('skill completion LangGraph subgraph', () => {
-  it('fills every empty skill slot with high reasoning effort', async () => {
+  it('fills every empty skill slot with xhigh reasoning effort', async () => {
     const model = new FakeChatModel(validAssignment);
     const result = await runSkillCompletion(oneSkillBlankInput, {
       model,
@@ -72,7 +72,7 @@ describe('skill completion LangGraph subgraph', () => {
     expect(result.teams[0]?.heroes[0]?.skills).toEqual(['甲技', '治疗术']);
     expect(result.teams[0]?.heroes[1]).toEqual(oneSkillBlankInput.teams[0]?.heroes[1]);
     expect(model.requests[0]).toMatchObject({
-      reasoningEffort: 'high',
+      reasoningEffort: 'xhigh',
       maxCompletionTokens: 8192,
     });
     expect(model.requests[0]?.messages[1]?.content).toContain('兵刃伤害 versus 谋略伤害');

--- a/agent/tests/teamReviewSubgraph.test.ts
+++ b/agent/tests/teamReviewSubgraph.test.ts
@@ -56,7 +56,7 @@ describe('TeamReviewSubgraph', () => {
     });
     expect(input.teams).toEqual(completeReviewTeams);
     expect(model.requests[0]).toMatchObject({
-      reasoningEffort: 'high',
+      reasoningEffort: 'xhigh',
       maxCompletionTokens: 8192,
     });
   });

--- a/agent/tests/teamReviewSubgraph.test.ts
+++ b/agent/tests/teamReviewSubgraph.test.ts
@@ -57,7 +57,7 @@ describe('TeamReviewSubgraph', () => {
     expect(input.teams).toEqual(completeReviewTeams);
     expect(model.requests[0]).toMatchObject({
       reasoningEffort: 'xhigh',
-      maxCompletionTokens: 8192,
+      maxCompletionTokens: 32_768,
     });
   });
 


### PR DESCRIPTION
## Intent

Update the local TypeScript agent to call the OpenAI Responses-compatible /v1/responses endpoint recently added to the separately running ai-gateway-provider, instead of /v1/chat/completions. Keep the agent's existing internal ChatModel and HTTP consumer contracts while translating messages to input, reasoning effort to reasoning.effort, completion limits to max_output_tokens, extracting output_text and Responses usage/status, and disabling response storage. Default the agent and every recommendation/review stage to model gpt-5.6-sol with literal xhigh reasoning effort, allow enough timeout for buffered xhigh responses, update documentation and tests, and verify the checked-in agent fixtures against the live provider.

## What Changed
- Replace the chat-completions adapter with an OpenAI-compatible `/v1/responses` adapter that preserves existing ChatModel and HTTP contracts while translating inputs, reasoning effort, output limits, response text, status, usage, and provider errors, with storage disabled.
- Default recommendation and review stages to `xhigh` reasoning, apply configured reasoning to chat and smoke requests, and increase provider timeouts plus skill/review output budgets for buffered responses.
- Update configuration documentation and tests for the Responses adapter, including request mapping, incomplete responses, usage normalization, and failed-response error handling.

## Risk Assessment

✅ Low: The focused adapter migration preserves the internal ChatModel and HTTP contracts while correctly mapping Responses API requests, output, usage, statuses, provider errors, defaults, and timeout configuration.

## Testing

The scoped Agent checks completed successfully, and live end-to-end verification exercised the Responses provider through smoke, HTTP, and both checked-in fixture workflows; both fixtures now produced complete accepted reviews—including outputs above the former 8,192-token limit—and the partial workflow filled all stages while preserving existing values. This is a CLI/HTTP backend change with no rendered UI, so reviewer-visible evidence is provided as response and transcript artifacts rather than screenshots.

<details>
<summary>Evidence: Concise live verification summary</summary>

`Live smoke used gpt-5.6-sol; the complete fixture preserved its teams exactly and completed review in one attempt with 8,444 output tokens; the partial fixture completed hero, formation, skill, and review stages in one attempt each, preserved all prefilled values, and completed review with 10,388 output tokens.`

```text
{
  "providerSmoke": {
    "model": "gpt-5.6-sol",
    "content": "agent-smoke-ok",
    "usage": {
      "promptTokens": 14,
      "completionTokens": 8,
      "totalTokens": 22
    }
  },
  "completeFixture": {
    "status": "complete",
    "reviewStatus": "complete",
    "attempts": {
      "heroes": 0,
      "formations": 0,
      "skills": 0,
      "review": 1
    },
    "inputTeamsPreservedExactly": true,
    "reviewOutcome": "accepted",
    "reviewCompletionTokens": 8444,
    "reviewDurationMs": 119629
  },
  "partialFixture": {
    "status": "complete",
    "reviewStatus": "complete",
    "attempts": {
      "heroes": 1,
      "formations": 1,
      "skills": 1,
      "review": 1
    },
    "allLineupFieldsFilled": true,
    "allPrefilledLineupValuesPreserved": true,
    "heroAssignments": 6,
    "formationDecisions": 2,
    "skillAssignments": 13,
    "reviewOutcome": "accepted",
    "reviewCompletionTokens": 10388,
    "reviewDurationMs": 153530
  }
}
```
</details>
<details>
<summary>Evidence: Live Agent HTTP response</summary>

`HTTP/1.1 200 OK; gpt-5.6-sol returned exactly agent-http-ok with normalized Responses usage.`

```text
HTTP/1.1 200 OK
content-type: application/json; charset=utf-8
Date: Sat, 15 Aug 2026 03:56:17 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

{"id":"resp_03116b13725618e0016a7fe3609d8087d1b036da194a074831","model":"gpt-5.6-sol","content":"agent-http-ok","finishReason":"stop","usage":{"promptTokens":13,"completionTokens":7,"totalTokens":20}}
```
</details>
<details>
<summary>Evidence: Live complete-fixture recommendation and accepted review</summary>

```text
$ tsx src/cli.ts recommend fixtures/complete-teams.json
{"event":"team_review_attempt","attempt":1,"promptCharacters":12195,"promptBytes":16925,"durationMs":119629,"finishReason":"stop","usage":{"promptTokens":5142,"completionTokens":8444,"totalTokens":13586},"outcome":"accepted","validationErrors":[]}
{
  "teams": [
    {
      "formation": "雁形阵",
      "heroes": [
        {
          "hero": "司马懿",
          "row": "前排",
          "skills": [
            "未雨绸缪",
            "奇正相生"
          ]
        },
        {
          "hero": "郝昭",
          "row": "前排",
          "skills": [
            "岿然不动",
            "知人善任"
          ]
        },
        {
          "hero": "曹丕",
          "row": "前排",
          "skills": [
            "折冲御侮",
            "铸甲销戈"
          ]
        }
      ]
    },
    {
      "formation": "雁形阵",
      "heroes": [
        {
          "hero": "孙坚2",
          "row": "后排",
          "skills": [
            "伏兵四起",
            "势如破竹"
          ]
        },
        {
          "hero": "吕布",
          "row": "后排",
          "skills": [
            "千里突袭",
            "兵贵神速"
          ]
        },
        {
          "hero": "貂蝉",
          "row": "前排",
          "skills": [
            "调和阴阳",
            "忘私相助"
          ]
        }
      ]
    },
    {
      "formation": "方圆阵",
      "heroes": [
        {
          "hero": "关羽",
          "row": "后排",
          "skills": [
            "如有神助",
            "及锋而试"
          ]
        },
        {
          "hero": "马云禄",
          "row": "后排",
          "skills": [
            "无难之志",
            "揭竿而起"
          ]
        },
        {
          "hero": "魏延",
          "row": "前排",
          "skills": [
            "断敌粮道",
            "挫锐折锋"
          ]
        }
      ]
    }
  ],
  "status": "complete",
  "stoppedAt": null,
  "attempts": {
    "heroes": 0,
    "formations": 0,
    "skills": 0,
    "review": 1
  },
  "heroAssignments": [],
  "formationDecisions": [],
  "skillAssignments": [],
  "review": {
    "status": "complete",
    "verdict": "workable",
    "teams": [
      {
        "teamIndex": 0,
        "verdict": "workable",
        "strengths": [
          {
            "category": "camp",
            "message": "三名魏将激活10%阵营加成，基础属性收益稳定。",
            "evidence": [
              {
                "source": "campBonus",
                "id": "team:0"
              }
            ]
          },
          {
            "category": "sustain",
            "message": "千机重城与铸甲销戈持续供给抵御，抵御消耗又能触发岿然不动的统率叠加和低兵力治疗，防护循环完整。",
            "evidence": [
              {
                "source": "skill",
                "id": "千机重城"
              },
              {
                "source": "skill",
                "id": "铸甲销戈"
              },
              {
                "source": "skill",
                "id": "岿然不动"
              }
            ]
          },
          {
            "category": "skill_synergy",
            "message": "司马懿智力245为队内最高，知人善任可定向保护其输出；抵御消耗后的谋略增伤也契合其谋略定位。",
            "evidence": [
              {
                "source": "hero",
                "id": "司马懿"
              },
              {
                "source": "skill",
                "id": "知人善任"
              },
              {
                "source": "skill",
                "id": "千机重城"
              }
            ]
          },
          {
            "category": "learned_evidence",
            "message": "同三人同阵型存在S级已知队参考，且司马懿与郝昭、曹丕的组合特征均为正向，构成相对阵容强度佐证。",
            "evidence": [
              {
                "source": "knownTeam",
                "id": "yanwu-司马懿-郝昭-曹丕-671ea9aa28599d54"
              },
              {
                "source": "learnedFeature",
                "id": "HP|司马懿|郝昭"
              },
              {
                "source": "learnedFeature",
                "id": "HP|司马懿|曹丕"
              }
            ]
          }
        ],
        "warnings": [
          {
            "severity": "warning",
            "category": "formation",
            "message": "三人全部位于前排，虽均获得20点统率，但雁形阵的后排15%伤害提升完全未被利用。",
            "suggestedAction": "重点记录中后期输出是否不足，评估未利用后排增伤的实战代价。",
            "evidence": [
              {
                "source": "formation",
                "id": "雁形阵"
              }
            ]
          },
          {
            "severity": "warning",
            "category": "team_balance",
            "message": "主输出偏向司马懿的谋略链条，千机重城更偏低系数补伤；核心输出受压时击杀速度可能下降。",
            "suggestedAction": "重点观察司马懿被控制或压制回合中的全队伤害曲线。",
            "evidence": [
              {
                "source": "skill",
                "id": "鹰视狼顾"
              },
              {
                "source": "skill",
                "id": "未雨绸缪"
              },
              {
                "source": "skill",
                "id": "千机重城"
              }
            ]
          }
        ]
      },
      {
        "teamIndex": 1,
        "verdict": "workable",
        "strengths": [
          {
            "category": "camp",
            "message": "三名群将激活10%阵营加成，整体属性获得稳定提升。",
            "evidence": [
              {
                "source": "campBonus",
                "id": "team:1"
              }
            ]
          },
          {
            "category": "formation",
            "message": "孙坚2与吕布位于后排，可共同利用雁形阵15%伤害提升，主攻位与阵型增伤吻合。",
            "evidence": [
              {
                "source": "formation",
                "id": "雁形阵"
              },
              {
                "source": "hero",
                "id": "孙坚2"
              },
              {
                "source": "hero",
                "id": "吕布"
              }
            ]
          },
          {
            "category": "skill_synergy",
            "message": "骁勇无前提供额外普攻机会，可分别触发千里突袭与兵贵神速，形成普攻、追击和先攻成长联动。",
            "evidence": [
              {
                "source": "skill",
                "id": "骁勇无前"
              },
              {
                "source": "skill",
                "id": "千里突袭"
              },
              {
                "source": "skill",
                "id": "兵贵神速"
              }
            ]
          },
          {
            "category": "sustain",
            "message": "调和阴阳与忘私相助构成受击恢复，秋波送情再为缘分武将补充12%普通攻击减伤。",
            "evidence": [
              {
                "source": "skill",
                "id": "调和阴阳"
              },
              {
                "source": "skill",
                "id": "忘私相助"
              },
              {
                "source": "bond",
                "id": "秋波送情"
              }
            ]
          }
        ],
        "warnings": [
          {
            "severity": "warning",
            "category": "damage_type",
            "message": "主要伤害来源均为兵刃伤害，对高统率或兵刃减伤体系的适应面较窄。",
            "suggestedAction": "重点观察高统率、兵刃减伤对局中的伤害衰减和击杀回合。",
            "evidence": [
              {
                "source": "skill",
                "id": "诛凶殄逆"
              },
              {
                "source": "skill",
                "id": "骁勇无前"
              },
              {
                "source": "skill",
                "id": "闭月"
              }
            ]
          },
          {
            "severity": "warning",
            "category": "control",
            "message": "现有主攻战法以直接伤害、会心和追击为主，几乎不限制敌方行动。",
            "suggestedAction": "将敌方主动战法能否连续展开作为重点风险指标。",
            "evidence": [
              {
                "source": "skill",
                "id": "伏兵四起"
              },
              {
                "source": "skill",
                "id": "势如破竹"
              },
              {
                "source": "skill",
                "id": "兵贵神速"
              }
            ]
          }
        ]
      },
      {
        "teamIndex": 2,
        "verdict": "workable",
        "strengths": [
          {
            "category": "camp",
            "message": "三名蜀将激活10%阵营加成，基础属性收益稳定。",
            "evidence": [
              {
                "source": "campBonus",
                "id": "team:2"
              }
            ]
          },
          {
            "category": "formation",
            "message": "当前阵容同时布置前后排武将，符合方圆阵前后排协同、兼顾攻防的定位。",
            "evidence": [
              {
                "source": "formation",
                "id": "方圆阵"
              }
            ]
          },
          {
            "category": "skill_synergy",
            "message": "红妆缭乱施加畏惧后，可同时触发子午奇谋追加伤害，并提高威震华夏的发动率与控制目标收益。",
            "evidence": [
              {
                "source": "skill",
                "id": "红妆缭乱"
              },
              {
                "source": "skill",
                "id": "子午奇谋"
              },
              {
                "source": "skill",
                "id": "威震华夏"
              }
            ]
          },
          {
            "category": "damage_type",
            "message": "关羽、马云禄、魏延武力分别为244、214、238，核心兵刃输出与三人的属性方向一致。",
            "evidence": [
              {
                "source": "hero",
                "id": "关羽"
              },
              {
                "source": "hero",
                "id": "马云禄"
              },
              {
                "source": "hero",
                "id": "魏延"
              }
            ]
          }
        ],
        "warnings": [
          {
            "severity": "warning",
            "category": "skill_synergy",
            "message": "队内明确施加的状态主要是畏惧和断粮，并非属性降低，及锋而试的额外30%伤害系数缺少明确触发点。",
            "suggestedAction": "在战报中核对及锋而试的条件增伤是否实际触发。",
            "evidence": [
              {
                "source": "skill",
                "id": "及锋而试"
              },
              {
                "source": "skill",
                "id": "红妆缭乱"
              },
              {
                "source": "skill",
                "id": "断敌粮道"
              }
            ]
          },
          {
            "severity": "warning",
            "category": "sustain",
            "message": "配置没有直接治疗，主要依赖无难之志和狂骨提供倒戈，且狂骨需要流血逐步累积，持久战恢复稳定性有限。",
            "suggestedAction": "重点观察第四回合后的兵力维持和倒戈实际治疗量。",
            "evidence": [
              {
                "source": "skill",
                "id": "无难之志"
              },
              {
                "source": "skill",
                "id": "子午奇谋"
              }
            ]
          },
          {
            "severity": "warning",
            "category": "control",
            "message": "畏惧来源集中在红妆缭乱；其未触发时，子午奇谋追加与威震华夏的畏惧增益会同步放缓。",
            "suggestedAction": "重点记录前三回合畏惧覆盖率及联动空窗。",
            "evidence": [
              {
                "source": "skill",
                "id": "红妆缭乱"
              },
              {
                "source": "skill",
                "id": "子午奇谋"
              },
              {
                "source": "skill",
                "id": "威震华夏"
              }
            ]
          }
        ]
      }
    ],
    "crossTeamWarnings": [],
    "deterministicRuleWarnings": [],
    "attempts": 1,
    "warnings": []
  },
  "warnings": []
}
```
</details>
<details>
<summary>Evidence: Live partial-fixture completion and accepted review</summary>

```text
$ tsx src/cli.ts recommend fixtures/partial-teams.json
{"event":"team_review_attempt","attempt":1,"promptCharacters":12210,"promptBytes":16896,"durationMs":153530,"finishReason":"stop","usage":{"promptTokens":5144,"completionTokens":10388,"totalTokens":15532},"outcome":"accepted","validationErrors":[]}
{
  "teams": [
    {
      "formation": "雁形阵",
      "heroes": [
        {
          "hero": "司马懿",
          "row": "前排",
          "skills": [
            "未雨绸缪",
            "奇正相生"
          ]
        },
        {
          "hero": "郝昭",
          "row": "前排",
          "skills": [
            "岿然不动",
            "知人善任"
          ]
        },
        {
          "hero": "曹丕",
          "row": "前排",
          "skills": [
            "折冲御侮",
            "铸甲销戈"
          ]
        }
      ]
    },
    {
      "formation": "雁形阵",
      "heroes": [
        {
          "hero": "孙坚2",
          "row": "后排",
          "skills": [
            "伏兵四起",
            "挫锐折锋"
          ]
        },
        {
          "hero": "吕布",
          "row": "后排",
          "skills": [
            "及锋而试",
            "揭竿而起"
          ]
        },
        {
          "hero": "貂蝉",
          "row": "前排",
          "skills": [
            "断敌粮道",
            "忘私相助"
          ]
        }
      ]
    },
    {
      "formation": "钩行阵",
      "heroes": [
        {
          "hero": "马云禄",
          "row": "后排",
          "skills": [
            "兵贵神速",
            "千里突袭"
          ]
        },
        {
          "hero": "关羽",
          "row": "后排",
          "skills": [
            "如有神助",
            "势如破竹"
          ]
        },
        {
          "hero": "魏延",
          "row": "前排",
          "skills": [
            "无难之志",
            "连环计"
          ]
        }
      ]
    }
  ],
  "status": "complete",
  "stoppedAt": null,
  "attempts": {
    "heroes": 1,
    "formations": 1,
    "skills": 1,
    "review": 1
  },
  "heroAssignments": [
    {
      "teamIndex": 1,
      "slotIndex": 0,
      "hero": "孙坚2",
      "reason": "与吕布、貂蝉组成三群阵容获得10%全属性，并提供高频群体兵刃伤害与叠层增伤。",
      "evidence": [
        "诛凶殄逆发动率65%，攻击统率最低两人并可叠加凶逆增伤",
        "learnedEvidence权重0.377667，支持数255，为候选中最高"
      ]
    },
    {
      "teamIndex": 1,
      "slotIndex": 1,
      "hero": "吕布",
      "reason": "三群阵容获得10%全属性；全队武力最高，可稳定承接貂蝉的兵刃增伤。",
      "evidence": [
        "吕布武力260，为该队最高",
        "闭月每回合使友军武力最高单体兵刃伤害提升15%",
        "骁勇无前可与敌军全体互相普攻，武力更高时追加100%兵刃伤害"
      ]
    },
    {
      "teamIndex": 1,
      "slotIndex": 2,
      "hero": "貂蝉",
      "reason": "补齐三群10%全属性，并持续强化吕布，兼具对异性减伤和反击能力。",
      "evidence": [
        "闭月每回合强化友军武力最高单体15%兵刃伤害",
        "貂蝉受到异性伤害降低25%",
        "孙坚2、吕布、貂蝉均属群阵营"
      ]
    },
    {
      "teamIndex": 2,
      "slotIndex": 0,
      "hero": "马云禄",
      "reason": "与关羽、魏延组成三蜀阵容获得10%全属性，其高概率畏惧可同时启动两名队友的核心机制。",
      "evidence": [
        "红妆缭乱发动率70%，普攻后施加持续2回合的畏惧",
        "畏惧后造成220%兵刃伤害，并有80%概率再造成220%伤害"
      ]
    },
    {
      "teamIndex": 2,
      "slotIndex": 1,
      "hero": "关羽",
      "reason": "三蜀阵容获得10%全属性，并直接利用马云禄施加的畏惧提升主动战法发动率与输出。",
      "evidence": [
        "威震华夏每有一个带畏惧的敌军额外提升3%发动率",
        "威震华夏对敌军全体造成160%兵刃伤害，目标有控制时可产生逃兵"
      ]
    },
    {
      "teamIndex": 2,
      "slotIndex": 2,
      "hero": "魏延",
      "reason": "补齐三蜀10%全属性，并在马云禄施加畏惧时追加伤害、流血与狂骨成长。",
      "evidence": [
        "我军施加畏惧时，子午奇谋对目标追加60%兵刃伤害",
        "追加攻击有30%概率施加流血，流血可叠加狂骨并触发集中结算",
        "马云禄、关羽、魏延均属蜀阵营"
      ]
    }
  ],
  "formationDecisions": [
    {
      "teamIndex": 1,
      "formation": "雁形阵",
      "rows": [
        {
          "slotIndex": 0,
          "row": "后排"
        },
        {
          "slotIndex": 1,
          "row": "后排"
        },
        {
          "slotIndex": 2,
          "row": "前排"
        }
      ],
      "reason": "貂蝉凭异性减伤和受击反击担当前排并获得统率提升；孙坚2、吕布置于后排获得15%增伤，同时规避吕布统率仅70的耐久短板。",
      "evidence": [
        "雁形阵使前排统率提升20点、后排造成伤害提升15%",
        "貂蝉受到异性伤害降低25%，且会反击本回合伤害过她的目标",
        "孙坚2和吕布武力分别为224、260，均以兵刃伤害为主",
        "孙坚2在learnedEvidence中的相对权重为0.377667，support为255"
      ]
    },
    {
      "teamIndex": 2,
      "formation": "钩行阵",
      "rows": [
        {
          "slotIndex": 0,
          "row": "后排"
        },
        {
          "slotIndex": 1,
          "row": "后排"
        },
        {
          "slotIndex": 2,
          "row": "前排"
        }
      ],
      "reason": "魏延统率最高且可通过狂骨获得倒戈，置前排享受8%减伤；马云禄置后排利用25%连击提升普攻后追击与畏惧施加频次，进而联动关羽和魏延。",
      "evidence": [
        "钩行阵使前排受到伤害降低8%、后排连击率提升25%",
        "魏延统率165，为三人最高，狂骨可叠加提供倒戈",
        "马云禄的红妆缭乱在普通攻击后施加畏惧并造成兵刃伤害",
        "关羽会依据敌军畏惧数量提升主动战法发动率，魏延会在我军施加畏惧时追加伤害"
      ]
    }
  ],
  "skillAssignments": [
    {
      "teamIndex": 0,
      "slotIndex": 1,
      "skillSlotIndex": 1,
      "skill": "知人善任",
      "reason": "以郝昭的智力定向保护司马懿并补充抵御，强化全前排阵容的核心生存。",
      "evidence": [
        "司马懿智力245，为本队智力最高单体",
        "郝昭智力188、统率206，且雁形阵使前排统率提升20点",
        "HS|郝昭|知人善任权重0.658557（support 14）；S|知人善任权重-0.006663（support 663）"
      ]
    },
    {
      "teamIndex": 1,
      "slotIndex": 0,
      "skillSlotIndex": 0,
      "skill": "伏兵四起",
      "reason": "孙坚2以高武力和后排增伤打出四段兵刃伤害，可反复兑现凶逆的受伤提升。",
      "evidence": [
        "孙坚2武力224，雁形阵使后排伤害提升15%",
        "诛凶殄逆可令目标受到伤害提升，伏兵四起可连续施放4次伤害",
        "HS|孙坚2|伏兵四起权重0.429418（support 19）；S|伏兵四起权重-0.511901（support 226）"
      ]
    },
    {
      "teamIndex": 1,
      "slotIndex": 0,
      "skillSlotIndex": 1,
      "skill": "挫锐折锋",
      "reason": "由本队统率最高的孙坚2承担前三回合减伤，保护唯一前排貂蝉并平衡双核输出队的生存。",
      "evidence": [
        "孙坚2统率206，为本队最高，适合承载受统率影响的减伤",
        "貂蝉是本队唯一前排，孙坚2与吕布均为后排输出核心",
        "秋波送情已提供缘分武将12%普攻减伤；S|挫锐折锋权重0.242373（support 483）"
      ]
    },
    {
      "teamIndex": 1,
      "slotIndex": 1,
      "skillSlotIndex": 0,
      "skill": "及锋而试",
 

... [9072 bytes truncated] ...

将提供普攻减伤。",
            "evidence": [
              {
                "source": "campBonus",
                "id": "team:1"
              },
              {
                "source": "bond",
                "id": "秋波送情"
              }
            ]
          },
          {
            "category": "position",
            "message": "孙坚2与吕布均为高武力兵刃核心，置于后排可完整获得雁形阵15%伤害提升。",
            "evidence": [
              {
                "source": "formation",
                "id": "雁形阵"
              },
              {
                "source": "hero",
                "id": "孙坚2"
              },
              {
                "source": "hero",
                "id": "吕布"
              }
            ]
          },
          {
            "category": "skill_synergy",
            "message": "闭月会强化友军武力最高者；吕布武力260为队内最高，可稳定获得兵刃增伤。",
            "evidence": [
              {
                "source": "skill",
                "id": "闭月"
              },
              {
                "source": "hero",
                "id": "吕布"
              },
              {
                "source": "skill",
                "id": "骁勇无前"
              }
            ]
          },
          {
            "category": "control",
            "message": "断敌粮道提供持续断粮，揭竿而起可进一步扩大断粮覆盖，能够持续压制敌方恢复。",
            "evidence": [
              {
                "source": "skill",
                "id": "断敌粮道"
              },
              {
                "source": "skill",
                "id": "揭竿而起"
              }
            ]
          }
        ],
        "warnings": [
          {
            "severity": "warning",
            "category": "skill_synergy",
            "message": "及锋而试的额外伤害要求目标存在属性降低；诛凶的受伤提升和断粮均不属于属性降低，条件难以触发。",
            "suggestedAction": "评估吕布伤害时按未触发额外30%系数计算，并核对实战触发记录。",
            "evidence": [
              {
                "source": "skill",
                "id": "及锋而试"
              },
              {
                "source": "skill",
                "id": "诛凶殄逆"
              },
              {
                "source": "skill",
                "id": "断敌粮道"
              }
            ]
          },
          {
            "severity": "warning",
            "category": "sustain",
            "message": "明确治疗主要依赖忘私相助在貂蝉受击前以50%概率触发，且只恢复两名队友，续航存在波动。",
            "suggestedAction": "重点观察貂蝉自身血线及忘私相助触发次数，按波动续航预期评估持久战。",
            "evidence": [
              {
                "source": "skill",
                "id": "忘私相助"
              },
              {
                "source": "hero",
                "id": "貂蝉"
              }
            ]
          },
          {
            "severity": "warning",
            "category": "team_balance",
            "message": "多项核心兵刃输出依赖40%至65%概率的主动战法，连续未发动时后排增伤利用率会明显下降。",
            "suggestedAction": "使用多场平均值评估输出稳定性，不以单场连续发动作为基准。",
            "evidence": [
              {
                "source": "skill",
                "id": "诛凶殄逆"
              },
              {
                "source": "skill",
                "id": "伏兵四起"
              },
              {
                "source": "skill",
                "id": "骁勇无前"
              }
            ]
          }
        ]
      },
      {
        "teamIndex": 2,
        "verdict": "workable",
        "strengths": [
          {
            "category": "camp",
            "message": "三名武将均属蜀，已获得10%阵营加成。",
            "evidence": [
              {
                "source": "campBonus",
                "id": "team:2"
              }
            ]
          },
          {
            "category": "formation",
            "message": "钩行阵为后排提供25%连击，能增加马云禄普攻及红妆缭乱的触发窗口；无难之志还能继续补充连击与倒戈。",
            "evidence": [
              {
                "source": "formation",
                "id": "钩行阵"
              },
              {
                "source": "skill",
                "id": "红妆缭乱"
              },
              {
                "source": "skill",
                "id": "无难之志"
              }
            ]
          },
          {
            "category": "skill_synergy",
            "message": "红妆缭乱施加畏惧后，可触发子午奇谋追加兵刃伤害与流血，并提高威震华夏的发动率和逃兵收益。",
            "evidence": [
              {
                "source": "skill",
                "id": "红妆缭乱"
              },
              {
                "source": "skill",
                "id": "子午奇谋"
              },
              {
                "source": "skill",
                "id": "威震华夏"
              }
            ]
          },
          {
            "category": "skill_synergy",
            "message": "如有神助同时提高主动战法发动率和伤害，直接覆盖关羽的威震华夏与势如破竹。",
            "evidence": [
              {
                "source": "skill",
                "id": "如有神助"
              },
              {
                "source": "skill",
                "id": "威震华夏"
              },
              {
                "source": "skill",
                "id": "势如破竹"
              }
            ]
          }
        ],
        "warnings": [
          {
            "severity": "warning",
            "category": "damage_type",
            "message": "主要伤害链几乎全部为兵刃伤害，面对高统率或兵刃减伤阵容时缺少谋略侧牵制。",
            "suggestedAction": "对高统率目标重点记录有效伤害衰减，按单一兵刃伤害面评估表现。",
            "evidence": [
              {
                "source": "skill",
                "id": "红妆缭乱"
              },
              {
                "source": "skill",
                "id": "威震华夏"
              },
              {
                "source": "skill",
                "id": "子午奇谋"
              }
            ]
          },
          {
            "severity": "warning",
            "category": "sustain",
            "message": "前排魏延的倒戈需要通过畏惧、流血逐步叠加狂骨，启动前主要依靠钩行阵8%减伤承压。",
            "suggestedAction": "重点观察前两回合魏延血线与狂骨启动速度。",
            "evidence": [
              {
                "source": "formation",
                "id": "钩行阵"
              },
              {
                "source": "skill",
                "id": "子午奇谋"
              },
              {
                "source": "hero",
                "id": "魏延"
              }
            ]
          },
          {
            "severity": "warning",
            "category": "skill_synergy",
            "message": "魏延智力165，而连环计的看破和传递比例受智力影响，与其高武力兵刃主轴匹配度有限。",
            "suggestedAction": "按实战传递比例评估连环计贡献，避免高估其智力加成效果。",
            "evidence": [
              {
                "source": "hero",
                "id": "魏延"
              },
              {
                "source": "skill",
                "id": "连环计"
              }
            ]
          }
        ]
      }
    ],
    "crossTeamWarnings": [],
    "deterministicRuleWarnings": [],
    "attempts": 1,
    "warnings": []
  },
  "warnings": []
}
```
</details>
<details>
<summary>Evidence: Live Responses provider smoke result</summary>

```text
$ tsx src/cli.ts smoke
{
  "model": "gpt-5.6-sol",
  "content": "agent-smoke-ok",
  "usage": {
    "promptTokens": 14,
    "completionTokens": 8,
    "totalTokens": 22
  }
}
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (1h2m50s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `agent/src/openAiCompatibleResponsesModel.ts:184` - For an HTTP-200 Responses object with status `failed`, the provider cause is normally available in `error.message`, but the schema discards that field and this branch returns only `Model provider returned response status failed`. This hides actionable failures from CLI/HTTP consumers and can make recommendation stages retry a permanent failure three times. Parse the optional response error and preserve its message while retaining the raw body in details.

🔧 Fix: Preserve provider errors from failed Responses
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `agent/src/team/teamReviewSubgraph.ts:376` - The documented live fixture workflows are not reliable with the required gpt-5.6-sol/xhigh defaults. The complete fixture exhausted all three review attempts: two returned no text and one reached max_output_tokens after exactly 8,192 output tokens. The partial-fixture retry completed hero, formation, and skill stages, but its review again reached the 8,192-token limit twice and then timed out. Both results therefore returned review.status &#34;unavailable&#34;. Increase or otherwise manage the review output budget and buffered-request timeout/retry behavior, then verify both fixtures again.
- `cd agent && pnpm test`
- `cd agent && AI_BASE_URL=http://127.0.0.1:8787/v1 AI_MODEL=gpt-5.6-sol SANMOU_REASONING_EFFORT=xhigh AI_TIMEOUT_MS=270000 pnpm smoke`
- <code>`cd agent &amp;&amp; SANMOU_AGENT_PORT=18790 AI_BASE_URL=http://127.0.0.1:8787/v1 AI_MODEL=gpt-5.6-sol SANMOU_REASONING_EFFORT=xhigh AI_TIMEOUT_MS=270000 pnpm start`, followed by a live `POST http://127.0.0.1:18790/v1/chat` request omitting reasoningEffort to exercise the configured default</code>
- `cd agent && AI_BASE_URL=http://127.0.0.1:8787/v1 AI_MODEL=gpt-5.6-sol SANMOU_REASONING_EFFORT=xhigh AI_TIMEOUT_MS=270000 pnpm --silent recommend fixtures/complete-teams.json`
- `cd agent && AI_BASE_URL=http://127.0.0.1:8787/v1 AI_MODEL=gpt-5.6-sol SANMOU_REASONING_EFFORT=xhigh AI_TIMEOUT_MS=270000 pnpm --silent recommend fixtures/partial-teams.json`
- <code>Retried `pnpm --silent recommend fixtures/partial-teams.json` with the same live configuration after a 60-second cooldown following the first attempt&#39;s HTTP 429</code>

🔧 Fix: Increase xhigh response budgets and timeout
✅ Re-checked - no issues remain.
- `cd agent && pnpm typecheck && pnpm test && pnpm build`
- <code>`cd agent &amp;&amp; pnpm smoke` against the live Responses provider</code>
- <code>`cd agent &amp;&amp; pnpm recommend fixtures/complete-teams.json` against the live provider</code>
- <code>`cd agent &amp;&amp; pnpm recommend fixtures/partial-teams.json` against the live provider</code>
- <code>Started the Agent with `cd agent &amp;&amp; pnpm start`, then sent a real `POST /v1/chat` request without an explicit reasoning effort and verified an HTTP 200 response from `gpt-5.6-sol`</code>
- <code>Parsed the live transcripts with `python3` and asserted complete status, accepted reviews, exact preservation of the complete fixture, preservation of all prefilled partial-fixture values, and completion of every blank</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
