### PR TITLE
feat(data): import cumulative S7–S16 Yanwu corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ in the browser:
   artifact — and **byte-reproducible**: no wall-clock or prior-output fields, so
   re-running on the same corpus yields a byte-identical file. A deterministic
   `corpus_version` content hash identifies the runtime training inputs. Trusted
-  local `Battle.season` remains model metadata for catalog consistency and
-  known-season popularity exposure; imported Yanwu battles always use null.
+  `Battle.season` remains model metadata for catalog consistency and
+  known-season popularity exposure. Yanwu season is inferred deterministically
+  from first appearance in the pinned cumulative S7–S16 assets.
 - **No runtime opponent.** The user never enters an opponent. A team's score is
   its **relative roster strength** (`w · features(team)`) against the learned
   metagame — *not* an opponent-specific win probability. The opponent term is a
@@ -245,24 +246,33 @@ data commits cannot race each other.
 
 ### Pinned external Yanwu corpus
 
-`data/external/yanwu-release.json` pins one immutable release asset from
-[CharlesWang505/yanwu-battle-reports](https://github.com/CharlesWang505/yanwu-battle-reports),
-including its byte size, SHA-256, source count, schema, attribution, and
+`data/external/yanwu-release.json` pins all ten immutable S7–S16 assets from the
+second [CharlesWang505/yanwu-battle-reports](https://github.com/CharlesWang505/yanwu-battle-reports)
+release, including each attachment's season, byte size, SHA-256, report count,
+schema, attribution, and
 [CC BY 4.0 licence](https://github.com/CharlesWang505/yanwu-battle-reports/blob/main/LICENSE).
 Adopting a later release is a reviewed manifest update; scheduled jobs never
-follow a mutable “latest” URL. Any `s16` text in the immutable release tag,
-filename, or URL is treated as an opaque asset identifier. The raw report's
-season label is ignored, is absent from manifest model metadata, and every
-normalized Yanwu battle has `"season": null`.
+follow a mutable “latest” URL.
+
+The upstream attachments are cumulative snapshots: all S7 report IDs recur in
+S8, and so on through S16. Normalization processes assets in ascending season
+order, keeps each report ID only at its first appearance, and assigns that
+attachment's numeric season. Every later occurrence must be otherwise identical
+(after removing only the rewritten raw season field), and every later asset must
+contain all prior IDs; conflicts or removals fail closed. This turns 39,898
+source rows into 8,154 unique report identities before ordinary completeness
+filtering, without multiplying repeated reports or assigning conflicting
+seasons. Season remains descriptive/model metadata and never affects evaluation
+split membership.
 
 `make sync-yanwu-corpus` verifies and normalizes the release into
 `.cache/yanwu/`. The raw and normalized files are regenerable and Git-ignored.
-A warm cache makes no network request: sync checksum-verifies the pinned raw
+A warm cache makes no network request: sync checksum-verifies every pinned raw
 asset, deterministically regenerates the expected normalized value, and accepts
-the normalized cache only when it matches. A cold cache downloads to a
-temporary file, verifies the manifest before publication, and normalizes
-atomically. Unknown catalog names or a checksum/schema/count mismatch fail
-closed.
+the normalized cache only when it matches. A cold cache downloads each asset to
+a temporary file, verifies the manifest before publication, and normalizes
+atomically. Unknown catalog names or a checksum/schema/count/cumulative-contract
+mismatch fails closed.
 `make build-recommendation` depends on this sync step, so it never silently
 falls back to a local-only model.
 
@@ -430,9 +440,10 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
   `catalog_version` content hash).
 - `battle_counts` — clean total / team1 / team2 wins, invalid count, and a
   deterministic `corpus_version` content hash over runtime training inputs.
-  Trusted local `Battle.season` remains part of that hash because it can affect
-  catalog checks and popularity adjustment; Yanwu contributes only null (no
-  build timestamp — the artifact is byte-reproducible).
+  Trusted `Battle.season`, including the first-appearance season inferred for
+  Yanwu, remains part of that hash because it can affect catalog checks and
+  popularity adjustment (no build timestamp — the artifact is
+  byte-reproducible).
 - `model` — the paired logistic weights keyed by **feature id**, plus per-feature
   `support` (evidence). Feature ids are pipe-joined, with pairs sorted for
   order-independence: `H|hero`, `S|skill`, `HP|a|b`, `HS|hero|skill`, `SP|hero|s1|s2`.

--- a/data/build_recommendation_data.py
+++ b/data/build_recommendation_data.py
@@ -204,6 +204,7 @@ class Battle:
     # Used only to keep separate contributors' upload sessions apart. It is
     # never serialized into the recommendation artifact or evaluation report.
     uploader_identity: str = ""
+    evaluation_identity: str = ""
 
 
 @dataclass(frozen=True)
@@ -245,6 +246,7 @@ def validate_battle(
     *,
     catalog_names: CatalogNames | None = None,
     catalog_seasons: _CatalogSeasons | None = None,
+    allow_shadow_skills: bool = False,
 ) -> Battle:
     """Validate a raw battle dict, returning a :class:`Battle`.
 
@@ -357,6 +359,11 @@ def validate_battle(
                             f"{skill!r} was introduced in season "
                             f"{intro_season}, after battle season {season}"
                         )
+            if "shadow_skills" in hero and not allow_shadow_skills:
+                raise InvalidBattleError(
+                    f"{filename}: team {team_key} hero {name!r} has "
+                    "unauthenticated shadow-skill provenance"
+                )
             shadow_skills_raw = hero.get("shadow_skills", [])
             if (
                 not isinstance(shadow_skills_raw, list)
@@ -628,6 +635,7 @@ def load_yanwu_battles(
                 filename,
                 catalog_names=catalog_names,
                 catalog_seasons=catalog_seasons,
+                allow_shadow_skills=True,
             )
         except InvalidBattleError as exc:
             errors.append(str(exc))
@@ -638,6 +646,7 @@ def load_yanwu_battles(
             continue
         battle.source = SOURCE_EXTERNAL_YANWU
         battle.captured_at = captured_at
+        battle.evaluation_identity = row["evaluation_identity"]
         battle.order_key = (
             f"2-{row['season']:04d}-{row['import_order']:08d}-{source_id}"
         )
@@ -1617,6 +1626,7 @@ def compute_evaluation_version(battles: list[Battle]) -> str:
             "observations": [
                 {
                     "filename": battle.filename,
+                    "evaluation_identity": battle.evaluation_identity,
                     "season": battle.season,
                     "source": battle.source,
                     "captured_at": battle.captured_at,

--- a/data/build_recommendation_data.py
+++ b/data/build_recommendation_data.py
@@ -357,11 +357,28 @@ def validate_battle(
                             f"{skill!r} was introduced in season "
                             f"{intro_season}, after battle season {season}"
                         )
+            shadow_skills_raw = hero.get("shadow_skills", [])
+            if (
+                not isinstance(shadow_skills_raw, list)
+                or any(
+                    not isinstance(skill, str)
+                    or not skill
+                    for skill in shadow_skills_raw
+                )
+                or len(set(shadow_skills_raw)) != len(shadow_skills_raw)
+                or any(skill not in skills_raw[1:] for skill in shadow_skills_raw)
+            ):
+                raise InvalidBattleError(
+                    f"{filename}: team {team_key} hero {name!r} has invalid "
+                    "shadow-skill provenance"
+                )
             # Preserve every position. Duplicate fingerprints intentionally
             # distinguish hero/skill reordering, so validation must never
             # collapse falsey entries or otherwise normalize this list.
-            skills = list(skills_raw)
-            heroes.append({"name": name, "skills": skills})
+            normalized_hero = {"name": name, "skills": list(skills_raw)}
+            if shadow_skills_raw:
+                normalized_hero["shadow_skills"] = list(shadow_skills_raw)
+            heroes.append(normalized_hero)
         if len(heroes) != TEAM_SIZE:
             raise InvalidBattleError(
                 f"{filename}: team {team_key} has {len(heroes)} heroes "
@@ -601,7 +618,10 @@ def load_yanwu_battles(
     errors: list[str] = []
     for row in corpus["reports"]:
         source_id = row["source_id"]
-        filename = f"external-yanwu/{row['import_order']:08d}-{source_id}.json"
+        filename = (
+            f"external-yanwu/S{row['season']}/"
+            f"{row['import_order']:08d}-{source_id}.json"
+        )
         try:
             battle = validate_battle(
                 row,
@@ -618,7 +638,9 @@ def load_yanwu_battles(
             continue
         battle.source = SOURCE_EXTERNAL_YANWU
         battle.captured_at = captured_at
-        battle.order_key = f"2-{row['import_order']:08d}-{source_id}"
+        battle.order_key = (
+            f"2-{row['season']:04d}-{row['import_order']:08d}-{source_id}"
+        )
         battles.append(battle)
 
     battles.sort(key=lambda battle: (battle.order_key, battle.filename))
@@ -1360,6 +1382,7 @@ def compute_analytics(
     hero_total: dict[str, int] = defaultdict(int)
     skill_wins: dict[str, int] = defaultdict(int)
     skill_total: dict[str, int] = defaultdict(int)
+    skill_shadow_total: dict[str, int] = defaultdict(int)
 
     global_wins = 0
     global_total = 0
@@ -1375,24 +1398,34 @@ def compute_analytics(
                 hero_wins[hero] += won
                 global_total += 1
                 global_wins += won
+                shadow_skills = set(hero_data.get("shadow_skills", []))
                 for skill in _non_default_skills(hero_data, default_skill):
                     skill_total[skill] += 1
                     skill_wins[skill] += won
+                    if skill in shadow_skills:
+                        skill_shadow_total[skill] += 1
 
     prior = (global_wins / global_total) if global_total else 0.5
 
-    def rows(wins: dict[str, int], total: dict[str, int]) -> list[dict[str, Any]]:
+    def rows(
+        wins: dict[str, int],
+        total: dict[str, int],
+        shadow_total: Mapping[str, int] | None = None,
+    ) -> list[dict[str, Any]]:
         out = []
         for name, tot in total.items():
             w = wins[name]
-            out.append({
+            row = {
                 "name": name,
                 "wins": w,
                 "losses": tot - w,
                 "total": tot,
                 "win_rate": round(w / tot, 4) if tot else 0.0,
                 "smoothed_win_rate": round(_smoothed_rate(w, tot, prior), 4),
-            })
+            }
+            if shadow_total is not None:
+                row["shadow_total"] = shadow_total.get(name, 0)
+            out.append(row)
         # Deterministic: smoothed rate desc, then total desc, then name.
         out.sort(key=lambda r: (-r["smoothed_win_rate"], -r["total"], r["name"]))
         return out
@@ -1400,7 +1433,7 @@ def compute_analytics(
     return {
         "prior_win_rate": round(prior, 4),
         "heroes": rows(hero_wins, hero_total),
-        "skills": rows(skill_wins, skill_total),
+        "skills": rows(skill_wins, skill_total, skill_shadow_total),
     }
 
 

--- a/data/external/yanwu-release.json
+++ b/data/external/yanwu-release.json
@@ -1,20 +1,95 @@
 {
-  "asset": {
-    "bytes": 58232906,
-    "filename": "s16-battle-reports-20260812.ywrlib.json",
-    "report_count": 4769,
-    "sha256": "6a39f1402f4609518b8c90ad9a09f8e78b379208917c94702afd1632a96a7156",
-    "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s16-20260812/s16-battle-reports-20260812.ywrlib.json"
-  },
+  "assets": [
+    {
+      "bytes": 857560,
+      "filename": "S7-battle-reports-20260818.ywrlib.json",
+      "report_count": 425,
+      "season": 7,
+      "sha256": "20e542e94e3f544f28332421f7e29666924dd9a940625d7eac0bc4c440697e06",
+      "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s7-s16-20260818/S7-battle-reports-20260818.ywrlib.json"
+    },
+    {
+      "bytes": 1985254,
+      "filename": "S8-battle-reports-20260818.ywrlib.json",
+      "report_count": 985,
+      "season": 8,
+      "sha256": "91da7666e9f2b5bc14835858c042205427d696357c20d948ce88a2075519cfbe",
+      "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s7-s16-20260818/S8-battle-reports-20260818.ywrlib.json"
+    },
+    {
+      "bytes": 2639363,
+      "filename": "S9-battle-reports-20260818.ywrlib.json",
+      "report_count": 1319,
+      "season": 9,
+      "sha256": "e630e80c7222b54d959c988c874a1026f1c6e1d759bccb45a1b9bc11b3518b1e",
+      "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s7-s16-20260818/S9-battle-reports-20260818.ywrlib.json"
+    },
+    {
+      "bytes": 3864844,
+      "filename": "S10-battle-reports-20260818.ywrlib.json",
+      "report_count": 1930,
+      "season": 10,
+      "sha256": "61c839e6e8bb0a5da8751a6df3ee320023ad51a3cfb75041efa0f3201c8095ad",
+      "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s7-s16-20260818/S10-battle-reports-20260818.ywrlib.json"
+    },
+    {
+      "bytes": 6117990,
+      "filename": "S11-battle-reports-20260818.ywrlib.json",
+      "report_count": 3050,
+      "season": 11,
+      "sha256": "0d410525b168e75ff09adc65deab6a04409e87a613a537f080b245ff0d68da6c",
+      "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s7-s16-20260818/S11-battle-reports-20260818.ywrlib.json"
+    },
+    {
+      "bytes": 8177205,
+      "filename": "S12-battle-reports-20260818.ywrlib.json",
+      "report_count": 4077,
+      "season": 12,
+      "sha256": "b6076fe892eaa46eb5e66f20097c63778c66d4e6dba0b0fccb26ed32883fefb2",
+      "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s7-s16-20260818/S12-battle-reports-20260818.ywrlib.json"
+    },
+    {
+      "bytes": 11698195,
+      "filename": "S13-battle-reports-20260818.ywrlib.json",
+      "report_count": 5813,
+      "season": 13,
+      "sha256": "467b069c6ce60193f03b5ea3f72020908d01a8b83ba58b23cd6e6bb98b11b3cf",
+      "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s7-s16-20260818/S13-battle-reports-20260818.ywrlib.json"
+    },
+    {
+      "bytes": 13537233,
+      "filename": "S14-battle-reports-20260818.ywrlib.json",
+      "report_count": 6702,
+      "season": 14,
+      "sha256": "7b7df6c95b43f2749e28f7b41e27bfebabeedcd644ce3730ce590bbdb492806d",
+      "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s7-s16-20260818/S14-battle-reports-20260818.ywrlib.json"
+    },
+    {
+      "bytes": 15063548,
+      "filename": "S15-battle-reports-20260818.ywrlib.json",
+      "report_count": 7443,
+      "season": 15,
+      "sha256": "9751207692125e500b5ec212515d9f26f19c2008b7e6ad8836f3f8c943d5fa98",
+      "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s7-s16-20260818/S15-battle-reports-20260818.ywrlib.json"
+    },
+    {
+      "bytes": 16477261,
+      "filename": "S16-battle-reports-20260818.ywrlib.json",
+      "report_count": 8154,
+      "season": 16,
+      "sha256": "335bb98b0cf529917c23b1518e937a30bb0ecaf5b898cab8fecb760a75936c26",
+      "url": "https://github.com/CharlesWang505/yanwu-battle-reports/releases/download/s7-s16-20260818/S16-battle-reports-20260818.ywrlib.json"
+    }
+  ],
   "license": {
     "name": "CC BY 4.0",
     "url": "https://github.com/CharlesWang505/yanwu-battle-reports/blob/main/LICENSE"
   },
-  "release_tag": "s16-20260812",
+  "release_tag": "s7-s16-20260818",
   "repository": "https://github.com/CharlesWang505/yanwu-battle-reports",
-  "schema_version": 2,
+  "schema_version": 3,
   "source": {
-    "format": "yanwu-report-library",
+    "format": "yanwu-report-library-public",
     "version": 1
   }
 }

--- a/data/recommendation_evaluation.py
+++ b/data/recommendation_evaluation.py
@@ -145,6 +145,13 @@ def matchup_skill_replacements(left: Any, right: Any) -> int | None:
     return min(direct, swapped)
 
 
+def _evaluation_identity(battle: Any, fallback: int) -> str | int:
+    return (
+        getattr(battle, "evaluation_identity", "")
+        or getattr(battle, "filename", fallback)
+    )
+
+
 def assign_evaluation_groups(
     battles: Sequence[Any],
     *,
@@ -252,7 +259,7 @@ def assign_evaluation_groups(
         labels = sorted(
             (
                 f"{getattr(battles[index], 'source', SOURCE_UPLOADED_BY_ME)}:"
-                f"{getattr(battles[index], 'filename', index)}"
+                f"{_evaluation_identity(battles[index], index)}"
             )
             for index in indices
         )

--- a/data/sync_yanwu_corpus.py
+++ b/data/sync_yanwu_corpus.py
@@ -50,7 +50,9 @@ def main(argv: list[str] | None = None) -> int:
     state = "cache hit" if cache_hit else "cache populated"
     print(
         f"Yanwu corpus {state}: {path} "
-        f"({summary['accepted_reports']} accepted, "
+        f"({summary['source_rows']} cumulative source rows -> "
+        f"{summary['unique_reports']} first-appearance reports; "
+        f"{summary['accepted_reports']} accepted, "
         f"{summary['excluded_reports']} excluded)."
     )
     return 0

--- a/data/test_build_recommendation_data.py
+++ b/data/test_build_recommendation_data.py
@@ -206,6 +206,26 @@ def test_validate_battle_accepts_catalogued_shadow_skill():
     assert battle.team1[0]["skills"][1] == "shadow-skill"
 
 
+def test_validate_battle_rejects_unauthenticated_shadow_provenance():
+    raw = _battle(
+        "shadow.json",
+        _team("A", "B", "C"),
+        _team("D", "E", "F"),
+        "1",
+    )
+    raw["1"][0]["shadow_skills"] = ["s1"]
+
+    with pytest.raises(InvalidBattleError, match="unauthenticated"):
+        validate_battle(raw, "shadow.json")
+
+    battle = validate_battle(
+        raw,
+        "external-shadow.json",
+        allow_shadow_skills=True,
+    )
+    assert battle.team1[0]["shadow_skills"] == ["s1"]
+
+
 def test_validate_battle_rejects_missing_winner():
     raw = {"1": [_hero("A", "d")], "2": [_hero("B", "d")]}
     with pytest.raises(InvalidBattleError):

--- a/data/test_build_recommendation_data.py
+++ b/data/test_build_recommendation_data.py
@@ -633,6 +633,33 @@ def test_compute_analytics_smoothing_and_sorting():
     assert a["heroes"][0]["smoothed_win_rate"] >= a["heroes"][-1]["smoothed_win_rate"]
 
 
+def test_compute_analytics_tracks_only_explicit_shadow_provenance():
+    battle = Battle(
+        filename="shadow.json",
+        team1=[
+            {
+                "name": "carrier",
+                "skills": ["signature", "shadowed", "plain"],
+                "shadow_skills": ["shadowed"],
+            }
+        ],
+        team2=[
+            {
+                "name": "other",
+                "skills": ["other-signature", "plain", "innate-looking"],
+            }
+        ],
+        winner=1,
+    )
+
+    analytics = compute_analytics([battle], {})
+    by_name = {row["name"]: row for row in analytics["skills"]}
+
+    assert by_name["shadowed"]["shadow_total"] == 1
+    assert by_name["plain"]["shadow_total"] == 0
+    assert by_name["innate-looking"]["shadow_total"] == 0
+
+
 def test_build_artifact_shape_and_backtest():
     battles = _synthetic_battles(300)
     # Give each observation a distinct roster so the leakage-safe fallback has

--- a/data/test_import_web_battles.py
+++ b/data/test_import_web_battles.py
@@ -832,22 +832,25 @@ def test_full_import_stages_recommendation_with_external_yanwu_corpus(
     _write_json(
         manifest_path,
         {
-            "asset": {
-                "bytes": 1,
-                "filename": "test.ywrlib.json",
-                "report_count": 1,
-                "sha256": source_sha,
-                "url": "https://github.com/example/repo/releases/download/test/test.ywrlib.json",
-            },
+            "assets": [
+                {
+                    "bytes": 1,
+                    "filename": "test.ywrlib.json",
+                    "report_count": 1,
+                    "season": 3,
+                    "sha256": source_sha,
+                    "url": "https://github.com/example/repo/releases/download/test/test.ywrlib.json",
+                }
+            ],
             "license": {
                 "name": "CC BY 4.0",
                 "url": "https://github.com/example/repo/blob/main/LICENSE",
             },
             "release_tag": "test",
             "repository": "https://github.com/example/repo",
-            "schema_version": 2,
+            "schema_version": 3,
             "source": {
-                "format": "yanwu-report-library",
+                "format": "yanwu-report-library-public",
                 "version": 1,
             },
         },
@@ -857,14 +860,14 @@ def test_full_import_stages_recommendation_with_external_yanwu_corpus(
         first=(1, 3, 5),
         second=(7, 9, 11),
         winner="1",
-        season=None,
+        season=3,
     )
     _write_json(
         corpus_path,
         {
             "catalog_version": tree["catalog_version"],
             "format": "sanmou-normalized-yanwu-corpus",
-            "normalizer_version": 2,
+            "normalizer_version": 3,
             "reports": [
                 {
                     **external_battle,
@@ -874,22 +877,33 @@ def test_full_import_stages_recommendation_with_external_yanwu_corpus(
                 }
             ],
             "source": {
-                "asset_filename": "test.ywrlib.json",
-                "asset_sha256": source_sha,
-                "exported_at": "2026-07-01T00:00:00Z",
-                "format": "yanwu-report-library",
+                "assets": [
+                    {
+                        "asset_filename": "test.ywrlib.json",
+                        "asset_sha256": source_sha,
+                        "exported_at": "2026-07-01T00:00:00Z",
+                        "report_count": 1,
+                        "season": 3,
+                    }
+                ],
+                "format": "yanwu-report-library-public",
                 "release_tag": "test",
-                "report_count": 1,
                 "repository": "https://github.com/example/repo",
+                "season_assignment": (
+                    "first_appearance_in_ascending_cumulative_assets"
+                ),
                 "version": 1,
             },
             "summary": {
+                "accepted_by_season": {"3": 1},
                 "accepted_reports": 1,
                 "excluded_reports": 0,
                 "exclusions": {},
-                "source_reports": 1,
+                "repeated_source_rows": 0,
+                "source_rows": 1,
+                "unique_reports": 1,
             },
-            "version": 1,
+            "version": 2,
         },
     )
 

--- a/data/test_import_web_battles.py
+++ b/data/test_import_web_battles.py
@@ -867,11 +867,14 @@ def test_full_import_stages_recommendation_with_external_yanwu_corpus(
         {
             "catalog_version": tree["catalog_version"],
             "format": "sanmou-normalized-yanwu-corpus",
-            "normalizer_version": 3,
+            "normalizer_version": 4,
             "reports": [
                 {
                     **external_battle,
                     "captured_at": "2026-07-01T00:00:00Z",
+                    "evaluation_identity": (
+                        "external-yanwu/00000000-external-report-id.json"
+                    ),
                     "import_order": 0,
                     "source_id": "external-report-id",
                 }
@@ -903,7 +906,7 @@ def test_full_import_stages_recommendation_with_external_yanwu_corpus(
                 "source_rows": 1,
                 "unique_reports": 1,
             },
-            "version": 2,
+            "version": 3,
         },
     )
 

--- a/data/test_recommendation_evaluation.py
+++ b/data/test_recommendation_evaluation.py
@@ -66,6 +66,7 @@ def _battle(
     captured_at: float | None = None,
     source: str = SOURCE_UPLOADED_BY_ME,
     uploader: str = "",
+    evaluation_identity: str = "",
     winner: int = 1,
     teams: tuple[
         list[dict[str, object]],
@@ -84,6 +85,7 @@ def _battle(
         source=source,
         captured_at=captured_at,
         uploader_identity=uploader,
+        evaluation_identity=evaluation_identity,
     )
 
 
@@ -247,6 +249,20 @@ def test_external_reports_start_as_stable_individual_groups():
 
     assert len(set(groups)) == 3
     assert len(set(clustered)) == 3
+
+
+def test_external_group_membership_uses_immutable_evaluation_identity():
+    original = _battle(
+        "external-yanwu/00000001-report.json",
+        source=SOURCE_EXTERNAL_YANWU,
+        evaluation_identity="external-yanwu/00000001-report.json",
+    )
+    changed = copy.deepcopy(original)
+    changed.filename = "external-yanwu/S7/99999999-report.json"
+    changed.order_key = "2-0007-99999999-report"
+    changed.season = 7
+
+    assert assign_evaluation_groups([original]) == assign_evaluation_groups([changed])
 
 
 def test_exact_and_near_duplicate_matchups_merge_without_using_winner():

--- a/data/test_yanwu_corpus.py
+++ b/data/test_yanwu_corpus.py
@@ -11,7 +11,9 @@ from data.yanwu_corpus import (
     InvalidYanwuCorpus,
     load_normalized_corpus,
     normalize_release,
+    normalize_releases,
     normalized_cache_path,
+    raw_cache_path,
     sync_corpus,
 )
 
@@ -41,7 +43,7 @@ def _hero(name: str, tactics: list[str] | None = None) -> dict:
 
 def _report(
     report_id: str,
-    import_order: int,
+    season: int,
     *,
     winner: str = "left",
     left: list[dict] | None = None,
@@ -49,9 +51,9 @@ def _report(
 ) -> dict:
     return {
         "id": report_id,
-        "importOrder": import_order,
-        "createdAt": f"2026-08-12T10:42:{import_order:02d}Z",
-        "season": "S16",
+        "createdAt": "2026-08-12T10:42:00Z",
+        "updatedAt": "2026-08-17T00:00:00Z",
+        "season": f"S{season}",
         "parsed": {
             "winnerSide": winner,
             "leftTeam": {
@@ -76,33 +78,39 @@ def _report(
     }
 
 
-def _release(reports: list[dict]) -> dict:
+def _release(season: int, reports: list[dict]) -> dict:
     return {
-        "format": "yanwu-report-library",
+        "format": "yanwu-report-library-public",
         "version": 1,
-        "exportedAt": "2026-08-12T10:42:28.089Z",
+        "season": f"S{season}",
+        "exportedAt": "2026-08-17T16:10:25.936Z",
         "reports": reports,
     }
 
 
-def _manifest(release_bytes: bytes) -> dict:
+def _asset(season: int, release_bytes: bytes) -> dict:
     release = json.loads(release_bytes)
     return {
-        "schema_version": 2,
+        "bytes": len(release_bytes),
+        "filename": f"S{season}-test.ywrlib.json",
+        "report_count": len(release["reports"]),
+        "season": season,
+        "sha256": hashlib.sha256(release_bytes).hexdigest(),
+        "url": (
+            "https://github.com/example/yanwu-battle-reports/releases/"
+            f"download/test/S{season}-test.ywrlib.json"
+        ),
+    }
+
+
+def _manifest(assets: list[dict]) -> dict:
+    return {
+        "schema_version": 3,
         "repository": "https://github.com/example/yanwu-battle-reports",
-        "release_tag": "s16-test",
-        "asset": {
-            "bytes": len(release_bytes),
-            "filename": "s16-test.ywrlib.json",
-            "report_count": len(release["reports"]),
-            "sha256": hashlib.sha256(release_bytes).hexdigest(),
-            "url": (
-                "https://github.com/example/yanwu-battle-reports/releases/"
-                "download/s16-test/s16-test.ywrlib.json"
-            ),
-        },
+        "release_tag": "s7-s16-test",
+        "assets": assets,
         "source": {
-            "format": "yanwu-report-library",
+            "format": "yanwu-report-library-public",
             "version": 1,
         },
         "license": {
@@ -112,21 +120,32 @@ def _manifest(release_bytes: bytes) -> dict:
     }
 
 
-def _write_manifest(path: Path, manifest: dict) -> None:
-    path.write_text(
-        json.dumps(manifest, ensure_ascii=False),
-        encoding="utf-8",
+def _release_bytes(release: dict) -> bytes:
+    return json.dumps(release, ensure_ascii=False).encode()
+
+
+def _normalize(releases: list[dict], manifest: dict) -> dict:
+    return normalize_releases(
+        releases,
+        manifest,
+        catalog_version="catalog-v1",
+        default_skill=DEFAULT_SKILLS,
+        catalog_skills=EQUIPPED_SKILLS | set(DEFAULT_SKILLS.values()),
     )
+
+
+def _write_manifest(path: Path, manifest: dict) -> None:
+    path.write_text(json.dumps(manifest, ensure_ascii=False), encoding="utf-8")
 
 
 def test_normalize_release_applies_aliases_shadow_skills_and_exclusions():
     reports = [
-        _report("valid", 0),
-        _report("unknown", 1, winner=""),
-        _report("short-team", 2, left=[_hero("SP孙坚")]),
+        _report("valid", 7),
+        _report("unknown", 7, winner=""),
+        _report("short-team", 7, left=[_hero("SP孙坚")]),
         _report(
             "short-tactics",
-            3,
+            7,
             left=[
                 _hero("SP孙坚", ["战八方"]),
                 _hero("SP周瑜"),
@@ -134,11 +153,12 @@ def test_normalize_release_applies_aliases_shadow_skills_and_exclusions():
             ],
         ),
     ]
-    release_bytes = json.dumps(_release(reports), ensure_ascii=False).encode()
-    manifest = _manifest(release_bytes)
+    release = _release(7, reports)
+    release_bytes = _release_bytes(release)
+    manifest = _manifest([_asset(7, release_bytes)])
 
     normalized = normalize_release(
-        _release(reports),
+        release,
         manifest,
         catalog_version="catalog-v1",
         default_skill=DEFAULT_SKILLS,
@@ -146,6 +166,7 @@ def test_normalize_release_applies_aliases_shadow_skills_and_exclusions():
     )
 
     assert normalized["summary"] == {
+        "accepted_by_season": {"7": 1},
         "accepted_reports": 1,
         "excluded_reports": 3,
         "exclusions": {
@@ -153,40 +174,89 @@ def test_normalize_release_applies_aliases_shadow_skills_and_exclusions():
             "incomplete_team": 1,
             "unknown_result": 1,
         },
-        "source_reports": 4,
+        "repeated_source_rows": 0,
+        "source_rows": 4,
+        "unique_reports": 4,
     }
     battle = normalized["reports"][0]
-    assert [hero["name"] for hero in battle["1"]] == [
-        "孙坚2",
-        "周瑜2",
-        "张辽",
-    ]
+    assert battle["season"] == 7
+    assert [hero["name"] for hero in battle["1"]] == ["孙坚2", "周瑜2", "张辽"]
     assert [hero["name"] for hero in battle["2"]] == [
         "诸葛亮2",
         "皇甫嵩2",
         "祝融",
     ]
-    assert battle["1"][0]["skills"][0] == "诛凶殄逆"
     assert battle["1"][1]["skills"] == ["焰燎江天", "折冲御侮", "万人之敌"]
-    assert battle["season"] is None
 
 
-def test_normalize_release_ignores_untrusted_raw_season_label():
-    report = _report("unknown-season", 0)
-    report["season"] = "S999"
-    release = _release([report])
-    release_bytes = json.dumps(release, ensure_ascii=False).encode()
-
-    normalized = normalize_release(
-        release,
-        _manifest(release_bytes),
-        catalog_version="catalog-v1",
-        default_skill=DEFAULT_SKILLS,
-        catalog_skills=EQUIPPED_SKILLS | set(DEFAULT_SKILLS.values()),
+def test_cumulative_assets_assign_first_appearance_season_and_remove_repeats():
+    first = _report("first", 7)
+    repeated = _report("first", 8)
+    new = _report("new", 8, winner="right")
+    release7 = _release(7, [first])
+    release8 = _release(8, [repeated, new])
+    manifest = _manifest(
+        [
+            _asset(7, _release_bytes(release7)),
+            _asset(8, _release_bytes(release8)),
+        ]
     )
 
-    assert normalized["reports"][0]["season"] is None
-    assert "season" not in normalized["source"]
+    normalized = _normalize([release7, release8], manifest)
+
+    assert [(row["source_id"], row["season"]) for row in normalized["reports"]] == [
+        ("first", 7),
+        ("new", 8),
+    ]
+    assert normalized["summary"] == {
+        "accepted_by_season": {"7": 1, "8": 1},
+        "accepted_reports": 2,
+        "excluded_reports": 0,
+        "exclusions": {},
+        "repeated_source_rows": 1,
+        "source_rows": 3,
+        "unique_reports": 2,
+    }
+
+
+def test_cumulative_assets_reject_conflicting_duplicate_content():
+    first = _report("same", 7)
+    changed = _report("same", 8, winner="right")
+    release7 = _release(7, [first])
+    release8 = _release(8, [changed])
+    manifest = _manifest(
+        [
+            _asset(7, _release_bytes(release7)),
+            _asset(8, _release_bytes(release8)),
+        ]
+    )
+
+    with pytest.raises(InvalidYanwuCorpus, match="conflicts across season assets"):
+        _normalize([release7, release8], manifest)
+
+
+def test_cumulative_assets_reject_removed_prior_report():
+    first = _report("first", 7)
+    release7 = _release(7, [first])
+    release8 = _release(8, [_report("new", 8)])
+    manifest = _manifest(
+        [
+            _asset(7, _release_bytes(release7)),
+            _asset(8, _release_bytes(release8)),
+        ]
+    )
+
+    with pytest.raises(InvalidYanwuCorpus, match="is not cumulative"):
+        _normalize([release7, release8], manifest)
+
+
+def test_release_and_report_seasons_must_match_manifest_asset():
+    report = _report("bad-season", 8)
+    release = _release(7, [report])
+    manifest = _manifest([_asset(7, _release_bytes(release))])
+
+    with pytest.raises(InvalidYanwuCorpus, match="season does not match its asset"):
+        _normalize([release], manifest)
 
 
 @pytest.mark.parametrize(
@@ -213,38 +283,42 @@ def test_normalize_release_fails_closed_on_unknown_catalog_values(
     catalog_skills: set[str],
     message: str,
 ):
-    reports = [_report("bad", 0, left=left)]
-    release_bytes = json.dumps(_release(reports), ensure_ascii=False).encode()
+    release = _release(7, [_report("bad", 7, left=left)])
+    manifest = _manifest([_asset(7, _release_bytes(release))])
 
     with pytest.raises(InvalidYanwuCorpus, match=message):
         normalize_release(
-            _release(reports),
-            _manifest(release_bytes),
+            release,
+            manifest,
             catalog_version="catalog-v1",
             default_skill=DEFAULT_SKILLS,
             catalog_skills=catalog_skills | set(DEFAULT_SKILLS.values()),
         )
 
 
-def test_sync_populates_then_reuses_and_repairs_the_cache(
+def test_sync_populates_reuses_and_authenticates_multi_asset_cache(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    source_bytes = json.dumps(
-        _release([_report("valid", 0)]),
-        ensure_ascii=False,
-    ).encode()
-    manifest = _manifest(source_bytes)
+    release7 = _release(7, [_report("first", 7)])
+    release8 = _release(8, [_report("first", 8), _report("new", 8)])
+    source_bytes = {
+        7: _release_bytes(release7),
+        8: _release_bytes(release8),
+    }
+    manifest = _manifest(
+        [_asset(season, source_bytes[season]) for season in (7, 8)]
+    )
     manifest_path = tmp_path / "manifest.json"
     cache_dir = tmp_path / "cache"
     _write_manifest(manifest_path, manifest)
-    calls = 0
+    calls: list[str] = []
 
-    def open_source(_request, *, timeout):
-        nonlocal calls
+    def open_source(request, *, timeout):
         assert timeout == 120
-        calls += 1
-        return io.BytesIO(source_bytes)
+        calls.append(request.full_url)
+        season = 7 if "S7-" in request.full_url else 8
+        return io.BytesIO(source_bytes[season])
 
     monkeypatch.setattr("data.yanwu_corpus.urllib.request.urlopen", open_source)
     path, summary, hit = sync_corpus(
@@ -255,9 +329,11 @@ def test_sync_populates_then_reuses_and_repairs_the_cache(
         catalog_skills=EQUIPPED_SKILLS | set(DEFAULT_SKILLS.values()),
     )
     assert hit is False
-    assert calls == 1
-    assert summary["accepted_reports"] == 1
+    assert len(calls) == 2
+    assert summary["accepted_by_season"] == {"7": 1, "8": 1}
     assert path == normalized_cache_path(manifest, cache_dir)
+    for asset in manifest["assets"]:
+        assert raw_cache_path(asset, cache_dir).exists()
 
     repeated_path, repeated_summary, repeated_hit = sync_corpus(
         manifest_path,
@@ -269,7 +345,7 @@ def test_sync_populates_then_reuses_and_repairs_the_cache(
     assert repeated_path == path
     assert repeated_summary == summary
     assert repeated_hit is True
-    assert calls == 1
+    assert len(calls) == 2
 
     tampered = json.loads(path.read_text(encoding="utf-8"))
     tampered["reports"][0]["winner"] = "2"
@@ -283,33 +359,19 @@ def test_sync_populates_then_reuses_and_repairs_the_cache(
     )
     assert repaired_path == path
     assert repaired_hit is False
-    assert calls == 1
-    assert json.loads(path.read_text(encoding="utf-8"))["reports"][0]["winner"] == "1"
-
-    path.write_text("not json", encoding="utf-8")
-    repaired_path, _repaired_summary, repaired_hit = sync_corpus(
-        manifest_path,
-        cache_dir,
-        catalog_version="catalog-v1",
-        default_skill=DEFAULT_SKILLS,
-        catalog_skills=EQUIPPED_SKILLS | set(DEFAULT_SKILLS.values()),
-    )
-    assert repaired_path == path
-    assert repaired_hit is False
-    assert calls == 1
-    load_normalized_corpus(path, manifest, catalog_version="catalog-v1")
+    assert len(calls) == 2
+    validated = load_normalized_corpus(path, manifest, catalog_version="catalog-v1")
+    assert validated["reports"][0]["winner"] == "1"
 
 
 def test_sync_rejects_a_download_that_does_not_match_the_manifest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    source_bytes = json.dumps(
-        _release([_report("valid", 0)]),
-        ensure_ascii=False,
-    ).encode()
-    manifest = _manifest(source_bytes)
-    manifest["asset"]["sha256"] = "0" * 64
+    release = _release(7, [_report("valid", 7)])
+    source_bytes = _release_bytes(release)
+    manifest = _manifest([_asset(7, source_bytes)])
+    manifest["assets"][0]["sha256"] = "0" * 64
     manifest_path = tmp_path / "manifest.json"
     cache_dir = tmp_path / "cache"
     _write_manifest(manifest_path, manifest)
@@ -318,7 +380,7 @@ def test_sync_rejects_a_download_that_does_not_match_the_manifest(
         lambda _request, *, timeout: io.BytesIO(source_bytes),
     )
 
-    with pytest.raises(InvalidYanwuCorpus, match="failed manifest verification"):
+    with pytest.raises(InvalidYanwuCorpus, match="failed verification"):
         sync_corpus(
             manifest_path,
             cache_dir,

--- a/data/test_yanwu_corpus.py
+++ b/data/test_yanwu_corpus.py
@@ -187,6 +187,8 @@ def test_normalize_release_applies_aliases_shadow_skills_and_exclusions():
         "祝融",
     ]
     assert battle["1"][1]["skills"] == ["焰燎江天", "折冲御侮", "万人之敌"]
+    assert battle["1"][1]["shadow_skills"] == ["万人之敌"]
+    assert battle["evaluation_identity"] == "external-yanwu/00000000-valid.json"
 
 
 def test_cumulative_assets_assign_first_appearance_season_and_remove_repeats():
@@ -204,9 +206,12 @@ def test_cumulative_assets_assign_first_appearance_season_and_remove_repeats():
 
     normalized = _normalize([release7, release8], manifest)
 
-    assert [(row["source_id"], row["season"]) for row in normalized["reports"]] == [
-        ("first", 7),
-        ("new", 8),
+    assert [
+        (row["source_id"], row["season"], row["evaluation_identity"])
+        for row in normalized["reports"]
+    ] == [
+        ("first", 7, "external-yanwu/00000000-first.json"),
+        ("new", 8, "external-yanwu/00000001-new.json"),
     ]
     assert normalized["summary"] == {
         "accepted_by_season": {"7": 1, "8": 1},

--- a/data/yanwu_corpus.py
+++ b/data/yanwu_corpus.py
@@ -1,4 +1,4 @@
-"""Verified, deterministic normalization for a pinned Yanwu release corpus."""
+"""Verified deterministic normalization for pinned multi-season Yanwu assets."""
 from __future__ import annotations
 
 import hashlib
@@ -10,15 +10,16 @@ import urllib.request
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
-from typing import Any, BinaryIO, Mapping
+from typing import Any, BinaryIO, Mapping, Sequence
 
 
-MANIFEST_SCHEMA_VERSION = 2
+MANIFEST_SCHEMA_VERSION = 3
 NORMALIZED_FORMAT = "sanmou-normalized-yanwu-corpus"
-NORMALIZED_VERSION = 1
-NORMALIZER_VERSION = 2
+NORMALIZED_VERSION = 2
+NORMALIZER_VERSION = 3
+SEASON_ASSIGNMENT = "first_appearance_in_ascending_cumulative_assets"
 DOWNLOAD_CHUNK_BYTES = 1024 * 1024
-USER_AGENT = "sanmou-yanwu-corpus-sync/1"
+USER_AGENT = "sanmou-yanwu-corpus-sync/2"
 
 HERO_ALIASES = {
     "SP周瑜": "周瑜2",
@@ -70,74 +71,116 @@ def _exact_keys(value: Any, expected: set[str], description: str) -> Mapping[str
     return value
 
 
+def _validated_asset(value: Any, description: str) -> dict[str, Any]:
+    asset = _exact_keys(
+        value,
+        {"bytes", "filename", "report_count", "season", "sha256", "url"},
+        description,
+    )
+    if (
+        isinstance(asset["bytes"], bool)
+        or not isinstance(asset["bytes"], int)
+        or asset["bytes"] <= 0
+        or isinstance(asset["report_count"], bool)
+        or not isinstance(asset["report_count"], int)
+        or asset["report_count"] <= 0
+        or isinstance(asset["season"], bool)
+        or not isinstance(asset["season"], int)
+        or asset["season"] <= 0
+    ):
+        raise InvalidYanwuCorpus("Yanwu manifest asset values must be positive integers")
+    if not isinstance(asset["sha256"], str) or not _SHA256_RE.fullmatch(
+        asset["sha256"]
+    ):
+        raise InvalidYanwuCorpus("Yanwu manifest asset SHA-256 is invalid")
+    for field in ("filename", "url"):
+        if not isinstance(asset[field], str) or not asset[field]:
+            raise InvalidYanwuCorpus(
+                f"Yanwu manifest asset {field} must be non-empty"
+            )
+    if not asset["url"].startswith("https://github.com/"):
+        raise InvalidYanwuCorpus(
+            "Yanwu manifest asset URL must use HTTPS on github.com"
+        )
+    return dict(asset)
+
+
 def load_manifest(path: Path) -> dict[str, Any]:
     value = _exact_keys(
         _load_json(path, "Yanwu release manifest"),
-        {"asset", "license", "release_tag", "repository", "schema_version", "source"},
+        {"assets", "license", "release_tag", "repository", "schema_version", "source"},
         "Yanwu release manifest",
     )
     if value["schema_version"] != MANIFEST_SCHEMA_VERSION:
         raise InvalidYanwuCorpus("unsupported Yanwu manifest schema version")
-
     for field in ("repository", "release_tag"):
         if not isinstance(value[field], str) or not value[field]:
             raise InvalidYanwuCorpus(f"Yanwu manifest {field} must be non-empty")
 
-    asset = _exact_keys(
-        value["asset"],
-        {"bytes", "filename", "report_count", "sha256", "url"},
-        "Yanwu manifest asset",
-    )
-    if (
-        not isinstance(asset["bytes"], int)
-        or isinstance(asset["bytes"], bool)
-        or asset["bytes"] <= 0
-        or not isinstance(asset["report_count"], int)
-        or isinstance(asset["report_count"], bool)
-        or asset["report_count"] <= 0
-    ):
-        raise InvalidYanwuCorpus("Yanwu manifest asset counts must be positive integers")
-    if not isinstance(asset["sha256"], str) or not _SHA256_RE.fullmatch(asset["sha256"]):
-        raise InvalidYanwuCorpus("Yanwu manifest asset SHA-256 is invalid")
-    for field in ("filename", "url"):
-        if not isinstance(asset[field], str) or not asset[field]:
-            raise InvalidYanwuCorpus(f"Yanwu manifest asset {field} must be non-empty")
-    if not asset["url"].startswith("https://github.com/"):
-        raise InvalidYanwuCorpus("Yanwu manifest asset URL must use HTTPS on github.com")
+    raw_assets = value["assets"]
+    if not isinstance(raw_assets, list) or not raw_assets:
+        raise InvalidYanwuCorpus("Yanwu manifest assets must be a non-empty array")
+    assets = [
+        _validated_asset(asset, f"Yanwu manifest asset {index}")
+        for index, asset in enumerate(raw_assets)
+    ]
+    seasons = [asset["season"] for asset in assets]
+    filenames = [asset["filename"] for asset in assets]
+    hashes = [asset["sha256"] for asset in assets]
+    if seasons != sorted(seasons) or len(set(seasons)) != len(seasons):
+        raise InvalidYanwuCorpus(
+            "Yanwu manifest assets must have unique ascending seasons"
+        )
+    if len(set(filenames)) != len(filenames) or len(set(hashes)) != len(hashes):
+        raise InvalidYanwuCorpus(
+            "Yanwu manifest assets must have unique filenames and SHA-256 values"
+        )
 
-    source = _exact_keys(
-        value["source"],
-        {"format", "version"},
-        "Yanwu manifest source",
-    )
+    source = _exact_keys(value["source"], {"format", "version"}, "Yanwu manifest source")
     if (
         not isinstance(source["format"], str)
         or not source["format"]
-        or not isinstance(source["version"], int)
         or isinstance(source["version"], bool)
+        or not isinstance(source["version"], int)
         or source["version"] <= 0
     ):
         raise InvalidYanwuCorpus("Yanwu manifest source contract is invalid")
 
     license_value = _exact_keys(
-        value["license"],
-        {"name", "url"},
-        "Yanwu manifest license",
+        value["license"], {"name", "url"}, "Yanwu manifest license"
     )
     if not all(
         isinstance(license_value[field], str) and license_value[field]
         for field in ("name", "url")
     ):
         raise InvalidYanwuCorpus("Yanwu manifest license fields must be non-empty")
-    return dict(value)
+
+    result = dict(value)
+    result["assets"] = assets
+    return result
+
+
+def _manifest_content_key(manifest: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        [
+            {
+                "season": asset["season"],
+                "sha256": asset["sha256"],
+            }
+            for asset in manifest["assets"]
+        ],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def normalized_cache_path(manifest: Mapping[str, Any], cache_dir: Path) -> Path:
-    return cache_dir / f"{manifest['asset']['sha256']}.normalized.json"
+    return cache_dir / f"{_manifest_content_key(manifest)}.normalized.json"
 
 
-def raw_cache_path(manifest: Mapping[str, Any], cache_dir: Path) -> Path:
-    return cache_dir / f"{manifest['asset']['sha256']}.ywrlib.json"
+def raw_cache_path(asset: Mapping[str, Any], cache_dir: Path) -> Path:
+    return cache_dir / f"{asset['sha256']}.ywrlib.json"
 
 
 def default_normalized_cache_path(manifest_path: Path, cache_dir: Path) -> Path:
@@ -162,6 +205,266 @@ def _normalized_skill(name: Any, description: str) -> str:
     return name.removeprefix(SHADOW_SKILL_PREFIX)
 
 
+def _comparable_report(raw: Mapping[str, Any]) -> str:
+    value = dict(raw)
+    value.pop("season", None)
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _normalize_unique_report(
+    raw: Mapping[str, Any],
+    *,
+    source_id: str,
+    import_order: int,
+    season: int,
+    default_skill: Mapping[str, str],
+    catalog_skills: set[str] | frozenset[str],
+    exclusions: Counter[str],
+) -> dict[str, Any] | None:
+    captured_at = _parse_timestamp(
+        raw.get("createdAt"),
+        f"Yanwu report {source_id!r} createdAt",
+    )
+    parsed = raw.get("parsed")
+    if not isinstance(parsed, dict):
+        raise InvalidYanwuCorpus(f"Yanwu report {source_id!r} parsed must be an object")
+    winner_side = parsed.get("winnerSide")
+    if winner_side not in {"left", "right"}:
+        exclusions["unknown_result"] += 1
+        return None
+
+    team_values: list[list[Any]] = []
+    for side in ("leftTeam", "rightTeam"):
+        team = parsed.get(side)
+        heroes = team.get("heroes") if isinstance(team, dict) else None
+        if not isinstance(heroes, list) or len(heroes) != 3:
+            exclusions["incomplete_team"] += 1
+            return None
+        team_values.append(heroes)
+
+    normalized_teams: list[list[dict[str, Any]]] = []
+    for team_index, heroes in enumerate(team_values, start=1):
+        normalized_heroes: list[dict[str, Any]] = []
+        seen_heroes: set[str] = set()
+        for hero_index, hero in enumerate(heroes, start=1):
+            if not isinstance(hero, dict):
+                exclusions["incomplete_tactics"] += 1
+                return None
+            raw_name = hero.get("name")
+            if not isinstance(raw_name, str) or not raw_name:
+                exclusions["incomplete_tactics"] += 1
+                return None
+            name = HERO_ALIASES.get(raw_name, raw_name)
+            if name not in default_skill:
+                raise InvalidYanwuCorpus(
+                    f"Yanwu report {source_id!r} has unknown hero {raw_name!r}"
+                )
+            if name in seen_heroes:
+                exclusions["incomplete_tactics"] += 1
+                return None
+            seen_heroes.add(name)
+            tactics = hero.get("tactics")
+            if not isinstance(tactics, list) or len(tactics) != 2:
+                exclusions["incomplete_tactics"] += 1
+                return None
+            normalized_tactics = [
+                _normalized_skill(
+                    tactic,
+                    f"Yanwu report {source_id!r} team {team_index} "
+                    f"hero {hero_index} tactic",
+                )
+                for tactic in tactics
+            ]
+            shadow_tactics = [
+                normalized
+                for raw_tactic, normalized in zip(tactics, normalized_tactics)
+                if raw_tactic.startswith(SHADOW_SKILL_PREFIX)
+            ]
+            unknown_skills = [
+                skill for skill in normalized_tactics if skill not in catalog_skills
+            ]
+            if unknown_skills:
+                raise InvalidYanwuCorpus(
+                    f"Yanwu report {source_id!r} has unknown skill "
+                    f"{unknown_skills[0]!r}"
+                )
+            normalized_hero = {
+                "name": name,
+                "skills": [default_skill[name], *normalized_tactics],
+            }
+            if shadow_tactics:
+                normalized_hero["shadow_skills"] = shadow_tactics
+            normalized_heroes.append(normalized_hero)
+        normalized_teams.append(normalized_heroes)
+
+    return {
+        "1": normalized_teams[0],
+        "2": normalized_teams[1],
+        "captured_at": captured_at,
+        "import_order": import_order,
+        "season": season,
+        "source_id": source_id,
+        "winner": "1" if winner_side == "left" else "2",
+    }
+
+
+def normalize_releases(
+    releases: Sequence[Any],
+    manifest: Mapping[str, Any],
+    *,
+    catalog_version: str,
+    default_skill: Mapping[str, str],
+    catalog_skills: set[str] | frozenset[str],
+) -> dict[str, Any]:
+    """Normalize cumulative assets, assigning each report to first appearance.
+
+    Assets are processed in ascending manifest season. Every later asset must be
+    cumulative and every repeated report ID must be byte-equivalent after
+    removing only its rewritten raw ``season`` field. The first asset containing
+    an ID therefore provides that report's deterministic inferred season.
+    """
+    assets = manifest["assets"]
+    if len(releases) != len(assets):
+        raise InvalidYanwuCorpus("Yanwu release asset count does not match manifest")
+
+    source = manifest["source"]
+    accepted: list[dict[str, Any]] = []
+    accepted_by_season: Counter[int] = Counter()
+    exclusions: Counter[str] = Counter()
+    seen_payloads: dict[str, str] = {}
+    previous_asset_ids: set[str] = set()
+    source_assets: list[dict[str, Any]] = []
+    source_rows = 0
+    repeated_rows = 0
+
+    for asset, release in zip(assets, releases):
+        root = _exact_keys(
+            release,
+            {"exportedAt", "format", "reports", "season", "version"},
+            f"Yanwu S{asset['season']} release",
+        )
+        expected_season = f"S{asset['season']}"
+        if (
+            root["format"] != source["format"]
+            or root["version"] != source["version"]
+            or root["season"] != expected_season
+        ):
+            raise InvalidYanwuCorpus(
+                f"Yanwu {expected_season} release contract does not match manifest"
+            )
+        exported_at = _parse_timestamp(
+            root["exportedAt"], f"Yanwu {expected_season} exportedAt"
+        )
+        reports = root["reports"]
+        if not isinstance(reports, list) or len(reports) != asset["report_count"]:
+            raise InvalidYanwuCorpus(
+                f"Yanwu {expected_season} report count does not match manifest"
+            )
+
+        asset_ids: set[str] = set()
+        global_offset = source_rows
+        for index, raw in enumerate(reports):
+            if not isinstance(raw, dict):
+                raise InvalidYanwuCorpus(
+                    f"Yanwu {expected_season} report {index} must be an object"
+                )
+            source_id = raw.get("id")
+            if (
+                not isinstance(source_id, str)
+                or not source_id
+                or source_id in asset_ids
+            ):
+                raise InvalidYanwuCorpus(
+                    f"Yanwu {expected_season} report {index} has an invalid/duplicate id"
+                )
+            if raw.get("season") != expected_season:
+                raise InvalidYanwuCorpus(
+                    f"Yanwu report {source_id!r} season does not match its asset"
+                )
+            asset_ids.add(source_id)
+            comparable = _comparable_report(raw)
+            previous = seen_payloads.get(source_id)
+            if previous is not None:
+                if previous != comparable:
+                    raise InvalidYanwuCorpus(
+                        f"Yanwu report {source_id!r} conflicts across season assets"
+                    )
+                repeated_rows += 1
+                continue
+            seen_payloads[source_id] = comparable
+            normalized = _normalize_unique_report(
+                raw,
+                source_id=source_id,
+                import_order=global_offset + index,
+                season=asset["season"],
+                default_skill=default_skill,
+                catalog_skills=catalog_skills,
+                exclusions=exclusions,
+            )
+            if normalized is not None:
+                accepted.append(normalized)
+                accepted_by_season[asset["season"]] += 1
+
+        missing_prior = previous_asset_ids - asset_ids
+        if missing_prior:
+            raise InvalidYanwuCorpus(
+                f"Yanwu {expected_season} asset is not cumulative; missing report "
+                f"{sorted(missing_prior)[0]!r}"
+            )
+        previous_asset_ids = asset_ids
+        source_rows += len(reports)
+        source_assets.append(
+            {
+                "asset_filename": asset["filename"],
+                "asset_sha256": asset["sha256"],
+                "exported_at": exported_at,
+                "report_count": len(reports),
+                "season": asset["season"],
+            }
+        )
+
+    accepted.sort(key=lambda row: (row["import_order"], row["source_id"]))
+    unique_reports = len(seen_payloads)
+    exclusion_count = sum(exclusions.values())
+    if len(accepted) + exclusion_count != unique_reports:
+        raise InvalidYanwuCorpus("Yanwu normalization counts are inconsistent")
+    if source_rows != unique_reports + repeated_rows:
+        raise InvalidYanwuCorpus("Yanwu cumulative de-duplication counts are inconsistent")
+
+    return {
+        "catalog_version": catalog_version,
+        "format": NORMALIZED_FORMAT,
+        "normalizer_version": NORMALIZER_VERSION,
+        "reports": accepted,
+        "source": {
+            "assets": source_assets,
+            "format": source["format"],
+            "release_tag": manifest["release_tag"],
+            "repository": manifest["repository"],
+            "season_assignment": SEASON_ASSIGNMENT,
+            "version": source["version"],
+        },
+        "summary": {
+            "accepted_by_season": {
+                str(season): accepted_by_season.get(season, 0)
+                for season in (asset["season"] for asset in assets)
+            },
+            "accepted_reports": len(accepted),
+            "excluded_reports": exclusion_count,
+            "exclusions": dict(sorted(exclusions.items())),
+            "repeated_source_rows": repeated_rows,
+            "source_rows": source_rows,
+            "unique_reports": unique_reports,
+        },
+        "version": NORMALIZED_VERSION,
+    }
+
+
 def normalize_release(
     release: Any,
     manifest: Mapping[str, Any],
@@ -170,165 +473,18 @@ def normalize_release(
     default_skill: Mapping[str, str],
     catalog_skills: set[str] | frozenset[str],
 ) -> dict[str, Any]:
-    """Normalize one verified source release into the model's compact battle shape."""
-    root = _exact_keys(
-        release,
-        {"exportedAt", "format", "reports", "version"},
-        "Yanwu release",
+    """Compatibility helper for focused one-asset tests."""
+    if len(manifest["assets"]) != 1:
+        raise InvalidYanwuCorpus(
+            "normalize_release requires a one-asset manifest; use normalize_releases"
+        )
+    return normalize_releases(
+        [release],
+        manifest,
+        catalog_version=catalog_version,
+        default_skill=default_skill,
+        catalog_skills=catalog_skills,
     )
-    source = manifest["source"]
-    if root["format"] != source["format"] or root["version"] != source["version"]:
-        raise InvalidYanwuCorpus("Yanwu release format/version does not match manifest")
-    exported_at = _parse_timestamp(root["exportedAt"], "Yanwu exportedAt")
-    reports = root["reports"]
-    if not isinstance(reports, list) or len(reports) != manifest["asset"]["report_count"]:
-        raise InvalidYanwuCorpus("Yanwu release report count does not match manifest")
-
-    seen_ids: set[str] = set()
-    seen_orders: set[int] = set()
-    accepted: list[dict[str, Any]] = []
-    exclusions: Counter[str] = Counter()
-
-    for index, raw in enumerate(reports):
-        if not isinstance(raw, dict):
-            raise InvalidYanwuCorpus(f"Yanwu report {index} must be an object")
-        source_id = raw.get("id")
-        import_order = raw.get("importOrder")
-        if not isinstance(source_id, str) or not source_id or source_id in seen_ids:
-            raise InvalidYanwuCorpus(f"Yanwu report {index} has an invalid/duplicate id")
-        if (
-            isinstance(import_order, bool)
-            or not isinstance(import_order, int)
-            or import_order < 0
-            or import_order in seen_orders
-        ):
-            raise InvalidYanwuCorpus(
-                f"Yanwu report {source_id!r} has an invalid/duplicate importOrder"
-            )
-        seen_ids.add(source_id)
-        seen_orders.add(import_order)
-        captured_at = _parse_timestamp(
-            raw.get("createdAt"),
-            f"Yanwu report {source_id!r} createdAt",
-        )
-        # The upstream report season label is untrustworthy. Ignore it rather
-        # than validating or preserving it; immutable asset identifiers that
-        # happen to contain "s16" are opaque provenance strings only.
-        parsed = raw.get("parsed")
-        if not isinstance(parsed, dict):
-            raise InvalidYanwuCorpus(f"Yanwu report {source_id!r} parsed must be an object")
-        winner_side = parsed.get("winnerSide")
-        if winner_side not in {"left", "right"}:
-            exclusions["unknown_result"] += 1
-            continue
-
-        team_values: list[list[Any]] = []
-        incomplete_team = False
-        for side in ("leftTeam", "rightTeam"):
-            team = parsed.get(side)
-            heroes = team.get("heroes") if isinstance(team, dict) else None
-            if not isinstance(heroes, list) or len(heroes) != 3:
-                incomplete_team = True
-                break
-            team_values.append(heroes)
-        if incomplete_team:
-            exclusions["incomplete_team"] += 1
-            continue
-
-        normalized_teams: list[list[dict[str, Any]]] = []
-        incomplete_tactics = False
-        for team_index, heroes in enumerate(team_values, start=1):
-            normalized_heroes: list[dict[str, Any]] = []
-            seen_heroes: set[str] = set()
-            for hero_index, hero in enumerate(heroes, start=1):
-                if not isinstance(hero, dict):
-                    incomplete_tactics = True
-                    break
-                raw_name = hero.get("name")
-                if not isinstance(raw_name, str) or not raw_name:
-                    incomplete_tactics = True
-                    break
-                name = HERO_ALIASES.get(raw_name, raw_name)
-                if name not in default_skill:
-                    raise InvalidYanwuCorpus(
-                        f"Yanwu report {source_id!r} has unknown hero {raw_name!r}"
-                    )
-                if name in seen_heroes:
-                    incomplete_tactics = True
-                    break
-                seen_heroes.add(name)
-                tactics = hero.get("tactics")
-                if not isinstance(tactics, list) or len(tactics) != 2:
-                    incomplete_tactics = True
-                    break
-                normalized_tactics = [
-                    _normalized_skill(
-                        tactic,
-                        f"Yanwu report {source_id!r} team {team_index} "
-                        f"hero {hero_index} tactic",
-                    )
-                    for tactic in tactics
-                ]
-                unknown_skills = [
-                    skill for skill in normalized_tactics if skill not in catalog_skills
-                ]
-                if unknown_skills:
-                    raise InvalidYanwuCorpus(
-                        f"Yanwu report {source_id!r} has unknown skill "
-                        f"{unknown_skills[0]!r}"
-                    )
-                normalized_heroes.append(
-                    {
-                        "name": name,
-                        "skills": [default_skill[name], *normalized_tactics],
-                    }
-                )
-            if incomplete_tactics:
-                break
-            normalized_teams.append(normalized_heroes)
-        if incomplete_tactics:
-            exclusions["incomplete_tactics"] += 1
-            continue
-
-        accepted.append(
-            {
-                "1": normalized_teams[0],
-                "2": normalized_teams[1],
-                "captured_at": captured_at,
-                "import_order": import_order,
-                "season": None,
-                "source_id": source_id,
-                "winner": "1" if winner_side == "left" else "2",
-            }
-        )
-
-    accepted.sort(key=lambda row: (row["import_order"], row["source_id"]))
-    exclusion_count = sum(exclusions.values())
-    if len(accepted) + exclusion_count != len(reports):
-        raise InvalidYanwuCorpus("Yanwu normalization counts are inconsistent")
-    return {
-        "catalog_version": catalog_version,
-        "format": NORMALIZED_FORMAT,
-        "normalizer_version": NORMALIZER_VERSION,
-        "reports": accepted,
-        "source": {
-            "asset_filename": manifest["asset"]["filename"],
-            "asset_sha256": manifest["asset"]["sha256"],
-            "exported_at": exported_at,
-            "format": source["format"],
-            "release_tag": manifest["release_tag"],
-            "report_count": len(reports),
-            "repository": manifest["repository"],
-            "version": source["version"],
-        },
-        "summary": {
-            "accepted_reports": len(accepted),
-            "excluded_reports": exclusion_count,
-            "exclusions": dict(sorted(exclusions.items())),
-            "source_reports": len(reports),
-        },
-        "version": NORMALIZED_VERSION,
-    }
 
 
 def load_normalized_corpus(
@@ -362,55 +518,107 @@ def load_normalized_corpus(
     source = _exact_keys(
         value["source"],
         {
-            "asset_filename",
-            "asset_sha256",
-            "exported_at",
+            "assets",
             "format",
             "release_tag",
-            "report_count",
             "repository",
+            "season_assignment",
             "version",
         },
         "normalized Yanwu source",
     )
     expected_source = manifest["source"]
     if (
-        source["asset_filename"] != manifest["asset"]["filename"]
-        or source["asset_sha256"] != manifest["asset"]["sha256"]
-        or source["release_tag"] != manifest["release_tag"]
+        source["release_tag"] != manifest["release_tag"]
         or source["repository"] != manifest["repository"]
-        or source["report_count"] != manifest["asset"]["report_count"]
         or source["format"] != expected_source["format"]
+        or source["season_assignment"] != SEASON_ASSIGNMENT
         or source["version"] != expected_source["version"]
+        or not isinstance(source["assets"], list)
+        or len(source["assets"]) != len(manifest["assets"])
     ):
         raise InvalidYanwuCorpus("normalized Yanwu source does not match manifest")
-    _parse_timestamp(source["exported_at"], "normalized Yanwu exported_at")
+    for index, (normalized_asset, manifest_asset) in enumerate(
+        zip(source["assets"], manifest["assets"])
+    ):
+        asset = _exact_keys(
+            normalized_asset,
+            {"asset_filename", "asset_sha256", "exported_at", "report_count", "season"},
+            f"normalized Yanwu source asset {index}",
+        )
+        if (
+            asset["asset_filename"] != manifest_asset["filename"]
+            or asset["asset_sha256"] != manifest_asset["sha256"]
+            or asset["report_count"] != manifest_asset["report_count"]
+            or asset["season"] != manifest_asset["season"]
+        ):
+            raise InvalidYanwuCorpus(
+                "normalized Yanwu source asset does not match manifest"
+            )
+        _parse_timestamp(asset["exported_at"], "normalized Yanwu exported_at")
 
     reports = value["reports"]
     summary = _exact_keys(
         value["summary"],
-        {"accepted_reports", "excluded_reports", "exclusions", "source_reports"},
+        {
+            "accepted_by_season",
+            "accepted_reports",
+            "excluded_reports",
+            "exclusions",
+            "repeated_source_rows",
+            "source_rows",
+            "unique_reports",
+        },
         "normalized Yanwu summary",
     )
+    expected_source_rows = sum(asset["report_count"] for asset in manifest["assets"])
+    expected_seasons = {str(asset["season"]) for asset in manifest["assets"]}
     if not isinstance(reports, list):
         raise InvalidYanwuCorpus("normalized Yanwu reports must be an array")
-    if (
-        summary["source_reports"] != manifest["asset"]["report_count"]
-        or summary["accepted_reports"] != len(reports)
-        or not isinstance(summary["excluded_reports"], int)
-        or isinstance(summary["excluded_reports"], bool)
-        or summary["excluded_reports"] < 0
-        or summary["accepted_reports"] + summary["excluded_reports"]
-        != summary["source_reports"]
-        or not isinstance(summary["exclusions"], dict)
-        or any(
-            not isinstance(reason, str)
-            or not reason
-            or isinstance(count, bool)
-            or not isinstance(count, int)
-            or count <= 0
+    count_fields = (
+        "accepted_reports",
+        "excluded_reports",
+        "repeated_source_rows",
+        "source_rows",
+        "unique_reports",
+    )
+    valid_counts = all(
+        not isinstance(summary[field], bool)
+        and isinstance(summary[field], int)
+        and summary[field] >= 0
+        for field in count_fields
+    )
+    valid_season_counts = (
+        isinstance(summary["accepted_by_season"], dict)
+        and set(summary["accepted_by_season"]) == expected_seasons
+        and all(
+            not isinstance(count, bool)
+            and isinstance(count, int)
+            and count >= 0
+            for count in summary["accepted_by_season"].values()
+        )
+    )
+    valid_exclusions = (
+        isinstance(summary["exclusions"], dict)
+        and all(
+            isinstance(reason, str)
+            and bool(reason)
+            and not isinstance(count, bool)
+            and isinstance(count, int)
+            and count > 0
             for reason, count in summary["exclusions"].items()
         )
+    )
+    if not valid_counts or not valid_season_counts or not valid_exclusions:
+        raise InvalidYanwuCorpus("normalized Yanwu summary is inconsistent")
+    if (
+        summary["source_rows"] != expected_source_rows
+        or summary["accepted_reports"] != len(reports)
+        or summary["accepted_reports"] + summary["excluded_reports"]
+        != summary["unique_reports"]
+        or summary["unique_reports"] + summary["repeated_source_rows"]
+        != summary["source_rows"]
+        or sum(summary["accepted_by_season"].values()) != len(reports)
         or sum(summary["exclusions"].values()) != summary["excluded_reports"]
     ):
         raise InvalidYanwuCorpus("normalized Yanwu summary is inconsistent")
@@ -418,17 +626,22 @@ def load_normalized_corpus(
     seen_ids: set[str] = set()
     seen_orders: set[int] = set()
     previous_key: tuple[int, str] | None = None
+    report_season_counts: Counter[int] = Counter()
+    valid_seasons = {asset["season"] for asset in manifest["assets"]}
     for index, report in enumerate(reports):
-        expected_keys = {
-            "1",
-            "2",
-            "captured_at",
-            "import_order",
-            "season",
-            "source_id",
-            "winner",
-        }
-        row = _exact_keys(report, expected_keys, f"normalized Yanwu report {index}")
+        row = _exact_keys(
+            report,
+            {
+                "1",
+                "2",
+                "captured_at",
+                "import_order",
+                "season",
+                "source_id",
+                "winner",
+            },
+            f"normalized Yanwu report {index}",
+        )
         source_id = row["source_id"]
         import_order = row["import_order"]
         if (
@@ -439,19 +652,28 @@ def load_normalized_corpus(
             or not isinstance(import_order, int)
             or import_order < 0
             or import_order in seen_orders
+            or isinstance(row["season"], bool)
+            or not isinstance(row["season"], int)
+            or row["season"] not in valid_seasons
         ):
             raise InvalidYanwuCorpus("normalized Yanwu report identity/order is invalid")
         key = (import_order, source_id)
         if previous_key is not None and key <= previous_key:
-            raise InvalidYanwuCorpus("normalized Yanwu reports are not deterministically sorted")
+            raise InvalidYanwuCorpus(
+                "normalized Yanwu reports are not deterministically sorted"
+            )
         previous_key = key
         seen_ids.add(source_id)
         seen_orders.add(import_order)
-        if row["season"] is not None:
-            raise InvalidYanwuCorpus(
-                "normalized Yanwu report season must be null"
-            )
-        _parse_timestamp(row["captured_at"], f"normalized Yanwu report {source_id!r}")
+        report_season_counts[row["season"]] += 1
+        _parse_timestamp(
+            row["captured_at"], f"normalized Yanwu report {source_id!r}"
+        )
+    if {
+        str(season): report_season_counts.get(season, 0)
+        for season in sorted(valid_seasons)
+    } != summary["accepted_by_season"]:
+        raise InvalidYanwuCorpus("normalized Yanwu season counts are inconsistent")
     return dict(value)
 
 
@@ -468,32 +690,35 @@ def _sha256_file(path: Path) -> tuple[str, int]:
     return digest.hexdigest(), size
 
 
-def _verified_raw_asset(path: Path, manifest: Mapping[str, Any]) -> bool:
+def _verified_raw_asset(path: Path, asset: Mapping[str, Any]) -> bool:
     try:
         digest, size = _sha256_file(path)
     except InvalidYanwuCorpus:
         return False
-    return digest == manifest["asset"]["sha256"] and size == manifest["asset"]["bytes"]
+    return digest == asset["sha256"] and size == asset["bytes"]
 
 
-def _download_to(handle: BinaryIO, manifest: Mapping[str, Any]) -> tuple[str, int]:
+def _download_to(handle: BinaryIO, asset: Mapping[str, Any]) -> tuple[str, int]:
     request = urllib.request.Request(
-        manifest["asset"]["url"],
-        headers={"User-Agent": USER_AGENT},
+        asset["url"], headers={"User-Agent": USER_AGENT}
     )
     digest = hashlib.sha256()
     size = 0
-    expected_size = manifest["asset"]["bytes"]
+    expected_size = asset["bytes"]
     try:
         with urllib.request.urlopen(request, timeout=120) as response:
             while chunk := response.read(DOWNLOAD_CHUNK_BYTES):
                 size += len(chunk)
                 if size > expected_size:
-                    raise InvalidYanwuCorpus("Yanwu download exceeds manifest byte size")
+                    raise InvalidYanwuCorpus(
+                        f"Yanwu S{asset['season']} download exceeds manifest byte size"
+                    )
                 digest.update(chunk)
                 handle.write(chunk)
     except (OSError, TimeoutError) as exc:
-        raise InvalidYanwuCorpus(f"cannot download pinned Yanwu release: {exc}") from exc
+        raise InvalidYanwuCorpus(
+            f"cannot download pinned Yanwu S{asset['season']} asset: {exc}"
+        ) from exc
     return digest.hexdigest(), size
 
 
@@ -532,34 +757,40 @@ def sync_corpus(
     default_skill: Mapping[str, str],
     catalog_skills: set[str] | frozenset[str],
 ) -> tuple[Path, dict[str, Any], bool]:
-    """Ensure the pinned normalized corpus exists; return path, summary, cache hit."""
+    """Ensure all pinned assets and their authenticated normalized corpus exist."""
     manifest = load_manifest(manifest_path)
     normalized_path = normalized_cache_path(manifest, cache_dir)
-    raw_path = raw_cache_path(manifest, cache_dir)
-
     cache_dir.mkdir(parents=True, exist_ok=True)
-    if not _verified_raw_asset(raw_path, manifest):
-        fd, temporary_name = tempfile.mkstemp(
-            dir=cache_dir,
-            prefix=".yanwu-download.",
-            suffix=".tmp",
-        )
-        try:
-            with os.fdopen(fd, "wb") as handle:
-                digest, size = _download_to(handle, manifest)
-            if digest != manifest["asset"]["sha256"] or size != manifest["asset"]["bytes"]:
-                raise InvalidYanwuCorpus("downloaded Yanwu asset failed manifest verification")
-            os.replace(temporary_name, raw_path)
-        except BaseException:
-            try:
-                os.unlink(temporary_name)
-            except OSError:
-                pass
-            raise
 
-    release = _load_json(raw_path, "pinned Yanwu release")
-    normalized = normalize_release(
-        release,
+    releases: list[Any] = []
+    for asset in manifest["assets"]:
+        raw_path = raw_cache_path(asset, cache_dir)
+        if not _verified_raw_asset(raw_path, asset):
+            fd, temporary_name = tempfile.mkstemp(
+                dir=cache_dir,
+                prefix=f".yanwu-S{asset['season']}-download.",
+                suffix=".tmp",
+            )
+            try:
+                with os.fdopen(fd, "wb") as handle:
+                    digest, size = _download_to(handle, asset)
+                if digest != asset["sha256"] or size != asset["bytes"]:
+                    raise InvalidYanwuCorpus(
+                        f"downloaded Yanwu S{asset['season']} asset failed verification"
+                    )
+                os.replace(temporary_name, raw_path)
+            except BaseException:
+                try:
+                    os.unlink(temporary_name)
+                except OSError:
+                    pass
+                raise
+        releases.append(
+            _load_json(raw_path, f"pinned Yanwu S{asset['season']} release")
+        )
+
+    normalized = normalize_releases(
+        releases,
         manifest,
         catalog_version=catalog_version,
         default_skill=default_skill,

--- a/data/yanwu_corpus.py
+++ b/data/yanwu_corpus.py
@@ -15,8 +15,8 @@ from typing import Any, BinaryIO, Mapping, Sequence
 
 MANIFEST_SCHEMA_VERSION = 3
 NORMALIZED_FORMAT = "sanmou-normalized-yanwu-corpus"
-NORMALIZED_VERSION = 2
-NORMALIZER_VERSION = 3
+NORMALIZED_VERSION = 3
+NORMALIZER_VERSION = 4
 SEASON_ASSIGNMENT = "first_appearance_in_ascending_cumulative_assets"
 DOWNLOAD_CHUNK_BYTES = 1024 * 1024
 USER_AGENT = "sanmou-yanwu-corpus-sync/2"
@@ -341,6 +341,7 @@ def normalize_releases(
     source_assets: list[dict[str, Any]] = []
     source_rows = 0
     repeated_rows = 0
+    final_asset_order: dict[str, int] = {}
 
     for asset, release in zip(assets, releases):
         root = _exact_keys(
@@ -410,6 +411,10 @@ def normalize_releases(
                 accepted.append(normalized)
                 accepted_by_season[asset["season"]] += 1
 
+        final_asset_order = {
+            raw["id"]: index
+            for index, raw in enumerate(reports)
+        }
         missing_prior = previous_asset_ids - asset_ids
         if missing_prior:
             raise InvalidYanwuCorpus(
@@ -428,6 +433,11 @@ def normalize_releases(
             }
         )
 
+    for row in accepted:
+        source_id = row["source_id"]
+        row["evaluation_identity"] = (
+            f"external-yanwu/{final_asset_order[source_id]:08d}-{source_id}.json"
+        )
     accepted.sort(key=lambda row: (row["import_order"], row["source_id"]))
     unique_reports = len(seen_payloads)
     exclusion_count = sum(exclusions.values())
@@ -635,6 +645,7 @@ def load_normalized_corpus(
                 "1",
                 "2",
                 "captured_at",
+                "evaluation_identity",
                 "import_order",
                 "season",
                 "source_id",
@@ -644,6 +655,7 @@ def load_normalized_corpus(
         )
         source_id = row["source_id"]
         import_order = row["import_order"]
+        evaluation_identity = row["evaluation_identity"]
         if (
             not isinstance(source_id, str)
             or not source_id
@@ -655,6 +667,11 @@ def load_normalized_corpus(
             or isinstance(row["season"], bool)
             or not isinstance(row["season"], int)
             or row["season"] not in valid_seasons
+            or not isinstance(evaluation_identity, str)
+            or not re.fullmatch(
+                rf"external-yanwu/\d{{8}}-{re.escape(source_id)}\.json",
+                evaluation_identity,
+            )
         ):
             raise InvalidYanwuCorpus("normalized Yanwu report identity/order is invalid")
         key = (import_order, source_id)

--- a/web/README.md
+++ b/web/README.md
@@ -228,11 +228,12 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   bonus, shown only on the synergy tables), and 参考场次 (reference battles). Individual
   hero/skill tables are ranked by 胜率参考 (descending, with deterministic tie-breakers);
   usage and top synergies keep their own orderings.
-- In the 全部战法 skill ranking, a skill is labelled `影 · <name>` when it can only
-  appear as a transferred/split (影) skill carried by another hero — either because
-  it is an orange hero's innate (自带) skill (its carrier's own usage is excluded by
-  the data builder) or because its skill catalog entry is explicitly marked
-  `shadow: true`. Its stats then reflect only that transferred usage.
+- In the 全部战法 skill ranking, a skill is labelled `影 · <name>` only when the
+  source battle explicitly carried 影 provenance (for example an upstream `影・`
+  tactic) or its skill catalog entry is marked `shadow: true`. Sharing a name with
+  an orange hero's innate skill is not enough: this prevents malformed/OCR reports
+  such as an equipped 星罗棋布 from creating a false 影 label. The generated
+  analytics retain the explicit-shadow observation count separately.
 - Technical model diagnostics (accuracy vs baseline, log loss, Brier, backtest sample/feature
   counts) live in an optional, collapsed accordion so they don't get in a casual player's way.
 

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -337,26 +337,11 @@ const Analytics = () => {
     }])
   ), []);
 
-  // A skill shown in 全部战法 is a 影 (transferred/split) skill in either of
-  // two explicit catalog cases:
-  //
-  //   1. It is an orange hero's innate (自带) skill: database.heroes[*].skill
-  //      records these. Its own carrier's usage is already excluded by the data
-  //      builder, so any appearance here is a transfer onto another hero.
-  //   2. Its skill catalog entry has `shadow: true` (e.g. 曲辞谄媚, 猿臂善射).
-  //
-  // We tag these rows with a "影 ·" prefix so it is clear the count reflects
-  // only the draftable (non-innate) usage.
-  const innateOrangeSkillSet = useMemo<Set<string>>(() => new Set(
-    Object.values(database.heroes || {})
-      .map((hero) => hero.skill)
-      .filter((s): s is string => Boolean(s))
-  ), []);
-  const isShadowSkill = useMemo(
-    () => (name: string): boolean =>
-      innateOrangeSkillSet.has(name) || database.skills?.[name]?.shadow === true,
-    [innateOrangeSkillSet]
-  );
+  // A skill is labelled 影 only with explicit evidence: source battle
+  // provenance (for example an upstream `影・` tactic) or catalog shadow
+  // metadata. Merely sharing a name with a hero's innate skill is insufficient.
+  const isShadowSkill = (skill: AnalyticsResult['skills'][number]): boolean =>
+    skill.shadowTotal > 0 || database.skills?.[skill.name]?.shadow === true;
 
   useEffect(() => {
     void loadTelemetryData()
@@ -640,7 +625,7 @@ const Analytics = () => {
                           <TableCell>{skillRankMap.get(s.name)}</TableCell>
                           <TableCell>
                             <Chip
-                              label={isShadowSkill(s.name) ? `影 · ${s.name}` : s.name}
+                              label={isShadowSkill(s) ? `影 · ${s.name}` : s.name}
                               color="secondary"
                               size="small"
                             />

--- a/web/src/recommendation_data.json
+++ b/web/src/recommendation_data.json
@@ -2203,34 +2203,34 @@
     ]
   },
   "backtest": {
-    "accuracy": 0.7267,
-    "baseline_accuracy": 0.5189,
-    "brier": 0.1868,
+    "accuracy": 0.7385,
+    "baseline_accuracy": 0.5237,
+    "brier": 0.1784,
     "confidence_interval_status": "available",
     "confidence_intervals_95": {
       "accuracy": {
-        "high": 0.7495,
-        "low": 0.6997
+        "high": 0.7616,
+        "low": 0.7141
       },
       "brier": {
-        "high": 0.2031,
-        "low": 0.1732
+        "high": 0.192,
+        "low": 0.1653
       },
       "log_loss": {
-        "high": 0.6149,
-        "low": 0.5261
+        "high": 0.5855,
+        "low": 0.5041
       }
     },
-    "holdout_frac": 0.2032,
-    "log_loss": 0.566,
-    "n_test": 1559,
+    "holdout_frac": 0.2008,
+    "log_loss": 0.5439,
+    "n_test": 1541,
     "n_test_groups": 647,
-    "n_train": 6114,
+    "n_train": 6132,
     "n_train_groups": 2590,
     "protocol": {
       "baseline": "training-majority class",
       "calendar_day_grouping": false,
-      "evaluation_version": "e775bb72bc0ae946",
+      "evaluation_version": "662a4e5eb35cc930",
       "external_initial_group": "stable report identity",
       "name": "grouped-stable-hash-holdout",
       "near_duplicate_max_skill_replacements": 1,
@@ -2252,49 +2252,49 @@
     },
     "source_breakdown": {
       "external_yanwu": {
-        "accuracy": 0.7184,
-        "brier": 0.1951,
+        "accuracy": 0.7285,
+        "brier": 0.1847,
         "confidence_interval_status": "available",
         "confidence_intervals_95": {
           "accuracy": {
-            "high": 0.7522,
-            "low": 0.6845
+            "high": 0.7599,
+            "low": 0.6948
           },
           "brier": {
-            "high": 0.2148,
-            "low": 0.1758
+            "high": 0.2031,
+            "low": 0.1669
           },
           "log_loss": {
-            "high": 0.6499,
-            "low": 0.536
+            "high": 0.6199,
+            "low": 0.5143
           }
         },
-        "log_loss": 0.5934,
-        "n": 902,
+        "log_loss": 0.5657,
+        "n": 884,
         "n_groups": 626,
         "n_groups_by_stratum": {
           "all": 626
         }
       },
       "uploaded_by_me": {
-        "accuracy": 0.7417,
-        "brier": 0.1717,
+        "accuracy": 0.7559,
+        "brier": 0.1673,
         "confidence_interval_status": "exploratory_few_groups",
         "confidence_intervals_95": {
           "accuracy": {
-            "high": 0.775,
-            "low": 0.7029
+            "high": 0.791,
+            "low": 0.7226
           },
           "brier": {
-            "high": 0.1923,
-            "low": 0.1541
+            "high": 0.1869,
+            "low": 0.1489
           },
           "log_loss": {
-            "high": 0.5714,
-            "low": 0.4618
+            "high": 0.561,
+            "low": 0.4514
           }
         },
-        "log_loss": 0.5137,
+        "log_loss": 0.5035,
         "n": 635,
         "n_groups": 13,
         "n_groups_by_stratum": {
@@ -2303,23 +2303,23 @@
       },
       "uploaded_by_others": {
         "accuracy": 0.6364,
-        "brier": 0.2837,
+        "brier": 0.2496,
         "confidence_interval_status": "exploratory_few_groups",
         "confidence_intervals_95": {
           "accuracy": {
-            "high": 0.8571,
-            "low": 0.4286
+            "high": 0.8125,
+            "low": 0.45
           },
           "brier": {
-            "high": 0.4713,
-            "low": 0.1322
+            "high": 0.4286,
+            "low": 0.1228
           },
           "log_loss": {
-            "high": 1.7718,
-            "low": 0.4435
+            "high": 1.621,
+            "low": 0.3854
           }
         },
-        "log_loss": 0.9561,
+        "log_loss": 0.8333,
         "n": 22,
         "n_groups": 8,
         "n_groups_by_stratum": {
@@ -2331,10 +2331,10 @@
       "test": {
         "by_source": {
           "external_yanwu": {
-            "n_battles": 902,
+            "n_battles": 884,
             "n_groups": 626,
-            "team1_wins": 486,
-            "team2_wins": 416
+            "team1_wins": 484,
+            "team2_wins": 400
           },
           "uploaded_by_me": {
             "n_battles": 635,
@@ -2349,18 +2349,18 @@
             "team2_wins": 9
           }
         },
-        "n_battles": 1559,
+        "n_battles": 1541,
         "n_groups": 647,
-        "team1_wins": 809,
-        "team2_wins": 750
+        "team1_wins": 807,
+        "team2_wins": 734
       },
       "train": {
         "by_source": {
           "external_yanwu": {
-            "n_battles": 3577,
+            "n_battles": 3595,
             "n_groups": 2530,
-            "team1_wins": 1958,
-            "team2_wins": 1619
+            "team1_wins": 1960,
+            "team2_wins": 1635
           },
           "uploaded_by_me": {
             "n_battles": 2438,
@@ -2375,10 +2375,10 @@
             "team2_wins": 24
           }
         },
-        "n_battles": 6114,
+        "n_battles": 6132,
         "n_groups": 2590,
-        "team1_wins": 3232,
-        "team2_wins": 2882
+        "team1_wins": 3234,
+        "team2_wins": 2898
       }
     }
   },

--- a/web/src/recommendation_data.json
+++ b/web/src/recommendation_data.json
@@ -799,6 +799,7 @@
       {
         "losses": 2,
         "name": "咏歌尝酒",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.625,
         "total": 7,
         "win_rate": 0.7143,
@@ -807,6 +808,7 @@
       {
         "losses": 687,
         "name": "忘私相助",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.6218,
         "total": 1818,
         "win_rate": 0.6221,
@@ -815,6 +817,7 @@
       {
         "losses": 301,
         "name": "合聚群雄",
+        "shadow_total": 638,
         "smoothed_win_rate": 0.6206,
         "total": 795,
         "win_rate": 0.6214,
@@ -823,6 +826,7 @@
       {
         "losses": 456,
         "name": "百战不殆",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.6201,
         "total": 1202,
         "win_rate": 0.6206,
@@ -831,6 +835,7 @@
       {
         "losses": 1292,
         "name": "折冲御侮",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.6196,
         "total": 3398,
         "win_rate": 0.6198,
@@ -839,6 +844,7 @@
       {
         "losses": 694,
         "name": "步步为营",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.6107,
         "total": 1784,
         "win_rate": 0.611,
@@ -847,6 +853,7 @@
       {
         "losses": 334,
         "name": "及锋而试",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.6074,
         "total": 852,
         "win_rate": 0.608,
@@ -855,6 +862,7 @@
       {
         "losses": 79,
         "name": "如沐春风",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.6044,
         "total": 201,
         "win_rate": 0.607,
@@ -863,6 +871,7 @@
       {
         "losses": 833,
         "name": "锐不可当",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5966,
         "total": 2066,
         "win_rate": 0.5968,
@@ -871,6 +880,7 @@
       {
         "losses": 21,
         "name": "曲辞谄媚",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5948,
         "total": 53,
         "win_rate": 0.6038,
@@ -879,6 +889,7 @@
       {
         "losses": 1360,
         "name": "胜敌益强",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5944,
         "total": 3354,
         "win_rate": 0.5945,
@@ -887,6 +898,7 @@
       {
         "losses": 757,
         "name": "洗筋伐髓",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5928,
         "total": 1860,
         "win_rate": 0.593,
@@ -895,6 +907,7 @@
       {
         "losses": 679,
         "name": "指点乾坤",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.585,
         "total": 1637,
         "win_rate": 0.5852,
@@ -903,6 +916,7 @@
       {
         "losses": 0,
         "name": "兵动若神",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5833,
         "total": 1,
         "win_rate": 1.0,
@@ -911,6 +925,7 @@
       {
         "losses": 0,
         "name": "星罗棋布",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5833,
         "total": 1,
         "win_rate": 1.0,
@@ -919,6 +934,7 @@
       {
         "losses": 98,
         "name": "建计举人",
+        "shadow_total": 26,
         "smoothed_win_rate": 0.583,
         "total": 236,
         "win_rate": 0.5847,
@@ -927,6 +943,7 @@
       {
         "losses": 3,
         "name": "划湘分荆",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5769,
         "total": 8,
         "win_rate": 0.625,
@@ -935,6 +952,7 @@
       {
         "losses": 610,
         "name": "践墨随敌",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5714,
         "total": 1424,
         "win_rate": 0.5716,
@@ -943,6 +961,7 @@
       {
         "losses": 185,
         "name": "流风回雪",
+        "shadow_total": 354,
         "smoothed_win_rate": 0.57,
         "total": 431,
         "win_rate": 0.5708,
@@ -951,6 +970,7 @@
       {
         "losses": 205,
         "name": "空城计",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5686,
         "total": 476,
         "win_rate": 0.5693,
@@ -959,6 +979,7 @@
       {
         "losses": 8,
         "name": "武烈破虏",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5625,
         "total": 19,
         "win_rate": 0.5789,
@@ -967,6 +988,7 @@
       {
         "losses": 12,
         "name": "强袭",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5606,
         "total": 28,
         "win_rate": 0.5714,
@@ -975,6 +997,7 @@
       {
         "losses": 698,
         "name": "惩前毖后",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5603,
         "total": 1588,
         "win_rate": 0.5605,
@@ -983,6 +1006,7 @@
       {
         "losses": 543,
         "name": "蓄势待发",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5565,
         "total": 1225,
         "win_rate": 0.5567,
@@ -991,6 +1015,7 @@
       {
         "losses": 571,
         "name": "金城汤池",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5527,
         "total": 1277,
         "win_rate": 0.5529,
@@ -999,6 +1024,7 @@
       {
         "losses": 2,
         "name": "太平余响",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.55,
         "total": 5,
         "win_rate": 0.6,
@@ -1007,6 +1033,7 @@
       {
         "losses": 451,
         "name": "威名显赫",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5474,
         "total": 997,
         "win_rate": 0.5476,
@@ -1015,6 +1042,7 @@
       {
         "losses": 504,
         "name": "谋而后动",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.547,
         "total": 1113,
         "win_rate": 0.5472,
@@ -1023,6 +1051,7 @@
       {
         "losses": 591,
         "name": "运智铺谋",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5424,
         "total": 1292,
         "win_rate": 0.5426,
@@ -1031,6 +1060,7 @@
       {
         "losses": 53,
         "name": "持军毅重",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5413,
         "total": 116,
         "win_rate": 0.5431,
@@ -1039,6 +1069,7 @@
       {
         "losses": 198,
         "name": "岿然不动",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5412,
         "total": 432,
         "win_rate": 0.5417,
@@ -1047,6 +1078,7 @@
       {
         "losses": 9,
         "name": "迎敌",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.54,
         "total": 20,
         "win_rate": 0.55,
@@ -1055,6 +1087,7 @@
       {
         "losses": 429,
         "name": "潜龙在渊",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5385,
         "total": 930,
         "win_rate": 0.5387,
@@ -1063,6 +1096,7 @@
       {
         "losses": 737,
         "name": "蹈锋饮血",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5384,
         "total": 1597,
         "win_rate": 0.5385,
@@ -1071,6 +1105,7 @@
       {
         "losses": 29,
         "name": "妖武",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5368,
         "total": 63,
         "win_rate": 0.5397,
@@ -1079,6 +1114,7 @@
       {
         "losses": 91,
         "name": "计袭粮仓",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5348,
         "total": 196,
         "win_rate": 0.5357,
@@ -1087,6 +1123,7 @@
       {
         "losses": 454,
         "name": "摧坚克难",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5342,
         "total": 975,
         "win_rate": 0.5344,
@@ -1095,6 +1132,7 @@
       {
         "losses": 18,
         "name": "十二奇策",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5341,
         "total": 39,
         "win_rate": 0.5385,
@@ -1103,6 +1141,7 @@
       {
         "losses": 405,
         "name": "调和阴阳",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5311,
         "total": 864,
         "win_rate": 0.5312,
@@ -1111,6 +1150,7 @@
       {
         "losses": 169,
         "name": "七进七出",
+        "shadow_total": 270,
         "smoothed_win_rate": 0.5262,
         "total": 357,
         "win_rate": 0.5266,
@@ -1119,6 +1159,7 @@
       {
         "losses": 409,
         "name": "披坚执锐",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5259,
         "total": 863,
         "win_rate": 0.5261,
@@ -1127,6 +1168,7 @@
       {
         "losses": 252,
         "name": "瞋目横矛",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5225,
         "total": 528,
         "win_rate": 0.5227,
@@ -1135,6 +1177,7 @@
       {
         "losses": 512,
         "name": "断敌粮道",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5214,
         "total": 1070,
         "win_rate": 0.5215,
@@ -1143,6 +1186,7 @@
       {
         "losses": 695,
         "name": "同舟共济",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.519,
         "total": 1445,
         "win_rate": 0.519,
@@ -1151,6 +1195,7 @@
       {
         "losses": 1088,
         "name": "明其虚实",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5175,
         "total": 2255,
         "win_rate": 0.5175,
@@ -1159,6 +1204,7 @@
       {
         "losses": 554,
         "name": "未雨绸缪",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5173,
         "total": 1148,
         "win_rate": 0.5174,
@@ -1167,6 +1213,7 @@
       {
         "losses": 810,
         "name": "横征暴敛",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5167,
         "total": 1676,
         "win_rate": 0.5167,
@@ -1175,6 +1222,7 @@
       {
         "losses": 42,
         "name": "雄踞西凉",
+        "shadow_total": 55,
         "smoothed_win_rate": 0.5163,
         "total": 87,
         "win_rate": 0.5172,
@@ -1183,6 +1231,7 @@
       {
         "losses": 425,
         "name": "万人之敌",
+        "shadow_total": 738,
         "smoothed_win_rate": 0.5159,
         "total": 878,
         "win_rate": 0.5159,
@@ -1191,6 +1240,7 @@
       {
         "losses": 871,
         "name": "运筹帷幄",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5101,
         "total": 1778,
         "win_rate": 0.5101,
@@ -1199,6 +1249,7 @@
       {
         "losses": 126,
         "name": "算无遗策",
+        "shadow_total": 109,
         "smoothed_win_rate": 0.5019,
         "total": 253,
         "win_rate": 0.502,
@@ -1207,6 +1258,7 @@
       {
         "losses": 3,
         "name": "大破街亭",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5,
         "total": 6,
         "win_rate": 0.5,
@@ -1215,6 +1267,7 @@
       {
         "losses": 1,
         "name": "决堰倾涛",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5,
         "total": 2,
         "win_rate": 0.5,
@@ -1223,6 +1276,7 @@
       {
         "losses": 1,
         "name": "直谏固政",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5,
         "total": 2,
         "win_rate": 0.5,
@@ -1231,6 +1285,7 @@
       {
         "losses": 1,
         "name": "驱兽御象",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.5,
         "total": 2,
         "win_rate": 0.5,
@@ -1239,6 +1294,7 @@
       {
         "losses": 140,
         "name": "睿虑合图",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4982,
         "total": 279,
         "win_rate": 0.4982,
@@ -1247,6 +1303,7 @@
       {
         "losses": 1341,
         "name": "避其锐气",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4968,
         "total": 2665,
         "win_rate": 0.4968,
@@ -1255,6 +1312,7 @@
       {
         "losses": 497,
         "name": "青囊急救",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4919,
         "total": 978,
         "win_rate": 0.4918,
@@ -1263,6 +1321,7 @@
       {
         "losses": 25,
         "name": "苦肉计",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4907,
         "total": 49,
         "win_rate": 0.4898,
@@ -1271,6 +1330,7 @@
       {
         "losses": 685,
         "name": "清风驱疾",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.49,
         "total": 1343,
         "win_rate": 0.4899,
@@ -1279,6 +1339,7 @@
       {
         "losses": 587,
         "name": "挫锐折锋",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4874,
         "total": 1145,
         "win_rate": 0.4873,
@@ -1287,6 +1348,7 @@
       {
         "losses": 554,
         "name": "奇正相生",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4871,
         "total": 1080,
         "win_rate": 0.487,
@@ -1295,6 +1357,7 @@
       {
         "losses": 857,
         "name": "知人善任",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4866,
         "total": 1669,
         "win_rate": 0.4865,
@@ -1303,6 +1366,7 @@
       {
         "losses": 14,
         "name": "来好息师",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4844,
         "total": 27,
         "win_rate": 0.4815,
@@ -1311,6 +1375,7 @@
       {
         "losses": 206,
         "name": "恩威并行",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4774,
         "total": 394,
         "win_rate": 0.4772,
@@ -1319,6 +1384,7 @@
       {
         "losses": 501,
         "name": "文武双全",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4772,
         "total": 958,
         "win_rate": 0.477,
@@ -1327,6 +1393,7 @@
       {
         "losses": 443,
         "name": "风助火势",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4765,
         "total": 846,
         "win_rate": 0.4764,
@@ -1335,6 +1402,7 @@
       {
         "losses": 328,
         "name": "斩将夺旗",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4762,
         "total": 626,
         "win_rate": 0.476,
@@ -1343,6 +1411,7 @@
       {
         "losses": 160,
         "name": "弓腰姬",
+        "shadow_total": 266,
         "smoothed_win_rate": 0.4741,
         "total": 304,
         "win_rate": 0.4737,
@@ -1351,6 +1420,7 @@
       {
         "losses": 879,
         "name": "战八方",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4693,
         "total": 1656,
         "win_rate": 0.4692,
@@ -1359,6 +1429,7 @@
       {
         "losses": 6,
         "name": "缮甲厉兵",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4688,
         "total": 11,
         "win_rate": 0.4545,
@@ -1367,6 +1438,7 @@
       {
         "losses": 570,
         "name": "御敌临前",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4674,
         "total": 1070,
         "win_rate": 0.4673,
@@ -1375,6 +1447,7 @@
       {
         "losses": 363,
         "name": "烈火张天",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4672,
         "total": 681,
         "win_rate": 0.467,
@@ -1383,6 +1456,7 @@
       {
         "losses": 29,
         "name": "勇冠三军",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4661,
         "total": 54,
         "win_rate": 0.463,
@@ -1391,6 +1465,7 @@
       {
         "losses": 524,
         "name": "固若金汤",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4649,
         "total": 979,
         "win_rate": 0.4648,
@@ -1399,6 +1474,7 @@
       {
         "losses": 154,
         "name": "掠阵破军",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.464,
         "total": 287,
         "win_rate": 0.4634,
@@ -1407,6 +1483,7 @@
       {
         "losses": 617,
         "name": "韬光养晦",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4613,
         "total": 1145,
         "win_rate": 0.4611,
@@ -1415,6 +1492,7 @@
       {
         "losses": 310,
         "name": "以静制动",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4603,
         "total": 574,
         "win_rate": 0.4599,
@@ -1423,6 +1501,7 @@
       {
         "losses": 203,
         "name": "连环计",
+        "shadow_total": 247,
         "smoothed_win_rate": 0.4592,
         "total": 375,
         "win_rate": 0.4587,
@@ -1431,6 +1510,7 @@
       {
         "losses": 471,
         "name": "神略制变",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4557,
         "total": 865,
         "win_rate": 0.4555,
@@ -1439,6 +1519,7 @@
       {
         "losses": 397,
         "name": "经天纬地",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.455,
         "total": 728,
         "win_rate": 0.4547,
@@ -1447,6 +1528,7 @@
       {
         "losses": 45,
         "name": "穷追不舍",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.454,
         "total": 82,
         "win_rate": 0.4512,
@@ -1455,6 +1537,7 @@
       {
         "losses": 657,
         "name": "十面埋伏",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4513,
         "total": 1197,
         "win_rate": 0.4511,
@@ -1463,6 +1546,7 @@
       {
         "losses": 1086,
         "name": "铸甲销戈",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4511,
         "total": 1978,
         "win_rate": 0.451,
@@ -1471,6 +1555,7 @@
       {
         "losses": 239,
         "name": "任人唯贤",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4511,
         "total": 435,
         "win_rate": 0.4506,
@@ -1479,6 +1564,7 @@
       {
         "losses": 31,
         "name": "乐不思蜀",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4508,
         "total": 56,
         "win_rate": 0.4464,
@@ -1487,6 +1573,7 @@
       {
         "losses": 112,
         "name": "鸩饮毒弑",
+        "shadow_total": 23,
         "smoothed_win_rate": 0.4495,
         "total": 203,
         "win_rate": 0.4483,
@@ -1495,6 +1582,7 @@
       {
         "losses": 287,
         "name": "轻装驰援",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4433,
         "total": 515,
         "win_rate": 0.4427,
@@ -1503,6 +1591,7 @@
       {
         "losses": 256,
         "name": "疾行侧击",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4429,
         "total": 459,
         "win_rate": 0.4423,
@@ -1511,6 +1600,7 @@
       {
         "losses": 30,
         "name": "折节学问",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4397,
         "total": 53,
         "win_rate": 0.434,
@@ -1519,6 +1609,7 @@
       {
         "losses": 25,
         "name": "乘间投隙",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4388,
         "total": 44,
         "win_rate": 0.4318,
@@ -1527,6 +1618,7 @@
       {
         "losses": 267,
         "name": "势如破竹",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4374,
         "total": 474,
         "win_rate": 0.4367,
@@ -1535,6 +1627,7 @@
       {
         "losses": 114,
         "name": "临机制胜",
+        "shadow_total": 138,
         "smoothed_win_rate": 0.4372,
         "total": 202,
         "win_rate": 0.4356,
@@ -1543,6 +1636,7 @@
       {
         "losses": 431,
         "name": "无难之志",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.437,
         "total": 765,
         "win_rate": 0.4366,
@@ -1551,6 +1645,7 @@
       {
         "losses": 89,
         "name": "潜师袭远",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4352,
         "total": 157,
         "win_rate": 0.4331,
@@ -1559,6 +1654,7 @@
       {
         "losses": 751,
         "name": "黄天惑心",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4339,
         "total": 1326,
         "win_rate": 0.4336,
@@ -1567,6 +1663,7 @@
       {
         "losses": 1084,
         "name": "料事如神",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4309,
         "total": 1904,
         "win_rate": 0.4307,
@@ -1575,6 +1672,7 @@
       {
         "losses": 134,
         "name": "一计决胜",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4289,
         "total": 234,
         "win_rate": 0.4274,
@@ -1583,6 +1681,7 @@
       {
         "losses": 75,
         "name": "文治武功",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4259,
         "total": 130,
         "win_rate": 0.4231,
@@ -1591,6 +1690,7 @@
       {
         "losses": 139,
         "name": "智破千军",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4248,
         "total": 241,
         "win_rate": 0.4232,
@@ -1599,6 +1699,7 @@
       {
         "losses": 165,
         "name": "三军夺气",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4244,
         "total": 286,
         "win_rate": 0.4231,
@@ -1607,6 +1708,7 @@
       {
         "losses": 368,
         "name": "伏兵四起",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4238,
         "total": 638,
         "win_rate": 0.4232,
@@ -1615,6 +1717,7 @@
       {
         "losses": 378,
         "name": "坚如磐石",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.42,
         "total": 651,
         "win_rate": 0.4194,
@@ -1623,6 +1726,7 @@
       {
         "losses": 116,
         "name": "揭竿而起",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4191,
         "total": 199,
         "win_rate": 0.4171,
@@ -1631,6 +1735,7 @@
       {
         "losses": 1,
         "name": "临阵突袭",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4167,
         "total": 1,
         "win_rate": 0.0,
@@ -1639,6 +1744,7 @@
       {
         "losses": 1,
         "name": "坚壁清野",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4167,
         "total": 1,
         "win_rate": 0.0,
@@ -1647,6 +1753,7 @@
       {
         "losses": 1,
         "name": "妖风大作",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4167,
         "total": 1,
         "win_rate": 0.0,
@@ -1655,6 +1762,7 @@
       {
         "losses": 1,
         "name": "素衣约俭",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4167,
         "total": 1,
         "win_rate": 0.0,
@@ -1663,6 +1771,7 @@
       {
         "losses": 1,
         "name": "荼蘼心计",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4167,
         "total": 1,
         "win_rate": 0.0,
@@ -1671,6 +1780,7 @@
       {
         "losses": 1,
         "name": "诛凶殄逆",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4167,
         "total": 1,
         "win_rate": 0.0,
@@ -1679,6 +1789,7 @@
       {
         "losses": 168,
         "name": "火羽",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4141,
         "total": 286,
         "win_rate": 0.4126,
@@ -1687,6 +1798,7 @@
       {
         "losses": 145,
         "name": "定军扬威",
+        "shadow_total": 143,
         "smoothed_win_rate": 0.4124,
         "total": 246,
         "win_rate": 0.4106,
@@ -1695,6 +1807,7 @@
       {
         "losses": 4,
         "name": "文韬武略",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4091,
         "total": 6,
         "win_rate": 0.3333,
@@ -1703,6 +1816,7 @@
       {
         "losses": 133,
         "name": "上兵伐谋",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4083,
         "total": 224,
         "win_rate": 0.4062,
@@ -1711,6 +1825,7 @@
       {
         "losses": 33,
         "name": "长驱直入",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.4083,
         "total": 55,
         "win_rate": 0.4,
@@ -1719,6 +1834,7 @@
       {
         "losses": 522,
         "name": "机变无穷",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.404,
         "total": 875,
         "win_rate": 0.4034,
@@ -1727,6 +1843,7 @@
       {
         "losses": 27,
         "name": "暗渡阴平",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.398,
         "total": 44,
         "win_rate": 0.3864,
@@ -1735,6 +1852,7 @@
       {
         "losses": 193,
         "name": "断戈夺锋",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3947,
         "total": 318,
         "win_rate": 0.3931,
@@ -1743,6 +1861,7 @@
       {
         "losses": 9,
         "name": "计逐穷寇",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3947,
         "total": 14,
         "win_rate": 0.3571,
@@ -1751,6 +1870,7 @@
       {
         "losses": 953,
         "name": "烈火焚营",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3937,
         "total": 1571,
         "win_rate": 0.3934,
@@ -1759,6 +1879,7 @@
       {
         "losses": 20,
         "name": "束手无策",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3919,
         "total": 32,
         "win_rate": 0.375,
@@ -1767,6 +1888,7 @@
       {
         "losses": 218,
         "name": "拔刀相向",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3909,
         "total": 357,
         "win_rate": 0.3894,
@@ -1775,6 +1897,7 @@
       {
         "losses": 189,
         "name": "水淹七军",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3862,
         "total": 307,
         "win_rate": 0.3844,
@@ -1783,6 +1906,7 @@
       {
         "losses": 302,
         "name": "如有神助",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3811,
         "total": 487,
         "win_rate": 0.3799,
@@ -1791,6 +1915,7 @@
       {
         "losses": 270,
         "name": "诱敌深入",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3807,
         "total": 435,
         "win_rate": 0.3793,
@@ -1799,6 +1924,7 @@
       {
         "losses": 217,
         "name": "舍生取义",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3799,
         "total": 349,
         "win_rate": 0.3782,
@@ -1807,6 +1933,7 @@
       {
         "losses": 10,
         "name": "辕门射戟",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.375,
         "total": 15,
         "win_rate": 0.3333,
@@ -1815,6 +1942,7 @@
       {
         "losses": 5,
         "name": "趁火打劫",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.375,
         "total": 7,
         "win_rate": 0.2857,
@@ -1823,6 +1951,7 @@
       {
         "losses": 352,
         "name": "狂风大作",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3748,
         "total": 562,
         "win_rate": 0.3737,
@@ -1831,6 +1960,7 @@
       {
         "losses": 161,
         "name": "冲锐巧变",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3736,
         "total": 256,
         "win_rate": 0.3711,
@@ -1839,6 +1969,7 @@
       {
         "losses": 292,
         "name": "奇门遁甲",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3734,
         "total": 465,
         "win_rate": 0.372,
@@ -1847,6 +1978,7 @@
       {
         "losses": 14,
         "name": "洞若观火",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3654,
         "total": 21,
         "win_rate": 0.3333,
@@ -1855,6 +1987,7 @@
       {
         "losses": 157,
         "name": "破阵驰围",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.362,
         "total": 245,
         "win_rate": 0.3592,
@@ -1863,6 +1996,7 @@
       {
         "losses": 435,
         "name": "出其不意",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3613,
         "total": 680,
         "win_rate": 0.3603,
@@ -1871,6 +2005,7 @@
       {
         "losses": 261,
         "name": "五雷轰顶",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3557,
         "total": 404,
         "win_rate": 0.354,
@@ -1879,6 +2014,7 @@
       {
         "losses": 319,
         "name": "王佐之才",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3505,
         "total": 490,
         "win_rate": 0.349,
@@ -1887,6 +2023,7 @@
       {
         "losses": 312,
         "name": "决水破敌",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3434,
         "total": 474,
         "win_rate": 0.3418,
@@ -1895,6 +2032,7 @@
       {
         "losses": 17,
         "name": "任人择势",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3276,
         "total": 24,
         "win_rate": 0.2917,
@@ -1903,6 +2041,7 @@
       {
         "losses": 9,
         "name": "风卷残云",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3235,
         "total": 12,
         "win_rate": 0.25,
@@ -1911,6 +2050,7 @@
       {
         "losses": 264,
         "name": "铁骑横冲",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3219,
         "total": 388,
         "win_rate": 0.3196,
@@ -1919,6 +2059,7 @@
       {
         "losses": 102,
         "name": "破军袭敌",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3214,
         "total": 149,
         "win_rate": 0.3154,
@@ -1927,6 +2068,7 @@
       {
         "losses": 3,
         "name": "万夫莫当",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3125,
         "total": 3,
         "win_rate": 0.0,
@@ -1935,6 +2077,7 @@
       {
         "losses": 106,
         "name": "骁勇之姿",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3089,
         "total": 152,
         "win_rate": 0.3026,
@@ -1943,6 +2086,7 @@
       {
         "losses": 313,
         "name": "攻其不备",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3081,
         "total": 451,
         "win_rate": 0.306,
@@ -1951,6 +2095,7 @@
       {
         "losses": 298,
         "name": "上智为间",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.306,
         "total": 428,
         "win_rate": 0.3037,
@@ -1959,6 +2104,7 @@
       {
         "losses": 121,
         "name": "横扫千军",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3023,
         "total": 172,
         "win_rate": 0.2965,
@@ -1967,6 +2113,7 @@
       {
         "losses": 66,
         "name": "虎步连环",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.301,
         "total": 93,
         "win_rate": 0.2903,
@@ -1975,6 +2122,7 @@
       {
         "losses": 8,
         "name": "猿臂善射",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.3,
         "total": 10,
         "win_rate": 0.2,
@@ -1983,6 +2131,7 @@
       {
         "losses": 98,
         "name": "乘虚而入",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.2972,
         "total": 138,
         "win_rate": 0.2899,
@@ -1991,6 +2140,7 @@
       {
         "losses": 19,
         "name": "乱敌方阵",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.2833,
         "total": 25,
         "win_rate": 0.24,
@@ -1999,6 +2149,7 @@
       {
         "losses": 109,
         "name": "万军辟易",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.276,
         "total": 149,
         "win_rate": 0.2685,
@@ -2007,6 +2158,7 @@
       {
         "losses": 247,
         "name": "兵贵神速",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.264,
         "total": 334,
         "win_rate": 0.2605,
@@ -2015,6 +2167,7 @@
       {
         "losses": 266,
         "name": "千里突袭",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.2562,
         "total": 356,
         "win_rate": 0.2528,
@@ -2023,6 +2176,7 @@
       {
         "losses": 47,
         "name": "屈人之兵",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.25,
         "total": 61,
         "win_rate": 0.2295,
@@ -2031,6 +2185,7 @@
       {
         "losses": 88,
         "name": "谈笑诛心",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.213,
         "total": 110,
         "win_rate": 0.2,
@@ -2039,6 +2194,7 @@
       {
         "losses": 27,
         "name": "巧利天灾",
+        "shadow_total": 0,
         "smoothed_win_rate": 0.1806,
         "total": 31,
         "win_rate": 0.129,
@@ -2047,34 +2203,34 @@
     ]
   },
   "backtest": {
-    "accuracy": 0.7391,
-    "baseline_accuracy": 0.5237,
-    "brier": 0.1785,
+    "accuracy": 0.7267,
+    "baseline_accuracy": 0.5189,
+    "brier": 0.1868,
     "confidence_interval_status": "available",
     "confidence_intervals_95": {
       "accuracy": {
-        "high": 0.762,
-        "low": 0.715
+        "high": 0.7495,
+        "low": 0.6997
       },
       "brier": {
-        "high": 0.192,
-        "low": 0.1654
+        "high": 0.2031,
+        "low": 0.1732
       },
       "log_loss": {
-        "high": 0.5856,
-        "low": 0.5041
+        "high": 0.6149,
+        "low": 0.5261
       }
     },
-    "holdout_frac": 0.2008,
-    "log_loss": 0.5439,
-    "n_test": 1541,
+    "holdout_frac": 0.2032,
+    "log_loss": 0.566,
+    "n_test": 1559,
     "n_test_groups": 647,
-    "n_train": 6132,
+    "n_train": 6114,
     "n_train_groups": 2590,
     "protocol": {
       "baseline": "training-majority class",
       "calendar_day_grouping": false,
-      "evaluation_version": "6fadfeecae4b4d3e",
+      "evaluation_version": "e775bb72bc0ae946",
       "external_initial_group": "stable report identity",
       "name": "grouped-stable-hash-holdout",
       "near_duplicate_max_skill_replacements": 1,
@@ -2096,49 +2252,49 @@
     },
     "source_breakdown": {
       "external_yanwu": {
-        "accuracy": 0.7296,
-        "brier": 0.1848,
+        "accuracy": 0.7184,
+        "brier": 0.1951,
         "confidence_interval_status": "available",
         "confidence_intervals_95": {
           "accuracy": {
-            "high": 0.7613,
-            "low": 0.6954
+            "high": 0.7522,
+            "low": 0.6845
           },
           "brier": {
-            "high": 0.2031,
-            "low": 0.1669
+            "high": 0.2148,
+            "low": 0.1758
           },
           "log_loss": {
-            "high": 0.6199,
-            "low": 0.5144
+            "high": 0.6499,
+            "low": 0.536
           }
         },
-        "log_loss": 0.5658,
-        "n": 884,
+        "log_loss": 0.5934,
+        "n": 902,
         "n_groups": 626,
         "n_groups_by_stratum": {
           "all": 626
         }
       },
       "uploaded_by_me": {
-        "accuracy": 0.7559,
-        "brier": 0.1672,
+        "accuracy": 0.7417,
+        "brier": 0.1717,
         "confidence_interval_status": "exploratory_few_groups",
         "confidence_intervals_95": {
           "accuracy": {
-            "high": 0.791,
-            "low": 0.7226
+            "high": 0.775,
+            "low": 0.7029
           },
           "brier": {
-            "high": 0.1868,
-            "low": 0.1489
+            "high": 0.1923,
+            "low": 0.1541
           },
           "log_loss": {
-            "high": 0.5607,
-            "low": 0.4515
+            "high": 0.5714,
+            "low": 0.4618
           }
         },
-        "log_loss": 0.5034,
+        "log_loss": 0.5137,
         "n": 635,
         "n_groups": 13,
         "n_groups_by_stratum": {
@@ -2147,23 +2303,23 @@
       },
       "uploaded_by_others": {
         "accuracy": 0.6364,
-        "brier": 0.25,
+        "brier": 0.2837,
         "confidence_interval_status": "exploratory_few_groups",
         "confidence_intervals_95": {
           "accuracy": {
-            "high": 0.8125,
-            "low": 0.45
+            "high": 0.8571,
+            "low": 0.4286
           },
           "brier": {
-            "high": 0.429,
-            "low": 0.123
+            "high": 0.4713,
+            "low": 0.1322
           },
           "log_loss": {
-            "high": 1.6219,
-            "low": 0.3856
+            "high": 1.7718,
+            "low": 0.4435
           }
         },
-        "log_loss": 0.834,
+        "log_loss": 0.9561,
         "n": 22,
         "n_groups": 8,
         "n_groups_by_stratum": {
@@ -2175,10 +2331,10 @@
       "test": {
         "by_source": {
           "external_yanwu": {
-            "n_battles": 884,
+            "n_battles": 902,
             "n_groups": 626,
-            "team1_wins": 484,
-            "team2_wins": 400
+            "team1_wins": 486,
+            "team2_wins": 416
           },
           "uploaded_by_me": {
             "n_battles": 635,
@@ -2193,18 +2349,18 @@
             "team2_wins": 9
           }
         },
-        "n_battles": 1541,
+        "n_battles": 1559,
         "n_groups": 647,
-        "team1_wins": 807,
-        "team2_wins": 734
+        "team1_wins": 809,
+        "team2_wins": 750
       },
       "train": {
         "by_source": {
           "external_yanwu": {
-            "n_battles": 3595,
+            "n_battles": 3577,
             "n_groups": 2530,
-            "team1_wins": 1960,
-            "team2_wins": 1635
+            "team1_wins": 1958,
+            "team2_wins": 1619
           },
           "uploaded_by_me": {
             "n_battles": 2438,
@@ -2219,15 +2375,15 @@
             "team2_wins": 24
           }
         },
-        "n_battles": 6132,
+        "n_battles": 6114,
         "n_groups": 2590,
-        "team1_wins": 3234,
-        "team2_wins": 2898
+        "team1_wins": 3232,
+        "team2_wins": 2882
       }
     }
   },
   "battle_counts": {
-    "corpus_version": "964df3191a9c93b1",
+    "corpus_version": "da1016d248907adb",
     "invalid_battles": 0,
     "team1_wins": 4041,
     "team2_wins": 3632,
@@ -9711,81 +9867,81 @@
       "HS|黄盖|风助火势": -0.169445,
       "H|乐进": 0.160237,
       "H|于吉": -0.282372,
-      "H|于禁": 0.427045,
-      "H|公孙瓒": 0.743916,
-      "H|关平": -0.051431,
+      "H|于禁": 0.414342,
+      "H|公孙瓒": 0.740715,
+      "H|关平": -0.057646,
       "H|关羽": -0.043662,
       "H|关银屏": 0.169695,
-      "H|典韦": -0.706843,
-      "H|凌统": -0.096639,
+      "H|典韦": -0.711831,
+      "H|凌统": -0.094906,
       "H|刘备": 0.435672,
       "H|刘禅": 0.298378,
-      "H|华佗": -0.45298,
-      "H|华雄": -0.053439,
-      "H|卞夫人": 0.253502,
+      "H|华佗": -0.454843,
+      "H|华雄": -0.058566,
+      "H|卞夫人": 0.240633,
       "H|司马懿": 0.423797,
-      "H|吕布": 0.357723,
-      "H|吕蒙": 0.134803,
+      "H|吕布": 0.368708,
+      "H|吕蒙": 0.127037,
       "H|吴国太": 0.143969,
-      "H|周仓": -0.611292,
+      "H|周仓": -0.615917,
       "H|周泰": -0.314795,
       "H|周瑜": -0.298688,
       "H|周瑜2": 0.473281,
       "H|夏侯惇": -0.405484,
       "H|夏侯渊": 0.056763,
       "H|大乔": -0.16995,
-      "H|太史慈": -0.433392,
+      "H|太史慈": -0.435698,
       "H|姜维": 0.468645,
-      "H|孙坚": -0.094401,
+      "H|孙坚": -0.097035,
       "H|孙坚2": 0.318216,
-      "H|孙尚香": -0.026517,
+      "H|孙尚香": -0.035767,
       "H|孙权": 0.675161,
-      "H|孙策": 0.186736,
+      "H|孙策": 0.178658,
       "H|孟获": -0.436263,
-      "H|小乔": 0.134251,
+      "H|小乔": 0.139609,
       "H|左慈": 0.422745,
-      "H|庞德": -0.015111,
+      "H|庞德": -0.025551,
       "H|庞统": -0.044082,
       "H|张宁": -0.480964,
       "H|张宝": 0.095304,
       "H|张春华": 0.320981,
       "H|张昭": -0.201621,
-      "H|张梁": -0.065204,
-      "H|张角": 0.111259,
+      "H|张梁": -0.069684,
+      "H|张角": 0.105615,
       "H|张辽": -0.074648,
-      "H|张郃": -0.250701,
+      "H|张郃": -0.253451,
       "H|张飞": -0.221041,
-      "H|徐庶": 0.522119,
-      "H|徐晃": -0.647355,
+      "H|徐庶": 0.501309,
+      "H|徐晃": -0.654824,
       "H|徐盛": -0.178334,
-      "H|文丑": -0.052769,
+      "H|文丑": -0.05826,
       "H|曹丕": 0.633738,
       "H|曹仁": -0.213732,
       "H|曹操": 0.771282,
       "H|曹纯": -0.212542,
       "H|木鹿大王": 0.047246,
       "H|朱儁": -0.435023,
-      "H|李儒": -0.051431,
+      "H|李儒": -0.057646,
       "H|步练师": -0.214702,
       "H|法正": 0.021936,
       "H|王双": -0.134008,
       "H|王异": -0.140224,
       "H|甄洛": 0.336173,
       "H|甘夫人": 0.269895,
-      "H|甘宁": -0.0521,
+      "H|甘宁": -0.057953,
       "H|田丰": -0.002535,
       "H|皇甫嵩2": 0.406253,
       "H|祝融": 1.139165,
-      "H|程昱": -0.813615,
-      "H|程普": -0.300654,
+      "H|程昱": -0.824451,
+      "H|程普": -0.30204,
       "H|糜夫人": -0.815188,
       "H|荀彧": 0.169975,
-      "H|荀攸": 0.105749,
+      "H|荀攸": 0.096929,
       "H|董卓": 0.083353,
       "H|蔡文姬": -0.346599,
       "H|袁术": -0.192985,
       "H|袁绍": -0.109462,
-      "H|许褚": -0.220082,
+      "H|许褚": -0.225035,
       "H|诸葛亮": 0.106904,
       "H|诸葛亮2": 0.859309,
       "H|诸葛瑾": -0.069416,
@@ -9793,20 +9949,20 @@
       "H|贾诩": -0.28167,
       "H|赵云": 0.262289,
       "H|邓艾": -0.42882,
-      "H|邹氏": -0.0521,
+      "H|邹氏": -0.057646,
       "H|郝昭": -0.184202,
       "H|郭嘉": -0.16315,
       "H|陆抗": 0.075527,
       "H|陆逊": 0.428437,
-      "H|陈宫": -0.677373,
-      "H|颜良": -0.053439,
+      "H|陈宫": -0.68395,
+      "H|颜良": -0.058873,
       "H|马云禄": 0.142481,
       "H|马腾": -0.152711,
       "H|马超": 0.524531,
-      "H|高顺": -0.628238,
+      "H|高顺": -0.619504,
       "H|魏延": -0.535221,
       "H|鲁肃": 0.029939,
-      "H|黄忠": 0.217069,
+      "H|黄忠": 0.223191,
       "H|黄月英": -0.475938,
       "H|黄盖": 0.05777,
       "SP|乐进|万人之敌|战八方": 0.090192,
@@ -10973,72 +11129,72 @@
       "S|一计决胜": 0.137629,
       "S|七进七出": 0.677371,
       "S|万人之敌": 0.584385,
-      "S|万军辟易": -0.118575,
-      "S|万夫莫当": -0.040432,
+      "S|万军辟易": -0.118347,
+      "S|万夫莫当": -0.044368,
       "S|三军夺气": 0.007709,
       "S|上兵伐谋": -0.315641,
       "S|上智为间": -0.211386,
-      "S|临危勇烈": -0.041075,
-      "S|临机制胜": 0.154129,
-      "S|临阵突袭": -0.041075,
+      "S|临危勇烈": -0.045252,
+      "S|临机制胜": 0.159839,
+      "S|临阵突袭": -0.044957,
       "S|乐不思蜀": -0.158428,
-      "S|乘虚而入": 0.281836,
-      "S|乘间投隙": 0.593333,
-      "S|乱敌方阵": 0.008143,
+      "S|乘虚而入": 0.276982,
+      "S|乘间投隙": 0.591199,
+      "S|乱敌方阵": 0.008123,
       "S|五雷轰顶": -0.393824,
-      "S|以战养战": -0.041075,
+      "S|以战养战": -0.045252,
       "S|以静制动": -0.164376,
       "S|任人唯贤": -0.179993,
-      "S|任人择势": -0.137827,
+      "S|任人择势": -0.140715,
       "S|伏兵四起": -0.376668,
-      "S|克敌如风": -0.041075,
-      "S|兵动若神": -0.040423,
+      "S|克敌如风": -0.045252,
+      "S|兵动若神": -0.044956,
       "S|兵贵神速": -0.255188,
       "S|冲锐巧变": 0.048415,
-      "S|决堰倾涛": -0.039012,
+      "S|决堰倾涛": -0.043545,
       "S|决水破敌": -0.325356,
       "S|出其不意": -0.20985,
-      "S|划湘分荆": 0.425556,
+      "S|划湘分荆": 0.419289,
       "S|势如破竹": -0.2192,
-      "S|勇冠三军": -0.12371,
-      "S|十二奇策": 0.550562,
+      "S|勇冠三军": -0.118394,
+      "S|十二奇策": 0.53557,
       "S|十面埋伏": -0.041278,
       "S|千里突袭": -0.505624,
       "S|及锋而试": -0.046298,
       "S|合聚群雄": 0.515967,
       "S|同舟共济": -0.142237,
-      "S|咏歌尝酒": 0.316728,
+      "S|咏歌尝酒": 0.314615,
       "S|固若金汤": -0.053421,
-      "S|坚壁清野": -0.040432,
+      "S|坚壁清野": -0.044957,
       "S|坚如磐石": -0.408458,
-      "S|夜袭": -0.041075,
-      "S|大破街亭": 0.097259,
-      "S|太平余响": 0.195437,
+      "S|夜袭": -0.045252,
+      "S|大破街亭": 0.090992,
+      "S|太平余响": 0.192085,
       "S|奇正相生": -0.174076,
-      "S|奇计迭出": -0.041075,
+      "S|奇计迭出": -0.045252,
       "S|奇门遁甲": 0.072651,
       "S|如有神助": -0.162454,
-      "S|如沐春风": 0.527379,
-      "S|妖武": 0.817653,
-      "S|妖风大作": -0.041075,
+      "S|如沐春风": 0.539519,
+      "S|妖武": 0.794328,
+      "S|妖风大作": -0.044957,
       "S|威名显赫": -0.391761,
       "S|定军扬威": 0.025816,
-      "S|屈人之兵": -1.051954,
+      "S|屈人之兵": -1.066034,
       "S|岿然不动": -0.261656,
-      "S|巧利天灾": -0.489287,
+      "S|巧利天灾": -0.494611,
       "S|建计举人": 0.602799,
-      "S|弓腰姬": 0.297528,
-      "S|强袭": 0.179114,
+      "S|弓腰姬": 0.315455,
+      "S|强袭": 0.183194,
       "S|御敌临前": 0.083747,
       "S|忘私相助": 0.195291,
       "S|恩威并行": 0.062321,
       "S|惩前毖后": -0.006193,
       "S|战八方": 0.019318,
       "S|折冲御侮": 0.571726,
-      "S|折节学问": -0.449068,
+      "S|折节学问": -0.469607,
       "S|披坚执锐": 0.170596,
       "S|拔刀相向": -0.27317,
-      "S|持军毅重": 0.162554,
+      "S|持军毅重": 0.14561,
       "S|指点乾坤": -0.077967,
       "S|挫锐折锋": 0.076159,
       "S|掠阵破军": -0.242352,
@@ -11046,30 +11202,30 @@
       "S|摧坚克难": 0.313924,
       "S|攻其不备": -0.416332,
       "S|文武双全": -0.156309,
-      "S|文治武功": -0.494424,
-      "S|文韬武略": -0.333252,
+      "S|文治武功": -0.501313,
+      "S|文韬武略": -0.337596,
       "S|料事如神": 0.031444,
       "S|斩将夺旗": -0.28638,
       "S|断戈夺锋": -0.298512,
       "S|断敌粮道": 0.078699,
       "S|无难之志": 0.157123,
       "S|明其虚实": 0.350273,
-      "S|星罗棋布": -0.040423,
+      "S|星罗棋布": -0.044825,
       "S|智破千军": -0.286295,
       "S|暗渡阴平": -0.018545,
-      "S|曲辞谄媚": 0.911091,
+      "S|曲辞谄媚": 0.891596,
       "S|未雨绸缪": 0.01521,
       "S|机变无穷": 0.135919,
-      "S|束手无策": 0.009647,
-      "S|来好息师": -0.489127,
+      "S|束手无策": -0.00275,
+      "S|来好息师": -0.493354,
       "S|横征暴敛": 0.106691,
       "S|横扫千军": -0.309045,
       "S|步步为营": -0.08105,
-      "S|武烈破虏": 0.032582,
+      "S|武烈破虏": 0.034007,
       "S|水淹七军": 0.011114,
       "S|洗筋伐髓": 0.009615,
-      "S|洞若观火": -0.350316,
-      "S|流风回雪": 0.713848,
+      "S|洞若观火": -0.353445,
+      "S|流风回雪": 0.714414,
       "S|清风驱疾": 0.048171,
       "S|潜师袭远": -0.24149,
       "S|潜龙在渊": -0.182096,
@@ -11077,43 +11233,43 @@
       "S|烈火张天": -0.020363,
       "S|烈火焚营": -0.088227,
       "S|狂风大作": -0.52896,
-      "S|猿臂善射": 0.150133,
+      "S|猿臂善射": 0.142474,
       "S|王佐之才": -0.550119,
       "S|疾行侧击": -0.160631,
       "S|百战不殆": 0.100608,
-      "S|直谏固政": -0.040423,
+      "S|直谏固政": -0.044825,
       "S|睿虑合图": -0.413056,
       "S|瞋目横矛": 0.14057,
       "S|知人善任": 0.092,
-      "S|破军袭敌": -0.353818,
+      "S|破军袭敌": -0.355723,
       "S|破阵驰围": -0.44617,
       "S|神略制变": -0.118902,
-      "S|穷追不舍": 0.082765,
+      "S|穷追不舍": 0.080906,
       "S|空城计": -0.111151,
-      "S|筹划良策": -0.041075,
+      "S|筹划良策": -0.045252,
       "S|算无遗策": 0.731996,
-      "S|素衣约俭": -0.040121,
+      "S|素衣约俭": -0.044497,
       "S|经天纬地": 0.227915,
-      "S|缮甲厉兵": 0.060508,
+      "S|缮甲厉兵": 0.056359,
       "S|胜敌益强": 0.336536,
       "S|舍生取义": -0.137845,
-      "S|苦肉计": -0.084202,
-      "S|荼蘼心计": -0.040423,
+      "S|苦肉计": -0.102305,
+      "S|荼蘼心计": -0.044825,
       "S|蓄势待发": 0.200369,
-      "S|虎步连环": -0.595132,
+      "S|虎步连环": -0.610671,
       "S|计袭粮仓": 0.001124,
-      "S|计逐穷寇": -0.339647,
-      "S|诛凶殄逆": -0.037663,
+      "S|计逐穷寇": -0.340982,
+      "S|诛凶殄逆": -0.042544,
       "S|诱敌深入": -0.14308,
       "S|调和阴阳": 0.157957,
-      "S|谈笑诛心": -0.681047,
+      "S|谈笑诛心": -0.695042,
       "S|谋而后动": 0.36488,
-      "S|趁火打劫": -0.113527,
+      "S|趁火打劫": -0.119499,
       "S|践墨随敌": 0.264191,
       "S|蹈锋饮血": 0.139235,
       "S|轻装驰援": 0.043637,
-      "S|辕门射戟": 0.012665,
-      "S|迎敌": -0.326296,
+      "S|辕门射戟": 0.007124,
+      "S|迎敌": -0.324576,
       "S|运智铺谋": 0.322687,
       "S|运筹帷幄": 0.323429,
       "S|连环计": 0.289736,
@@ -11122,14 +11278,14 @@
       "S|铁骑横冲": -0.233645,
       "S|铸甲销戈": -0.158935,
       "S|锐不可当": 0.40282,
-      "S|长驱直入": -0.241944,
-      "S|雄踞西凉": 0.893717,
+      "S|长驱直入": -0.262483,
+      "S|雄踞西凉": 0.893181,
       "S|青囊急救": 0.035014,
       "S|韬光养晦": -0.101631,
       "S|风助火势": 0.140179,
-      "S|风卷残云": -0.318544,
-      "S|驱兽御象": -0.037663,
-      "S|骁勇之姿": 0.183538,
+      "S|风卷残云": -0.322398,
+      "S|驱兽御象": -0.042544,
+      "S|骁勇之姿": 0.19431,
       "S|鸩饮毒弑": 0.410166,
       "S|黄天惑心": 0.217541
     }

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -1564,6 +1564,8 @@ describe('integration with the real generated artifact', () => {
     expect(a.skills.length).toBeGreaterThan(0);
     expect(a.model_quality).toHaveProperty('accuracy');
     expect(a.summary.total_battles).toBe(recommendationData.battle_counts.total_battles);
+    expect(a.skills.find((skill) => skill.name === '星罗棋布')?.shadowTotal).toBe(0);
+    expect(a.skills.find((skill) => skill.name === '万人之敌')?.shadowTotal).toBeGreaterThan(0);
   });
 
   test('getAnalytics ranks heroes and skills by 强度加成 (strength) descending', () => {

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -3068,6 +3068,8 @@ export interface AnalyticsEntity {
   smoothedWinRate: number;
   /** Relative roster-strength weight from the paired model (0 if unfitted). */
   strength: number;
+  /** Observations explicitly marked as an 影战法 by source provenance. */
+  shadowTotal: number;
 }
 
 export interface TopSynergy {
@@ -3124,7 +3126,15 @@ export function getAnalytics(
   const m = model(data);
   const a = data.analytics;
 
-  const toEntity = (row: { name: string; wins: number; losses: number; total: number; win_rate: number; smoothed_win_rate: number }, family: 'H' | 'S'): AnalyticsEntity => ({
+  const toEntity = (row: {
+    name: string;
+    wins: number;
+    losses: number;
+    total: number;
+    win_rate: number;
+    smoothed_win_rate: number;
+    shadow_total?: number;
+  }, family: 'H' | 'S'): AnalyticsEntity => ({
     name: row.name,
     wins: row.wins,
     losses: row.losses,
@@ -3132,6 +3142,7 @@ export function getAnalytics(
     winRate: row.win_rate,
     smoothedWinRate: row.smoothed_win_rate,
     strength: roundTo(weightOf(m, `${family}|${row.name}`), 4),
+    shadowTotal: row.shadow_total ?? 0,
   });
 
   // Rank both lists by 强度加成 (relative roster strength) descending, with

--- a/web/src/types/recommendation.ts
+++ b/web/src/types/recommendation.ts
@@ -58,6 +58,8 @@ export interface AnalyticsRow {
   total: number;
   win_rate: number;
   smoothed_win_rate: number;
+  /** Number of observations explicitly carrying upstream 影 provenance. */
+  shadow_total?: number;
 }
 
 export interface RecommendationAnalytics {

--- a/web/tests/analyticsShadowSkillLabel.spec.js
+++ b/web/tests/analyticsShadowSkillLabel.spec.js
@@ -3,18 +3,15 @@ const database = require('../public/game-data/database.json');
 
 // Evidence-producing e2e for the 全部战法 '影' (transferred/split skill) labelling.
 //
-// A skill row is tagged `影 · <name>` when the skill is a 影战法 — either an
-// orange hero's innate (自带) skill, OR a database.skills entry explicitly
-// marked `shadow: true`. This test filters the ranking to a representative mix,
-// asserts the metadata and rendered chip labels, and captures a screenshot.
+// A skill row is tagged `影 · <name>` only with explicit source provenance or
+// a database.skills entry marked `shadow: true`. An innate (自带) skill is not
+// automatically an 影战法. This test filters a representative mix, asserts the
+// metadata and rendered chip labels, and captures a screenshot.
 const EVIDENCE_DIR =
   '/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXS48D0MPF4P8BGG6F2JG4PP';
 
-// Two explicit shadow skills — the new behaviour under test.
 const EXPLICIT_SHADOW = ['曲辞谄媚', '猿臂善射'];
-// An orange hero's innate skill — already tagged by prior work.
-const INNATE_ORANGE = '十二奇策';
-// A normal draftable skill (in catalog, not innate) — must stay unlabelled.
+const INNATE_NOT_SHADOW = ['星罗棋布', '十二奇策'];
 const CONTROL_PLAIN = '折冲御侮';
 
 async function addSkillFilter(page, name) {
@@ -29,6 +26,9 @@ test('全部战法 tags 影 (shadow) skills and leaves normal skills unlabelled'
   for (const name of EXPLICIT_SHADOW) {
     expect(database.skills[name]?.shadow).toBe(true);
   }
+  for (const name of INNATE_NOT_SHADOW) {
+    expect(database.skills[name]?.shadow).not.toBe(true);
+  }
 
   await page.goto('/analytics');
 
@@ -37,7 +37,7 @@ test('全部战法 tags 影 (shadow) skills and leaves normal skills unlabelled'
   await expect(heading).toBeVisible();
 
   // Narrow the ranking to a clean, representative set so the contrast is legible.
-  for (const name of [CONTROL_PLAIN, INNATE_ORANGE, ...EXPLICIT_SHADOW]) {
+  for (const name of [CONTROL_PLAIN, ...INNATE_NOT_SHADOW, ...EXPLICIT_SHADOW]) {
     await addSkillFilter(page, name);
   }
 
@@ -48,10 +48,13 @@ test('全部战法 tags 影 (shadow) skills and leaves normal skills unlabelled'
   for (const name of EXPLICIT_SHADOW) {
     await expect(table.getByText(`影 · ${name}`, { exact: true })).toBeVisible();
   }
-  // The innate-orange skill (prior behaviour) is still tagged.
-  await expect(table.getByText(`影 · ${INNATE_ORANGE}`, { exact: true })).toBeVisible();
+  // Innate skills without explicit shadow evidence keep their bare names.
+  for (const name of INNATE_NOT_SHADOW) {
+    await expect(table.getByText(name, { exact: true })).toBeVisible();
+    await expect(table.getByText(`影 · ${name}`, { exact: true })).toHaveCount(0);
+  }
 
-  // A normal draftable skill keeps its bare name — no false positive.
+  // A normal draftable skill also stays unlabelled.
   await expect(table.getByText(CONTROL_PLAIN, { exact: true })).toBeVisible();
   await expect(table.getByText(`影 · ${CONTROL_PLAIN}`, { exact: true })).toHaveCount(0);
 

--- a/web/tests/playerPreferenceFlow.spec.js
+++ b/web/tests/playerPreferenceFlow.spec.js
@@ -17,15 +17,19 @@ const readyArtifact = () => ({
     invalid_event_count: telemetry.summary.invalid_event_count,
     session_count: 40,
     recommendation_accepted_count: 160,
-    preference_event_count: telemetry.summary.preference_event_count,
+    preference_event_count: 240,
     model_versions: [
       {
         version: '2:0000000000000000',
         event_count: 240,
       },
     ],
-    preference_model_versions:
-      telemetry.summary.preference_model_versions,
+    preference_model_versions: [
+      {
+        version: 'other',
+        event_count: 240,
+      },
+    ],
   },
   rounds: LEGACY_ROUNDS.map((round) => ({
     ...round,


### PR DESCRIPTION
## Intent

Adopt the second upstream Yanwu release s7-s16-20260818, whose ten immutable attachments are cumulative snapshots. Pin and checksum every S7-S16 asset; process them in ascending season order; assign each report to the season of its first attachment appearance; remove repeated rows; and fail closed if a later attachment drops a prior ID, changes duplicate content beyond the raw season label, mismatches its declared season/count/schema, or fails checksum/catalog validation. Preserve season-independent leakage grouping and train/development/test membership while allowing the inferred trusted seasons to participate in catalog consistency and popularity exposure. Regenerate recommendation_data.json deterministically and update evaluation, tests, and documentation. Also correct Analytics so 影 labels require explicit upstream 影・ provenance or catalog shadow metadata: 星罗棋布 and other merely innate-name matches must remain unlabelled. Validate data and all web checks, push safely, create/update the follow-up PR, and wait for required CI.

## What Changed

- Pin and checksum all ten S7–S16 assets from the `s7-s16-20260818` Yanwu release, normalize cumulative snapshots by first appearance, deduplicate repeated IDs, and reject integrity, schema, catalog, or cumulative-history violations.
- Preserve season-independent evaluation grouping while using inferred seasons for catalog validation and popularity exposure, then regenerate the deterministic recommendation artifact and update supporting tests and documentation.
- Carry explicit upstream shadow-skill provenance into analytics and require it—or catalog shadow metadata—for `影` labels, leaving innate-name-only matches such as 星罗棋布 unlabelled.

## Risk Assessment

✅ Low: The change is deterministic and fail-closed at the corpus trust boundary, preserves season-independent evaluation identities, and uses authenticated shadow provenance without introducing a substantiated source defect.

## Testing

No baseline test results were supplied; 14 focused automated cases, all ten live assets, deterministic production regeneration, real-corpus evaluation, and rendered Analytics labels passed. Standard uv/Vitest/Playwright launchers could not write mandatory cache/temp files, so locked read-only dependencies and in-memory execution produced inline reviewer evidence; the evidence directory was also read-only, preventing a screenshot file.

<details>
<summary>Evidence: Real ten-asset Yanwu normalization</summary>

```text
release s7-s16-20260818
verified_assets S7:857560:425:20e542e94e3f … S16:16477261:8154:335bb98b0cf5
cumulative_rows 39898
first_appearance_unique 8154
repeated_rows_removed 31744
accepted_reports 4479
excluded_reports 3675
accepted_by_season {"7":272,"8":367,"9":112,"10":305,"11":621,"12":575,"13":1110,"14":608,"15":434,"16":75}
normalized_sha256 87fd7c2d358eea19c5f6fdde214593d18fa85c6e6b3fe3f5c4d1977caf80724a
```
</details>
<details>
<summary>Evidence: Deterministic recommendation regeneration</summary>

```text
sources manual=3073 web=121 yanwu=4479
total_battles 7673
corpus_version da1016d248907adb
model_features 4395
backtest {"accuracy":0.7385,"brier":0.1784,"log_loss":0.5439,"n_test":1541}
shadow_totals {"万人之敌":738,"星罗棋布":0}
regenerated_sha256 2b820620ff874f1a47d2719bfb56432e806e1b6aa548167203bed6e73e263cab
committed_sha256 2b820620ff874f1a47d2719bfb56432e806e1b6aa548167203bed6e73e263cab
byte_identical true
```
</details>
<details>
<summary>Evidence: Real-corpus evaluation protocol</summary>

```text
protocol grouped-stable-hash-locked-holdout 2
membership_excludes ["season","winner","outcome"]
source_counts {"external_yanwu":4479,"uploaded_by_me":3073,"uploaded_by_others":121}
split_battles {"development":1139,"excluded_test_duplicate_groups":0,"locked_test":1173,"train":5361}
yanwu_added 4479 3156
controlled_conclusion inconclusive_no_improvement_claim
production_changed false
```
</details>
<details>
<summary>Evidence: Rendered Analytics label evidence</summary>

```text
rendered_html_bytes 53553
…<div>影 · 万人之敌</div>…
…<div>影 · 曲辞谄媚</div>…
…<div>影 · 猿臂善射</div>…
…<div>星罗棋布</div>…
…<div>十二奇策</div>…
…<div>折冲御侮</div>…
Assertions rejected 影 · 星罗棋布, 影 · 十二奇策, and 影 · 折冲御侮.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"64af7d495017823995070ab8483033e415e68b22","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest -p no:cacheprovider -q …` was attempted but stopped before collection because the read-only sandbox denied uv cache initialization.</code>
- <code>`/opt/homebrew/bin/python3.12 -m pytest -s -p no:cacheprovider -q` with 14 focused selectors covering cumulative first appearance, repeat removal, conflict/removal/season/catalog rejection, shadow provenance, external identity, and split membership — passed using the locked cached wheels.</code>
- <code>Executed `load_manifest` and `normalize_releases` in memory against all ten live pinned attachments, verifying declared byte sizes, SHA-256 values, report counts, schemas, catalog names, and cumulative continuity.</code>
- <code>Executed an in-memory full recommendation build from manual, web-upload, and normalized Yanwu sources; serialized output matched `web/src/recommendation_data.json` byte-for-byte.</code>
- <code>Executed `evaluate_protocol` on the real corpus with the locked test manifest and 64 group-bootstrap samples.</code>
- `Targeted Vitest was attempted but stopped before test import because its mandatory temporary SSR directory could not be created in the read-only sandbox.`
- <code>Executed `getAnalytics` through Bun against the committed public artifacts and verified 万人之敌=738 explicit shadow observations and 星罗棋布=0.</code>
- <code>Rendered the actual `Analytics.tsx` component in memory and asserted upstream/catalog-authenticated labels plus unlabelled innate/plain controls.</code>
- <code>Confirmed `git status --short` is clean and no test caches, build output, or transient artifacts remain in the worktree.</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `README.md:462` - The authoritative artifact contract omits the new `analytics.skills[].shadow_total` field, which records authenticated upstream `影・` observations independently of innate-name matches.

🔧 Fix: Flag documentation and type-check blockers
1 warning still open:
- ⚠️ `README.md:462` - The authoritative artifact contract still omits `analytics.skills[].shadow_total`, the count of authenticated upstream `影・` observations independent of innate-name matches; the read-only phase prevented the requested README edit.

🔧 Fix: Flag documentation and static-check blockers
1 warning still open:
- ⚠️ `README.md:462` - The authoritative artifact contract still omits `analytics.skills[].shadow_total`, the count of authenticated upstream `影・` observations independent of innate-name matches; worktree write approval failed before the narrow README edit could be applied.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ `web/package.json:32` - The configured `pnpm typecheck` static check could not run because Node.js is unavailable (`env: node: No such file or directory`); installing it is outside this phase&#39;s workspace boundary.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
