### PR TITLE
fix(web): apply guide-first team builder recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,13 @@ in the browser:
   gates. A skill must independently clear both its atomic skill (`S`) and
   hero-skill (`HS`) gates.
   Supported within-hero skill-pair (`SP`) evidence, including negative weights,
-  ranks qualified choices without vetoing the pairing. Owned guide skills keep
-  their canonical slots only after passing the same gates. Unsupported
-  heroes and skills stay in the warehouse for manual placement instead of being
-  forced into a complete 9-hero/18-skill result.
+  ranks qualified model-only choices without vetoing the pairing. For a
+  qualified 2/3 or 3/3 known-team core, owned guide skills assigned to the
+  present guide heroes are globally reserved in their canonical slots before
+  model-only fallback, but only after each route passes the same `S` and `HS`
+  gates; an absent guide hero is never inserted and makes no skill claim.
+  Unsupported heroes and skills stay in the warehouse for manual placement
+  instead of being forced into a complete 9-hero/18-skill result.
   The deterministic search runs in a client Web Worker, with a yielding
   main-thread fallback and an in-memory result cache, so it adds no Cloudflare
   Function usage and keeps the loading UI responsive. Players can then drag,

--- a/README.md
+++ b/README.md
@@ -116,8 +116,14 @@ in the browser:
   present guide heroes are globally reserved in their canonical slots before
   model-only fallback, but only after each route passes the same `S` and `HS`
   gates; an absent guide hero is never inserted and makes no skill claim.
-  Unsupported heroes and skills stay in the warehouse for manual placement
-  instead of being forced into a complete 9-hero/18-skill result.
+  Global conflict resolution keeps each skill unique, prefers exact 3/3 cores
+  over partial 2/3 cores, and orders each guide slot's qualified alternatives
+  by model weight then support. The hero-group search retains
+  every evidence-qualified trio in the at-most-15-hero pool (at most 455)
+  before maximizing the number of disjoint complete teams; it applies no
+  gain-ranked candidate cutoff. Unsupported heroes and skills stay in the
+  warehouse for manual placement instead of being forced into a complete
+  9-hero/18-skill result.
   The deterministic search runs in a client Web Worker, with a yielding
   main-thread fallback and an in-memory result cache, so it adds no Cloudflare
   Function usage and keeps the loading UI responsive. Players can then drag,

--- a/web/README.md
+++ b/web/README.md
@@ -24,20 +24,12 @@ the model data is generated and community reports are imported.
   team library, five championship groups, 13×13 matchup explorer, and workbook
   analysis. This full guide is the sole UI location for the 飞将吕布 attribution.
 - **Manual Editing**: Edit team composition manually at any time
