### PR TITLE
fix(web): prioritize qualified known teams and formation gain

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,14 @@ in the browser:
   gates; an absent guide hero is never inserted and makes no skill claim.
   Global conflict resolution keeps each skill unique, prefers exact 3/3 cores
   over partial 2/3 cores, and orders each guide slot's qualified alternatives
-  by model weight then support. The hero-group search retains
-  every evidence-qualified trio in the at-most-15-hero pool (at most 455)
-  before maximizing the number of disjoint complete teams; it applies no
-  gain-ranked candidate cutoff. Unsupported heroes and skills stay in the
-  warehouse for manual placement instead of being forced into a complete
-  9-hero/18-skill result.
+  by model weight then support. The hero-group search considers supported pairs
+  and trios together. It first prioritizes evidence-qualified exact 3/3 guide
+  cores that can use at least one owned, qualified canonical guide skill, then
+  ranks a bounded deterministic candidate set by fully assigned total model
+  gain before hero coverage or complete-trio count. The beam reserves the best
+  extension for every exact-guide core so a low raw-weight curated core is
+  not pruned. Unsupported heroes and skills stay in the warehouse for manual
+  placement instead of being forced into a complete 9-hero/18-skill result.
   The deterministic search runs in a client Web Worker, with a yielding
   main-thread fallback and an in-memory result cache, so it adds no Cloudflare
   Function usage and keeps the loading UI responsive. Players can then drag,

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -1286,13 +1286,22 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
       n_features: 13,
     });
 
+    const supportedGuide = makeTeamComp(
+      'supported-signs',
+      ['h0', 'h1', 'h2'],
+      [
+        [['s0'], ['s1']],
+        [['missing-0'], ['missing-1']],
+        [['missing-2'], ['missing-3']],
+      ]
+    );
     const result = recommendHybridTeams(
       heroes,
       skills,
       data,
       data.catalog,
       {},
-      []
+      [supportedGuide]
     );
     const placedHeroes = result.options[0].teams.flatMap(
       (team) => team.heroes
@@ -1421,6 +1430,194 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
 
     expect(h0?.skillSlots).toEqual(['s0', 's2']);
     expect(h0?.skills).not.toContain('s1');
+  });
+
+  test('prioritizes a usable exact guide core ahead of a stronger model-only trio', () => {
+    const exactHeroes = Array.from({ length: 9 }, (_, index) => `e${index}`);
+    const exactSkills = Array.from({ length: 18 }, (_, index) => `es${index}`);
+    const weights: Record<string, number> = {
+      'HP|e0|e1': 0,
+      'HP|e0|e2': 0,
+      'HP|e1|e2': 0,
+      'HP|e0|e3': 5,
+      'HP|e0|e4': 5,
+      'HP|e3|e4': 5,
+      'S|es0': 0,
+      'HS|e0|es0': 0,
+    };
+    const support: Record<string, number> = {
+      'HP|e0|e1': 16,
+      'HP|e0|e2': 16,
+      'HP|e1|e2': 16,
+      'HP|e0|e3': 16,
+      'HP|e0|e4': 16,
+      'HP|e3|e4': 16,
+      'S|es0': 10,
+      'HS|e0|es0': 16,
+    };
+    for (const hero of exactHeroes) {
+      weights[`H|${hero}`] = 0;
+      support[`H|${hero}`] = 10;
+    }
+    const data = makeData({
+      weights,
+      support,
+      n_features: Object.keys(weights).length,
+    });
+    const exactGuide = makeTeamComp('usable-exact', ['e0', 'e1', 'e2'], [
+      [['es0'], ['missing-0']],
+      [['missing-1'], ['missing-2']],
+      [['missing-3'], ['missing-4']],
+    ]);
+
+    const result = recommendHybridTeams(
+      exactHeroes,
+      exactSkills,
+      data,
+      data.catalog,
+      {},
+      [exactGuide]
+    );
+
+    const matched = result.options[0].teams.find(
+      ({ knownTeam }) => knownTeam?.id === 'usable-exact'
+    );
+    expect(matched?.heroes.map(({ name }) => name)).toEqual([
+      'e0',
+      'e1',
+      'e2',
+    ]);
+  });
+
+  test('ranks total formation gain ahead of the number of complete trios', () => {
+    const scoreHeroes = Array.from({ length: 9 }, (_, index) => `g${index}`);
+    const scoreSkills = Array.from({ length: 18 }, (_, index) => `gs${index}`);
+    const weights: Record<string, number> = {};
+    const support: Record<string, number> = {};
+    for (const hero of scoreHeroes) {
+      weights[`H|${hero}`] = 0;
+      support[`H|${hero}`] = 10;
+    }
+    const supportedPairs: [string, string, number][] = [
+      ['g0', 'g1', 2],
+      ['g0', 'g2', 2],
+      ['g1', 'g2', 2],
+      ['g0', 'g3', 0],
+      ['g0', 'g4', 0],
+      ['g3', 'g4', 0],
+      ['g1', 'g5', 0],
+      ['g1', 'g6', 0],
+      ['g5', 'g6', 0],
+      ['g7', 'g8', 0],
+    ];
+    for (const [first, second, weight] of supportedPairs) {
+      weights[`HP|${first}|${second}`] = weight;
+      support[`HP|${first}|${second}`] = 16;
+    }
+    const data = makeData({
+      weights,
+      support,
+      n_features: Object.keys(weights).length,
+    });
+    const unusableExactGuide = makeTeamComp(
+      'unusable-exact',
+      ['g0', 'g3', 'g4'],
+      [
+        [['missing-0'], ['missing-1']],
+        [['missing-2'], ['missing-3']],
+        [['missing-4'], ['missing-5']],
+      ]
+    );
+
+    const result = recommendHybridTeams(
+      scoreHeroes,
+      scoreSkills,
+      data,
+      data.catalog,
+      {},
+      [unusableExactGuide]
+    );
+    const teams = result.options[0].teams;
+
+    expect(
+      teams.some(
+        ({ heroes: teamHeroes }) =>
+          teamHeroes.map(({ name }) => name).sort().join('|') === 'g0|g1|g2'
+      )
+    ).toBe(true);
+    expect(
+      teams.filter(({ heroes: teamHeroes }) => teamHeroes.length === 3)
+    ).toHaveLength(1);
+    expect(
+      teams.some(
+        ({ heroes: teamHeroes }) =>
+          teamHeroes.map(({ name }) => name).sort().join('|') === 'g0|g3|g4'
+      )
+    ).toBe(false);
+  });
+
+  test('keeps the current supported exact 孟获/祝融/木鹿大王 guide core together', () => {
+    const currentHeroes = [
+      '孟获',
+      '贾诩',
+      '荀攸',
+      '吕布',
+      '张宁',
+      '木鹿大王',
+      '马云禄',
+      '赵云',
+      '朱儁',
+      '张昭',
+      '祝融',
+    ];
+    const currentSkills = [
+      '烈火焚营',
+      '计袭粮仓',
+      '十面埋伏',
+      '鸩饮毒弑',
+      '避其锐气',
+      '屈人之兵',
+      '一计决胜',
+      '穷追不舍',
+      '步步为营',
+      '烈火张天',
+      '断敌粮道',
+      '金城汤池',
+      '韬光养晦',
+      '惩前毖后',
+      '暗渡阴平',
+      '千里突袭',
+      '黄天惑心',
+      '威名显赫',
+      '兵贵神速',
+      '冲锐巧变',
+    ];
+    const heroMeta = Object.fromEntries(
+      currentHeroes.map((name) => [name, { camp: database.heroes[name].camp }])
+    );
+
+    const result = recommendHybridTeams(
+      currentHeroes,
+      currentSkills,
+      recommendationData,
+      recommendationData.catalog,
+      heroMeta,
+      database.team
+    );
+    const matched = result.options[0].teams.find(
+      ({ knownTeam }) =>
+        knownTeam?.id === 'yanwu-孟获-祝融-木鹿大王-8506bab2d533d512'
+    );
+
+    expect(matched?.formation).toBe('箕形阵');
+    expect(matched?.heroes.map(({ name }) => name)).toEqual([
+      '孟获',
+      '祝融',
+      '木鹿大王',
+    ]);
+    expect(
+      matched?.heroes.find(({ name }) => name === '孟获')?.skills
+    ).toContain('步步为营');
   });
 
   test('real model-only fallback never places a relationship below the evidence gate', () => {

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -2331,69 +2331,6 @@ interface ConfidentHeroGroup {
   mask: number;
 }
 
-interface ConfidentGroupSelection {
-  groups: ConfidentHeroGroup[];
-  gain: number;
-  support: number;
-  key: string;
-}
-
-function betterConfidentGroupSelection(
-  left: ConfidentGroupSelection,
-  right: ConfidentGroupSelection
-): boolean {
-  if (left.groups.length !== right.groups.length)
-    return left.groups.length > right.groups.length;
-  if (Math.abs(left.gain - right.gain) > 1e-9)
-    return left.gain > right.gain;
-  if (left.support !== right.support) return left.support > right.support;
-  return left.key < right.key;
-}
-
-/** Select the maximum number of disjoint confident groups, then their gain. */
-function selectConfidentHeroGroups(
-  groups: ConfidentHeroGroup[],
-  maxGroups: number
-): ConfidentHeroGroup[] {
-  if (maxGroups <= 0 || groups.length === 0) return [];
-  const memo = new Map<string, ConfidentGroupSelection>();
-  const solve = (usedMask: number, remaining: number): ConfidentGroupSelection => {
-    if (remaining === 0) return { groups: [], gain: 0, support: 0, key: '' };
-    const memoKey = `${usedMask}|${remaining}`;
-    const cached = memo.get(memoKey);
-    if (cached) return cached;
-    let best: ConfidentGroupSelection = {
-      groups: [],
-      gain: 0,
-      support: 0,
-      key: '',
-    };
-    for (const group of groups) {
-      if ((usedMask & group.mask) !== 0) continue;
-      const tail = solve(usedMask | group.mask, remaining - 1);
-      const selectedGroups = [group, ...tail.groups].sort((a, b) =>
-        a.key.localeCompare(b.key)
-      );
-      const candidate: ConfidentGroupSelection = {
-        groups: selectedGroups,
-        gain: group.gain + tail.gain,
-        support: group.support + tail.support,
-        key: selectedGroups.map(({ key }) => key).join('||'),
-      };
-      if (betterConfidentGroupSelection(candidate, best)) best = candidate;
-    }
-    memo.set(memoKey, best);
-    return best;
-  };
-  return solve(0, maxGroups).groups.sort((a, b) =>
-    b.gain !== a.gain
-      ? b.gain - a.gain
-      : b.support !== a.support
-        ? b.support - a.support
-        : a.key.localeCompare(b.key)
-  );
-}
-
 function confidentHeroGroups(
   heroes: string[],
   size: 2 | 3,
@@ -2451,9 +2388,9 @@ function confidentHeroGroups(
       ),
     });
   }