-- **Team Builder**: Start from one evidence-only three-team
-  recommendation. Every placed hero must independently pass its `H` gate and
-  every relationship in its pair/trio must pass `HP`; every skill must pass both
-  `S` and `HS`. Each gate needs the fitted support floor (5 battles for atomic
-  hero/skill features, 8 for pair features). Positive, zero, and negative
-  fitted weights remain eligible and affect ranking; displayed evidence keeps a
-  +0.1 visibility floor so non-positive and tiny gains are not shown as positive
-  explanations. Supported `SP`, including negative weights, ranks
-  otherwise-qualified skills without vetoing the pair. A
-  qualified two- or three-hero guide core keeps
-  its formation and canonical slots, including gaps, but guide data never
-  bypasses these gates. Unsupported positions stay blank. The deterministic
-  search runs in a client Web Worker (with a cooperative fallback and memory
-  cache), keeping the loading screen responsive without consuming Cloudflare
+- **Team Builder**: Start from one three-team recommendation under the
+  authoritative evidence, guide-priority, and complete-group-search policy in
+  the root [Recommendation pipeline](../README.md#recommendation-pipeline).
+  Unsupported positions stay blank. The deterministic search runs in a client
+  Web Worker with a cooperative fallback and in-memory cache, keeping the
+  loading screen responsive without consuming Cloudflare
   Function quota. Players can then rearrange heroes and tactics with pointer,
   touch, keyboard, or tap-to-place controls, and copy an exact-lineup validation
   prompt backed by the public game database and formula reference
@@ -181,12 +173,8 @@ The draft has ten rounds. A one-click win gate controls progression from Round
 6 to 7 and Round 8 to 9. The existing support pick remains optional after Round
 6, and any support selections carry through the later rounds. A completed
 supported draft can therefore contain up to 15 heroes and 28 skills. Team
-Builder recommendations consider that full pool with an evidence-only policy.
-Each hero and skill must pass its own atomic and relationship gates at the
-model's configured support floor; every fitted weight remains eligible and
-affects ranking regardless of sign.
-A qualified two- or three-hero `database.json` core keeps its formation and
-canonical slots, while unsupported hero and skill positions remain blank.
+Builder recommendations consider that full pool under the authoritative policy
+in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
 
 - **GameBoard**: Main game container managing the draft rounds
 - **RoundInfo**: Display current round information with stepper
@@ -200,10 +188,10 @@ canonical slots, while unsupported hero and skill positions remain blank.
   highlights the highest as 玩家选择最高 (independently from the AI 推荐 card), and — only when the
   two tops differ by a meaningful margin — shows a short non-causal A/B/C disagreement note
 - **FormationWorkbench**: The `/team-builder` page's light, game-layout-inspired
-  three-team editor. It seeds the evidence-only recommendation,
-  leaves unsupported positions blank, keeps live per-team model scores, uses
-  matched formations and canonical slots from qualified `database.json` cores,
-  and supports drag/drop plus tap-to-place on mobile.
+  three-team editor. It seeds the recommendation documented in the root
+  [Recommendation pipeline](../README.md#recommendation-pipeline), leaves
+  unsupported positions blank, keeps live per-team model scores, and supports
+  drag/drop plus tap-to-place on mobile.
 - **KnownStrongTeams**: Filters the imported strong/championship library against
   the acquired pool and the current offers. Hero rounds keep cards concise and
   collapse same-roster build variants (whose skill differences are hidden) into a

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -1039,6 +1039,8 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
         'HS|h0|s0': 10,
         'S|s1': 0.2,
         'HS|h0|s1': 0.3,
+        'S|s2': 10,
+        'HS|h0|s2': 10,
       },
       support: {
         'H|h0': 10,
@@ -1048,14 +1050,16 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
         'HS|h0|s0': 16,
         'S|s1': 10,
         'HS|h0|s1': 16,
+        'S|s2': 10,
+        'HS|h0|s2': 7,
       },
-      n_features: 7,
+      n_features: 9,
     });
     const partial = makeTeamComp(
       'partial-guide-gated',
       ['h0', 'missing-guide-hero', 'h2'],
       [
-        [['s0'], ['missing-0']],
+        [['s0'], ['s2']],
         [['missing-1'], ['missing-2']],
         [['missing-3'], ['missing-4']],
       ]
@@ -1074,7 +1078,57 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
     );
 
     expect(h0?.skills).not.toContain('s0');
+    expect(h0?.skills).not.toContain('s2');
     expect(h0?.skills).toContain('s1');
+  });
+
+  test('an absent guide hero neither appears nor reserves an otherwise qualified owned skill', () => {
+    const data = makeData({
+      weights: {
+        'H|h0': 0.4,
+        'H|h2': 0.3,
+        'HP|h0|h2': 0.5,
+        'S|s0': 10,
+        'HS|missing-guide-hero|s0': 10,
+        'S|s1': 0.2,
+        'HS|h0|s1': 0.3,
+      },
+      support: {
+        'H|h0': 10,
+        'H|h2': 10,
+        'HP|h0|h2': 16,
+        'S|s0': 10,
+        'HS|missing-guide-hero|s0': 16,
+        'S|s1': 10,
+        'HS|h0|s1': 16,
+      },
+      n_features: 7,
+    });
+    const partial = makeTeamComp(
+      'absent-guide-hero',
+      ['h0', 'missing-guide-hero', 'h2'],
+      [
+        [['missing-0'], ['missing-1']],
+        [['s0'], ['missing-2']],
+        [['missing-3'], ['missing-4']],
+      ]
+    );
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      [partial]
+    );
+    const placed = result.options[0].teams.flatMap(({ heroes: teamHeroes }) =>
+      teamHeroes
+    );
+
+    expect(placed.map(({ name }) => name)).not.toContain('missing-guide-hero');
+    expect(placed.flatMap(({ skills: assignedSkills }) => assignedSkills)).not.toContain('s0');
+    expect(placed.find(({ name }) => name === 'h0')?.skills).toContain('s1');
   });
 
   test('gives an exact guide core priority over a partial core for a shared skill', () => {
@@ -1412,6 +1466,52 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
       }
     }
   });
+
+  test('searches qualified trios beyond the former 320-candidate cutoff', () => {
+    const largeHeroes = Array.from({ length: 15 }, (_, index) =>
+      `h${index.toString().padStart(2, '0')}`
+    );
+    const largeSkills = Array.from({ length: 18 }, (_, index) => `s${index}`);
+    const weights: Record<string, number> = {};
+    const support: Record<string, number> = {};
+    for (const [index, hero] of largeHeroes.entries()) {
+      weights[`H|${hero}`] = index < 6 ? 1 : 0;
+      support[`H|${hero}`] = 10;
+    }
+    for (let first = 0; first < largeHeroes.length; first += 1) {
+      for (let second = first + 1; second < largeHeroes.length; second += 1) {
+        const key = `HP|${largeHeroes[first]}|${largeHeroes[second]}`;
+        const samePreferredTrio =
+          (first < 3 && second < 3) ||
+          (first >= 3 && first < 6 && second < 6);
+        weights[key] = samePreferredTrio ? 100 : 0;
+        support[key] = 16;
+      }
+    }
+    const data = makeData({
+      weights,
+      support,
+      n_features: Object.keys(weights).length,
+    });
+
+    const result = recommendHybridTeams(
+      largeHeroes,
+      largeSkills,
+      data,
+      data.catalog,
+      {},
+      []
+    );
+    const selectedTrios = result.options[0].teams
+      .map(({ heroes: teamHeroes }) => teamHeroes.map(({ name }) => name).sort())
+      .sort((left, right) => left.join('|').localeCompare(right.join('|')));
+
+    expect(selectedTrios).toEqual([
+      ['h00', 'h01', 'h02'],
+      ['h03', 'h04', 'h05'],
+      ['h06', 'h07', 'h08'],
+    ]);
+  }, 20_000);
 
   test('cooperative fallback returns the same deterministic result', async () => {
     const data = makeData();

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -970,6 +970,182 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
     expect(matched.heroes[1].skillSlots).toEqual(['s4', null]);
   });
 