-  // The game contract caps the pool at 15 heroes (455 possible trios), so keep
-  // every qualified group. Truncating by gain here can discard the low-ranked
-  // disjoint trio needed to place the maximum number of complete teams.
+  // The game contract caps the pool at 15 heroes, so keep every qualified
+  // group. Candidate-set bounding happens only after exact guide matches have
+  // been attached, preventing a gain cutoff from discarding a curated core.
   return groups.sort((left, right) =>
     right.gain !== left.gain
       ? right.gain - left.gain
@@ -2530,6 +2467,136 @@ function bestConservativeGuideMatch(
 interface ConservativeTeamGroup {
   group: ConfidentHeroGroup;
   guide?: ConservativeGuideMatch;
+  /** Exact 3/3 guide core with at least one owned, evidence-qualified guide slot. */
+  prioritizedExactGuide: boolean;
+}
+
+interface ConservativeGroupSelection {
+  groups: ConservativeTeamGroup[];
+  usedMask: number;
+  exactGuideIds: string[];
+  heroGain: number;
+  heroSupport: number;
+  heroesPlaced: number;
+  completeTrios: number;
+  key: string;
+}
+
+/**
+ * Keep the mixed pair/trio search bounded while reserving the best extension
+ * for every exact-guide core. The final winner is chosen only after the
+ * globally unique skill assignment has produced a full model score.
+ */
+const CONSERVATIVE_SELECTION_BEAM_CAP = 64;
+
+const exactGuideIdsFor = (groups: ConservativeTeamGroup[]): string[] =>
+  groups
+    .filter(({ prioritizedExactGuide }) => prioritizedExactGuide)
+    .map(({ guide }) => guide!.comp.id)
+    .sort();
+
+function makeConservativeGroupSelection(
+  groups: ConservativeTeamGroup[],
+  usedMask: number
+): ConservativeGroupSelection {
+  const ordered = [...groups].sort((left, right) =>
+    left.group.key.localeCompare(right.group.key)
+  );
+  return {
+    groups: ordered,
+    usedMask,
+    exactGuideIds: exactGuideIdsFor(ordered),
+    heroGain: ordered.reduce((sum, { group }) => sum + group.gain, 0),
+    heroSupport: ordered.reduce((sum, { group }) => sum + group.support, 0),
+    heroesPlaced: ordered.reduce(
+      (sum, { group }) => sum + group.heroes.length,
+      0
+    ),
+    completeTrios: ordered.filter(({ group }) => group.heroes.length === 3)
+      .length,
+    key: ordered.map(({ group }) => group.key).join('||'),
+  };
+}
+
+/** Proxy ordering for the bounded search; final ordering uses assigned skills. */
+function compareConservativeSelectionProxy(
+  left: ConservativeGroupSelection,
+  right: ConservativeGroupSelection
+): number {
+  if (left.exactGuideIds.length !== right.exactGuideIds.length)
+    return right.exactGuideIds.length - left.exactGuideIds.length;
+  if (Math.abs(left.heroGain - right.heroGain) > 1e-9)
+    return right.heroGain - left.heroGain;
+  if (left.heroesPlaced !== right.heroesPlaced)
+    return right.heroesPlaced - left.heroesPlaced;
+  if (left.completeTrios !== right.completeTrios)
+    return right.completeTrios - left.completeTrios;
+  if (left.heroSupport !== right.heroSupport)
+    return right.heroSupport - left.heroSupport;
+  return left.key.localeCompare(right.key);
+}
+
+function capConservativeSelections(
+  selections: ConservativeGroupSelection[]
+): ConservativeGroupSelection[] {
+  const ordered = [...selections].sort(compareConservativeSelectionProxy);
+  if (ordered.length <= CONSERVATIVE_SELECTION_BEAM_CAP) return ordered;
+
+  // A low raw-weight exact team must not disappear merely because a different
+  // exact or model-only core sorts above it. Keep one best extension containing
+  // every exact guide ID, then fill the remaining beam by proxy strength. The
+  // reserve is still bounded by the at-most-455 qualified trios in a 15-hero
+  // pool, rather than by the combinatorial number of guide-ID sets.
+  const reserved = new Map<string, ConservativeGroupSelection>();
+  for (const selection of ordered) {
+    for (const guideId of selection.exactGuideIds) {
+      if (!reserved.has(guideId)) reserved.set(guideId, selection);
+    }
+  }
+  const picked = [...new Map(
+    [...reserved.values()].map((selection) => [selection.key, selection])
+  ).values()];
+  const pickedKeys = new Set(picked.map(({ key }) => key));
+  for (const selection of ordered) {
+    if (picked.length >= Math.max(CONSERVATIVE_SELECTION_BEAM_CAP, reserved.size))
+      break;
+    if (pickedKeys.has(selection.key)) continue;
+    picked.push(selection);
+    pickedKeys.add(selection.key);
+  }
+  return picked.sort(compareConservativeSelectionProxy);
+}
+
+/** Enumerate bounded, disjoint selections of one to three mixed pairs/trios. */
+function enumerateConservativeGroupSelections(
+  candidateGroups: ConservativeTeamGroup[]
+): ConservativeGroupSelection[] {
+  const candidates = [...candidateGroups].sort((left, right) =>
+    left.group.key.localeCompare(right.group.key)
+  );
+  let frontier: ConservativeGroupSelection[] = [
+    makeConservativeGroupSelection([], 0),
+  ];
+  const selections: ConservativeGroupSelection[] = [];
+
+  for (let depth = 0; depth < 3; depth += 1) {
+    const nextByKey = new Map<string, ConservativeGroupSelection>();
+    for (const selection of frontier) {
+      for (const candidate of candidates) {
+        if ((selection.usedMask & candidate.group.mask) !== 0) continue;
+        const extended = makeConservativeGroupSelection(
+          [...selection.groups, candidate],
+          selection.usedMask | candidate.group.mask
+        );
+        nextByKey.set(extended.key, extended);
+      }
+    }
+    frontier = capConservativeSelections([...nextByKey.values()]);
+    if (frontier.length === 0) break;
+    selections.push(...frontier);
+  }
+
+  return selections;
 }
 
 interface ConservativeHeroPlacement {
@@ -2833,6 +2900,101 @@ function assignConservativeSkills(
   return assigned;
 }
 
+interface EvaluatedConservativeSelection {
+  selection: ConservativeGroupSelection;
+  teamGroups: ConservativeTeamGroup[];
+  skillAssignments: Map<string, ConservativeSkillSlots>;
+  totalFormationGain: number;
+  exactChampionshipTeams: number;
+  exactRankingScore: number;
+}
+
+const orderConservativeTeamGroups = (
+  groups: ConservativeTeamGroup[]
+): ConservativeTeamGroup[] =>
+  [...groups].sort((left, right) =>
+    right.group.gain !== left.group.gain
+      ? right.group.gain - left.group.gain
+      : left.group.key.localeCompare(right.group.key)
+  );
+
+function evaluateConservativeSelection(
+  selection: ConservativeGroupSelection,
+  skills: string[],
+  m: PairedModel,
+  catalog: RecommendationCatalog
+): EvaluatedConservativeSelection {
+  const teamGroups = orderConservativeTeamGroups(selection.groups);
+  const skillAssignments = assignConservativeSkills(
+    teamGroups,
+    skills,
+    m,
+    catalog
+  );
+  const totalFormationGain = teamGroups.reduce(
+    (sum, { group }) =>
+      sum +
+      scoreTeam(
+        group.heroes.map((name) => ({
+          name,
+          skills: (skillAssignments.get(name) ?? [null, null]).filter(
+            (skill): skill is string => skill !== null
+          ),
+        })),
+        m
+      ),
+    0
+  );
+  const exactGroups = teamGroups.filter(
+    ({ prioritizedExactGuide }) => prioritizedExactGuide
+  );
+  return {
+    selection,
+    teamGroups,
+    skillAssignments,
+    totalFormationGain,
+    exactChampionshipTeams: exactGroups.filter(({ guide }) =>
+      isChampionshipComp(guide!.comp)
+    ).length,
+    exactRankingScore: exactGroups.reduce(
+      (sum, { guide }) => sum + teamRankingScore(guide!.comp.ranking),
+      0
+    ),
+  };
+}
+
+/**
+ * Final conservative ordering: usable exact guides and fully assigned model
+ * strength both outrank how many heroes happened to fit into complete trios.
+ */
+function compareEvaluatedConservativeSelections(
+  left: EvaluatedConservativeSelection,
+  right: EvaluatedConservativeSelection
+): number {
+  if (
+    left.selection.exactGuideIds.length !==
+    right.selection.exactGuideIds.length
+  ) {
+    return (
+      right.selection.exactGuideIds.length -
+      left.selection.exactGuideIds.length
+    );
+  }
+  if (Math.abs(left.totalFormationGain - right.totalFormationGain) > 1e-9)
+    return right.totalFormationGain - left.totalFormationGain;
+  if (left.exactChampionshipTeams !== right.exactChampionshipTeams)
+    return right.exactChampionshipTeams - left.exactChampionshipTeams;
+  if (left.exactRankingScore !== right.exactRankingScore)
+    return right.exactRankingScore - left.exactRankingScore;
+  if (left.selection.heroesPlaced !== right.selection.heroesPlaced)
+    return right.selection.heroesPlaced - left.selection.heroesPlaced;
+  if (left.selection.completeTrios !== right.selection.completeTrios)
+    return right.selection.completeTrios - left.selection.completeTrios;
+  if (left.selection.heroSupport !== right.selection.heroSupport)
+    return right.selection.heroSupport - left.selection.heroSupport;
+  return left.selection.key.localeCompare(right.selection.key);
+}
+
 function buildConfidentTeamEvidence(
   team: AssignedHero[],
   m: PairedModel
@@ -2867,10 +3029,13 @@ function buildConfidentTeamEvidence(
 /**
  * Evidence-only Team Builder policy. Every placed hero, skill, and relationship
  * must clear the model's fitted support floor. Positive, zero, and negative
- * weights all remain eligible and affect ranking. Guide data preserves a
- * qualified 2/3 or 3/3 core's canonical hero slots and formation, then reserves
- * owned, qualified guide skills for matched heroes before model-only fallback;
- * it never places an absent guide hero or bypasses the evidence gates.
+ * weights all remain eligible and affect ranking. Supported exact 3/3 guide
+ * cores with at least one qualified owned guide skill are prioritized first;
+ * fully assigned total model gain then ranks mixed pair/trio formations ahead
+ * of complete-team count. Guide data preserves a qualified 2/3 or 3/3 core's
+ * canonical hero slots and formation, then reserves owned, qualified guide
+ * skills for matched heroes before model-only fallback; it never places an
+ * absent guide hero or bypasses the evidence gates.
  */
 function recommendConservativeHybridTeams(
   heroPool: string[],
@@ -2888,40 +3053,36 @@ function recommendConservativeHybridTeams(
   const boundedHeroes = [...heroes]
     .sort()
     .slice(0, FORMATION_HERO_POOL_CAP);
-  const trios = selectConfidentHeroGroups(
-    confidentHeroGroups(boundedHeroes, 3, m),
-    3
-  );
-  const trioHeroes = new Set(trios.flatMap(({ heroes: group }) => group));
-  const pairPool = boundedHeroes.filter((hero) => !trioHeroes.has(hero));
-  const pairs = selectConfidentHeroGroups(
-    confidentHeroGroups(pairPool, 2, m),
-    3 - trios.length
-  );
   const skillSet = new Set(skills);
-  const teamGroups: ConservativeTeamGroup[] = [...trios, ...pairs]
-    .sort((left, right) =>
-      right.gain !== left.gain
-        ? right.gain - left.gain
-        : left.key.localeCompare(right.key)
-    )
-    .map((group) => ({
+  const candidateGroups: ConservativeTeamGroup[] = [
+    ...confidentHeroGroups(boundedHeroes, 3, m),
+    ...confidentHeroGroups(boundedHeroes, 2, m),
+  ].map((group) => {
+    const guide = bestConservativeGuideMatch(
+      group.heroes,
+      teamComps,
+      skillSet,
+      catalog,
+      m
+    );
+    return {
       group,
-      guide: bestConservativeGuideMatch(
-        group.heroes,
-        teamComps,
-        skillSet,
-        catalog,
-        m
-      ),
-    }));
-
-  const skillAssignments = assignConservativeSkills(
-    teamGroups,
-    skills,
-    m,
-    catalog
-  );
+      guide,
+      prioritizedExactGuide:
+        guide !== undefined &&
+        guide.matchedHeroes.length === 3 &&
+        guide.potentialSkillSlots > 0,
+    };
+  });
+  const evaluated = enumerateConservativeGroupSelections(candidateGroups)
+    .map((selection) =>
+      evaluateConservativeSelection(selection, skills, m, catalog)
+    )
+    .sort(compareEvaluatedConservativeSelections);
+  const winner = evaluated[0];
+  const teamGroups = winner?.teamGroups ?? [];
+  const skillAssignments =
+    winner?.skillAssignments ?? new Map<string, ConservativeSkillSlots>();
   const teams: ProjectedTeam[] = teamGroups.map(({ group, guide }) => {
     const placements = placeConservativeTeamHeroes(group.heroes, guide);
     const assignedHeroes: AssignedHero[] = placements.map(({ name }) => ({

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -738,7 +738,7 @@ test.describe('Team Builder mobile placement', () => {
       .poll(() => poolHeroButtons.count(), { timeout: 30000 })
       .toBeGreaterThanOrEqual(8);
     await expect(page.getByTestId('recommendation-warning')).toHaveText(
-      '部分战法未通过证据量门槛，已保留空位。'
+      '部分武将或战法未通过证据量门槛，已保留空位。'
     );
     await expect(page.getByTestId('recommendation-warning')).toHaveClass(
       /MuiAlert-standardWarning/


### PR DESCRIPTION
## Intent

Prioritize evidence-qualified exact known-team matches, or otherwise total fully assigned formation gain, ahead of the number of complete trios in the Team Builder. Keep H/HP and S/HS evidence gates intact; only give exact 3/3 guide cores primary priority when at least one owned canonical guide skill has a supported route. Consider supported pairs and trios jointly, preserve unique skill assignment and canonical guide slots/formations, remain deterministic and bounded for up to 15 heroes, and specifically keep the supplied 孟获 + 祝融 + 木鹿大王 S-ranked 箕形阵 core together with 步步为营 on 孟获 when available.

## What Changed

- Jointly search evidence-qualified hero pairs and trios with a bounded deterministic beam, prioritizing usable exact 3/3 guide cores before fully assigned formation gain and complete-trio count.
- Retain H/HP and S/HS evidence gates, unique skill assignment, and canonical guide routing, including the 孟获/祝融/木鹿大王 箕形阵 core with 步步为营 on 孟获.
- Document the revised selection policy and add regression coverage for exact-guide priority, gain-first ranking, and the supplied known-team lineup.

## Risk Assessment

🚨 High: The implementation satisfies the supplied fixture but leaves a reachable valid-pool path that contradicts an explicit required skill assignment, so it should not merge without resolving or explicitly approving that conflict policy.

## Testing

The canonical test command was initially blocked by missing Node dependencies and the read-only phase sandbox, but the equivalent focused Vitest slices passed through the existing package store and executable Team Builder checks demonstrated both the supplied production roster and assigned-gain priority; no screenshot was captured because the browser runtime was unavailable and evidence-file writes were denied.

<details>
<summary>Evidence: Production-data Team Builder recommendation</summary>

```text
{"knownTeam":"yanwu-孟获-祝融-木鹿大王-8506bab2d533d512","ranking":"S","formation":"箕形阵","heroes":["孟获","祝融","木鹿大王"],"孟获技能":["步步为营","断敌粮道"],"allAssignedSkillsUnique":true}
```
</details>
<details>
<summary>Evidence: Assigned-gain priority scenario</summary>

```text
A feasible lower-gain three-trio formation was rejected for a two-trio result whose supported HS|x|s0 assignment supplied the higher total formation gain, demonstrating that assigned gain outranks complete-trio count.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d838b53e7c7faa19a7ef96ca7f25f70359082f55","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `web/src/services/recommendationEngine.ts:3071` - The required criterion says to “specifically keep the supplied 孟获 + 祝融 + 木鹿大王 S-ranked 箕形阵 core together with 步步为营 on 孟获 when available,” but this hunk marks exact cores as prioritized before global skill matching. A valid pool can also contain the database’s exact championship 司马懿/曹操/曹丕 core, whose 曹操 slot claims the same owned skill; all relevant H/HP and both S/HS routes clear the current evidence floors. The championship tie-break then assigns 步步为营 to 曹操, leaving 孟获 without it while both cores remain primary. Confirm that the mandated 孟获 route should win this conflict, then carry that priority into the shared guide-slot matching boundary while retaining unique assignment.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t &#39;recommendHybridTeams — evidence-only partial placement&#39;` (setup-only failure before test loading: Node/dependencies unavailable).</code>
- <code>Focused Vitest selector `recommendHybridTeams — evidence-only partial placement`, run programmatically with the repository’s virtual database consumer and filesystem cache disabled; exercised H/HP and S/HS gates, supported pairs/trios, usable exact-guide priority, assigned-gain ordering, 15-hero bounding, and deterministic fallback.</code>
- <code>Focused `src/services/__tests__/teamBuilderMessaging.test.ts` through the same programmatic Vitest runner.</code>
- <code>Executable `recommendHybridTeams(...)` call using the supplied roster, production `recommendation_data.json`, and production guide database; asserted S rank, 箕形阵, canonical hero slots, 步步为营 on 孟获, and globally unique skills.</code>
- <code>Synthetic executable `recommendHybridTeams(...)` scenario proving a supported HS skill route’s assigned gain outranks a feasible formation containing more complete trios.</code>
- `Attempted rendered UI evidence via the local dev-server/browser path; no server was available and the read-only sandbox rejected locked dependency installation and evidence-directory writes.`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `web/src/services/recommendationEngine.ts:2418` - The refactor now annotates every evidence-qualified candidate pair/trio before final selection, so “already model-selected” is stale. Replace it with “evidence-qualified”; the read-only workspace rejected the edit.

🔧 Fix: Clarify Team Builder guide annotation
1 info still open:
- ℹ️ `web/src/services/recommendationEngine.ts:2418` - The requested behavior-preserving correction remains blocked: change “already model-selected” to “evidence-qualified”. Both the patch tool and escalated apply_patch failed because this worktree is read-only.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ `web/package.json:32` - The configured `pnpm typecheck` could not run because dependencies are absent and pnpm cannot create its install temporary file in the read-only worktree. `git diff --check` passed; rerun type-checking in a writable environment with dependencies available.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