+  test('reserves qualified guide skills for a partial core before a stronger model pair', () => {
+    const data = makeData({
+      weights: {
+        'H|h0': 0.4,
+        'H|h2': 0.3,
+        'HP|h0|h2': 0.5,
+        'S|s0': 0.1,
+        'HS|h0|s0': 0.1,
+        'S|s1': 0.1,
+        'HS|h0|s1': 0.1,
+        'S|s2': 0.5,
+        'HS|h0|s2': 0.5,
+        'S|s3': 0.5,
+        'HS|h0|s3': 0.5,
+        'SP|h0|s2|s3': 1,
+      },
+      support: {
+        'H|h0': 10,
+        'H|h2': 10,
+        'HP|h0|h2': 16,
+        'S|s0': 10,
+        'HS|h0|s0': 16,
+        'S|s1': 10,
+        'HS|h0|s1': 16,
+        'S|s2': 10,
+        'HS|h0|s2': 16,
+        'S|s3': 10,
+        'HS|h0|s3': 16,
+        'SP|h0|s2|s3': 8,
+      },
+      n_features: 12,
+    });
+    const partial = makeTeamComp(
+      'partial-guide-first',
+      ['h0', 'missing-guide-hero', 'h2'],
+      [
+        [['s0'], ['s1']],
+        [['missing-0'], ['missing-1']],
+        [['missing-2'], ['missing-3']],
+      ]
+    );
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      [partial]
+    );
+    const h0 = result.options[0].teams[0].heroes.find(
+      ({ name }) => name === 'h0'
+    );
+
+    expect(h0?.skillSlots).toEqual(['s0', 's1']);
+    expect(h0?.skills).not.toContain('s2');
+    expect(h0?.skills).not.toContain('s3');
+  });
+
+  test('does not reserve a partial-guide skill that fails S or HS support', () => {
+    const data = makeData({
+      weights: {
+        'H|h0': 0.4,
+        'H|h2': 0.3,
+        'HP|h0|h2': 0.5,
+        'S|s0': 10,
+        'HS|h0|s0': 10,
+        'S|s1': 0.2,
+        'HS|h0|s1': 0.3,
+      },
+      support: {
+        'H|h0': 10,
+        'H|h2': 10,
+        'HP|h0|h2': 16,
+        'S|s0': 4,
+        'HS|h0|s0': 16,
+        'S|s1': 10,
+        'HS|h0|s1': 16,
+      },
+      n_features: 7,
+    });
+    const partial = makeTeamComp(
+      'partial-guide-gated',
+      ['h0', 'missing-guide-hero', 'h2'],
+      [
+        [['s0'], ['missing-0']],
+        [['missing-1'], ['missing-2']],
+        [['missing-3'], ['missing-4']],
+      ]
+    );
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      [partial]
+    );
+    const h0 = result.options[0].teams[0].heroes.find(
+      ({ name }) => name === 'h0'
+    );
+
+    expect(h0?.skills).not.toContain('s0');
+    expect(h0?.skills).toContain('s1');
+  });
+
+  test('gives an exact guide core priority over a partial core for a shared skill', () => {
+    const data = makeData({
+      weights: {
+        'H|h0': 0.2,
+        'H|h1': 0.2,
+        'H|h2': 0.2,
+        'HP|h0|h1': 0.2,
+        'HP|h0|h2': 0.2,
+        'HP|h1|h2': 0.2,
+        'H|h3': 0.2,
+        'H|h4': 0.2,
+        'H|h5': 0.2,
+        'HP|h3|h4': 0.2,
+        'HP|h3|h5': 0.2,
+        'HP|h4|h5': 0.2,
+        'S|s0': 0.2,
+        'HS|h0|s0': 0.2,
+        'HS|h3|s0': 10,
+      },
+      support: {
+        'H|h0': 10,
+        'H|h1': 10,
+        'H|h2': 10,
+        'HP|h0|h1': 16,
+        'HP|h0|h2': 16,
+        'HP|h1|h2': 16,
+        'H|h3': 10,
+        'H|h4': 10,
+        'H|h5': 10,
+        'HP|h3|h4': 16,
+        'HP|h3|h5': 16,
+        'HP|h4|h5': 16,
+        'S|s0': 10,
+        'HS|h0|s0': 16,
+        'HS|h3|s0': 16,
+      },
+      n_features: 15,
+    });
+    const exact = makeTeamComp('exact-shared', ['h0', 'h1', 'h2'], [
+      [['s0'], ['missing-0']],
+      [['missing-1'], ['missing-2']],
+      [['missing-3'], ['missing-4']],
+    ]);
+    const partial = makeTeamComp(
+      'partial-shared',
+      ['h3', 'h4', 'missing-guide-hero'],
+      [
+        [['s0'], ['missing-5']],
+        [['missing-6'], ['missing-7']],
+        [['missing-8'], ['missing-9']],
+      ]
+    );
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      [partial, exact]
+    );
+    const placed = result.options[0].teams.flatMap(({ heroes: teamHeroes }) =>
+      teamHeroes
+    );
+
+    expect(placed.find(({ name }) => name === 'h0')?.skills).toContain('s0');
+    expect(placed.find(({ name }) => name === 'h3')?.skills).not.toContain('s0');
+  });
+
   test('shows all three canonical slots when the complete guide trio is confident', () => {
     const data = makeData({
       weights: {
@@ -1143,7 +1319,7 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
     expect(result.options[0].teams.every(({ heroes }) => heroes.length === 0)).toBe(true);
   });
 
-  test('requires both S and HS support and uses negative SP as a ranking penalty', () => {
+  test('requires both S and HS support and uses model gain among guide alternatives', () => {
     const data = makeData({
       weights: {
         'H|h0': 0.4,

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -691,9 +691,6 @@ export const TEAM_BUILDER_SUPPORT_MULTIPLIER = 1;
 /** Smallest contribution shown as positive evidence in the player-facing scale. */
 export const TEAM_BUILDER_VISIBLE_DISPLAY_GAIN = 0.1;
 
-/** Hard bound on confidence-gated hero groups considered by the partial policy. */
-export const TEAM_BUILDER_GROUP_CANDIDATE_CAP = 320;
-
 /** Maximum hero pool supported by the ten-round draft contract. */
 const FORMATION_HERO_POOL_CAP = 15;
 
@@ -821,9 +818,10 @@ function maximumKnownSlotMatching(
     return false;
   };
 
-  // Process lower-priority slots first. Later (higher-priority) slots may
-  // displace them through the augmenting path while preserving max cardinality.
-  for (const slot of [...slots].reverse()) {
+  // Process higher-priority slots first. A later slot can take an occupied
+  // skill only when the earlier owner can move to an alternative, preserving
+  // both maximum cardinality and the priority of a sole contested claim.
+  for (const slot of slots) {
     assign(slot.key, new Set(), new Set());
   }
   return slotSkill;
@@ -2453,15 +2451,16 @@ function confidentHeroGroups(
       ),
     });
   }
-  return groups
-    .sort((left, right) =>
-      right.gain !== left.gain
-        ? right.gain - left.gain
-        : right.support !== left.support
-          ? right.support - left.support
-          : left.key.localeCompare(right.key)
-    )
-    .slice(0, TEAM_BUILDER_GROUP_CANDIDATE_CAP);
+  // The game contract caps the pool at 15 heroes (455 possible trios), so keep
+  // every qualified group. Truncating by gain here can discard the low-ranked
+  // disjoint trio needed to place the maximum number of complete teams.
+  return groups.sort((left, right) =>
+    right.gain !== left.gain
+      ? right.gain - left.gain
+      : right.support !== left.support
+        ? right.support - left.support
+        : left.key.localeCompare(right.key)
+  );
 }
 
 interface ConservativeGuideMatch {
@@ -2571,6 +2570,91 @@ function placeConservativeTeamHeroes(
 
 type ConservativeSkillSlots = [string | null, string | null];
 
+interface ConservativeGuideSkillSlot extends KnownSkillSlot {
+  matchedHeroCount: number;
+  potentialSkillSlots: number;
+  championship: boolean;
+  rankingScore: number;
+}
+
+function compareConservativeGuideSkillSlots(
+  left: ConservativeGuideSkillSlot,
+  right: ConservativeGuideSkillSlot
+): number {
+  if (left.matchedHeroCount !== right.matchedHeroCount)
+    return right.matchedHeroCount - left.matchedHeroCount;
+  if (left.potentialSkillSlots !== right.potentialSkillSlots)
+    return right.potentialSkillSlots - left.potentialSkillSlots;
+  if (left.championship !== right.championship)
+    return Number(right.championship) - Number(left.championship);
+  if (left.rankingScore !== right.rankingScore)
+    return right.rankingScore - left.rankingScore;
+  return left.key.localeCompare(right.key);
+}
+
+/**
+ * Build guide claims only for heroes actually present in a qualified 2/3 or
+ * 3/3 core. Every alternative still has to clear its atomic S and hero-skill
+ * HS gates. Exact cores outrank partial cores when two guide slots compete for
+ * one owned skill; model gain orders alternatives within the same guide slot.
+ */
+function conservativeGuideSkillSlots(
+  teamGroups: ConservativeTeamGroup[],
+  skillPool: Set<string>,
+  m: PairedModel,
+  catalog: RecommendationCatalog
+): ConservativeGuideSkillSlot[] {
+  const slots = teamGroups.flatMap(({ group, guide }, teamIndex) => {
+    if (!guide) return [];
+    const matchedHeroes = new Set(guide.matchedHeroes);
+    return guide.comp.members.flatMap((member) => {
+      if (!matchedHeroes.has(member.hero)) return [];
+      return member.skillSlots.map((alternatives, slotIndex) => {
+        const eligible = alternatives
+          .filter(
+            (skill) =>
+              skillPool.has(skill) &&
+              skill !== catalog.default_skill[member.hero] &&
+              isConfidentGuideSkillRoute(m, member.hero, skill)
+          )
+          .sort((left, right) => {
+            const leftGain =
+              weightOf(m, skillId(left)) +
+              weightOf(m, heroSkillId(member.hero, left));
+            const rightGain =
+              weightOf(m, skillId(right)) +
+              weightOf(m, heroSkillId(member.hero, right));
+            if (Math.abs(leftGain - rightGain) > 1e-9)
+              return rightGain - leftGain;
+            const leftSupport =
+              supportOf(m, skillId(left)) +
+              supportOf(m, heroSkillId(member.hero, left));
+            const rightSupport =
+              supportOf(m, skillId(right)) +
+              supportOf(m, heroSkillId(member.hero, right));
+            return leftSupport !== rightSupport
+              ? rightSupport - leftSupport
+              : left.localeCompare(right);
+          });
+        return {
+          key: `conservative|${teamIndex}|${guide.comp.id}|${member.hero}|${slotIndex}`,
+          teamKey: group.key,
+          hero: member.hero,
+          slotIndex,
+          alternatives: eligible,
+          matchedHeroCount: guide.matchedHeroes.length,
+          potentialSkillSlots: guide.potentialSkillSlots,
+          championship: isChampionshipComp(guide.comp),
+          rankingScore: teamRankingScore(guide.comp.ranking),
+        };
+      });
+    });
+  });
+  return slots
+    .filter(({ alternatives }) => alternatives.length > 0)
+    .sort(compareConservativeGuideSkillSlots);
+}
+
 interface ConservativeSkillCandidate {
   hero: string;
   additions: string[];
@@ -2602,6 +2686,26 @@ function assignConservativeSkills(
     heroes.map((hero) => [hero, [null, null]])
   );
   const usedSkills = new Set<string>();
+
+  // Guide policy wins among routes that passed the same evidence gates as
+  // model-only placements. Match all selected 2/3 and 3/3 cores together so a
+  // unique owned skill is never reserved twice; absent guide heroes make no
+  // claims. The remaining open slots are filled by the model loop below.
+  const guideSlots = conservativeGuideSkillSlots(
+    teamGroups,
+    availableSkills,
+    m,
+    catalog
+  );
+  const guideSlotByKey = new Map(guideSlots.map((slot) => [slot.key, slot]));
+  const guideMatching = maximumKnownSlotMatching(guideSlots);
+  for (const [slotKey, skill] of guideMatching) {
+    const slot = guideSlotByKey.get(slotKey);
+    if (!slot) continue;
+    assigned.get(slot.hero)![slot.slotIndex] = skill;
+    usedSkills.add(skill);
+  }
+
   const guideByHero = new Map<string, ConservativeGuideMatch>();
   for (const { guide } of teamGroups) {
     if (!guide) continue;
@@ -2763,9 +2867,10 @@ function buildConfidentTeamEvidence(
 /**
  * Evidence-only Team Builder policy. Every placed hero, skill, and relationship
  * must clear the model's fitted support floor. Positive, zero, and negative
- * weights all remain eligible and affect ranking; guide data can then preserve
- * a qualified 2/3 or 3/3 core's canonical slots and formation, but never
- * bypasses those evidence gates.
+ * weights all remain eligible and affect ranking. Guide data preserves a
+ * qualified 2/3 or 3/3 core's canonical hero slots and formation, then reserves
+ * owned, qualified guide skills for matched heroes before model-only fallback;
+ * it never places an absent guide hero or bypasses the evidence gates.
  */
 function recommendConservativeHybridTeams(
   heroPool: string[],
@@ -2889,7 +2994,8 @@ function recommendConservativeHybridTeams(
 
 /**
  * Evidence-only Team Builder recommendation. Guide pairs/trios annotate
- * already-qualified model groups and preserve their canonical positions;
+ * already-qualified model groups, preserve their canonical positions, and
+ * reserve qualified skills for present guide heroes before model fallback;
  * unsupported positions stay blank.
  */
 export function recommendHybridTeams(


### PR DESCRIPTION
## Intent

On the /team-builder page, make the known-team guide policy win over model-only skill assignment for qualified 2/3 as well as 3/3 guide cores. A missing guide hero must not be inserted or make skill claims; only present matched heroes may reserve owned canonical guide skills, and every reserved route must still pass the existing atomic skill (S) and hero-skill (HS) evidence gates. Resolve guide claims globally so skills remain unique, prefer exact 3/3 guide cores over partial 2/3 cores on conflicts, use model evidence among guide-listed alternatives, and let the model fill only remaining slots. Also remove the 320 candidate cap for evidence-qualified hero pairs/trios so the complete game-contract search can consider every qualified trio (at most 455 for 15 heroes) and maximize disjoint complete teams.

## What Changed

- Reserve evidence-qualified canonical guide skills globally for present heroes in matched 2/3 and 3/3 cores, prioritizing exact cores and using model evidence to rank alternatives before fallback assignment.
- Remove the 320-candidate cutoff so Team Builder evaluates every qualified trio and can maximize disjoint complete teams.
- Expand recommendation-engine coverage and consolidate the guide-first policy documentation.

## Risk Assessment

✅ Low: The change is well-bounded and source inspection confirms guide reservations remain evidence-gated and globally unique while the qualified-group cap is fully removed.

## Testing

With no pre-supplied baseline results, I corrected the initial dependency-install working directory, added focused regression coverage for both S/HS rejection, absent-guide claims, and the former 320-trio cutoff, then completed focused and full unit, type, browser, prerender, and production-build checks. Manual `/team-builder` verification also showed a real qualified 2/3 core receiving its canonical formation and guide skills without inserting the missing hero; all validation succeeded.

- Evidence: Rendered /team-builder partial-guide recommendation (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M06XPHH47TD3QZ1XBX9D9GK7/team-builder-partial-guide.png</code>)
<details>
<summary>Evidence: Partial-guide browser verification transcript</summary>

`/team-builder rendered 雁形阵 with only owned guide heroes 司马懿 and 曹操, assigned 未雨绸缪、潜龙在渊、步步为营、折冲御侮, omitted absent guide hero 曹丕, and satisfied all recorded acceptance checks.`

```text
{
  "route": "/team-builder",
  "guide": {
    "id": "yanwu-司马懿-曹操-曹丕-73954cef88c92b17",
    "formation": "雁形阵",
    "fullHeroes": [
      "司马懿",
      "曹操",
      "曹丕"
    ]
  },
  "ownedHeroes": [
    "司马懿",
    "曹操",
    "甘宁",
    "李儒",
    "华雄",
    "颜良",
    "文丑",
    "邹氏",
    "关平"
  ],
  "absentGuideHero": "曹丕",
  "renderedFormation": "雁形阵",
  "renderedHeroes": [
    {
      "testId": "hero-slot-0-0",
      "ariaLabel": "队伍 1，武将位 1：司马懿，魏阵营"
    },
    {
      "testId": "hero-slot-0-1",
      "ariaLabel": "队伍 1，武将位 2：曹操，魏阵营"
    }
  ],
  "renderedSkills": [
    {
      "testId": "skill-slot-0-0-0",
      "text": "未雨绸缪"
    },
    {
      "testId": "skill-slot-0-0-1",
      "text": "潜龙在渊"
    },
    {
      "testId": "skill-slot-0-1-0",
      "text": "步步为营"
    },
    {
      "testId": "skill-slot-0-1-1",
      "text": "折冲御侮"
    }
  ],
  "renderedNotice": "部分武将或战法未通过证据量门槛，已保留空位。",
  "acceptanceChecks": {
    "onlyPresentGuideHeroesPlaced": true,
    "absentGuideHeroNotRendered": true,
    "allFourPresentHeroGuideSkillsRendered": true,
    "canonicalFormationRendered": true
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd web && pnpm install --frozen-lockfile`
- `cd web && pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t 'recommendHybridTeams — evidence-only partial placement'`
- `cd web && pnpm exec playwright test tests/buildATeam.spec.js --grep 'seeds exactly one evidence-only editable three-team formation'`
- `cd web && pnpm typecheck`
- `cd web && pnpm test`
- `cd web && pnpm test:e2e`
- `cd web && pnpm build`
- <code>Started Vite with `cd web &amp;&amp; pnpm start --host 127.0.0.1`, seeded a real 2/3 司马懿/曹操/曹丕 guide pool in headless Chromium, opened `/team-builder`, verified the absent 曹丕 was not inserted, and captured the rendered canonical formation and four owned guide skills.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
