### PR TITLE
feat(web): show model-weight analytics rankings

### DIFF
--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -294,8 +294,8 @@ const TelemetryAnalyticsSection = ({
       </Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
         匿名选项统计汇总玩家使用本工具时的匿名选择：它只记录游戏每轮三组选项中提供了哪些武将、
-        战法，以及玩家最终选择了什么，不重复计算已有阵容。这里展示的是选择次数和倾向，不是胜率，
-        也不会改变 AI 的阵容评分推荐。
+        战法，以及玩家最终选择了什么，不重复计算已有阵容。这里展示的是选择次数和倾向，
+        不代表武将、战法的模型强度，也不会改变 AI 的阵容评分推荐。
       </Typography>
 
       <Grid container spacing={2.5}>
@@ -377,17 +377,17 @@ const Analytics = () => {
   const hasHeroFilter = selectedHeroes.length > 0;
   const hasSkillFilter = selectedSkills.length > 0;
 
-  // Rank the individual hero/skill tables by 胜率参考 (smoothed win rate) descending,
+  // Rank the individual hero/skill tables by fitted model weight descending,
   // with deterministic tie-breakers (reference battles desc, then name). This is a
   // display-only ordering; the underlying data.heroes/data.skills stay untouched.
-  const byWinRate = <T extends { smoothedWinRate: number; total: number; name: string }>(a: T, b: T): number =>
-    b.smoothedWinRate - a.smoothedWinRate || b.total - a.total || a.name.localeCompare(b.name, 'zh-Hans-CN');
+  const byStrength = <T extends { strength: number; total: number; name: string }>(a: T, b: T): number =>
+    b.strength - a.strength || b.total - a.total || a.name.localeCompare(b.name, 'zh-Hans-CN');
   // Ranks (排名) are always computed against the *full* sorted list so that when a
   // search filter is applied the rows keep their true position (e.g. 排名 42) instead
   // of restarting at 1. We build a name/label -> rank lookup from the full ordering,
   // then filter for display without disturbing the rank shown per row.
-  const sortedHeroes = data.heroes.slice().sort(byWinRate);
-  const sortedSkills = data.skills.slice().sort(byWinRate);
+  const sortedHeroes = data.heroes.slice().sort(byStrength);
+  const sortedSkills = data.skills.slice().sort(byStrength);
   const heroRankMap = new Map(sortedHeroes.map((h, i) => [h.name, i + 1]));
   const skillRankMap = new Map(sortedSkills.map((s, i) => [s.name, i + 1]));
   const heroUsageRankMap = new Map(data.hero_usage.map(([h], i) => [h, i + 1]));
@@ -484,15 +484,15 @@ const Analytics = () => {
             <Typography component="h3" variant="h6" gutterBottom>三步看懂这些数字</Typography>
             <Grid container spacing={2}>
               <Grid size={{ xs: 12, md: 4 }}>
-                <Typography variant="subtitle2" gutterBottom>1. 胜率参考</Typography>
+                <Typography variant="subtitle2" gutterBottom>1. 模型权重</Typography>
                 <Typography variant="body2" color="text.secondary">
-                  经过校正、平滑处理后的历史表现，不是直接的胜负计数。场次少时会更贴近整体平均，避免被个别对局误导。
+                  表示单个武将或战法对阵容相对强度的贡献。数值越高越值得优先考虑；它不是百分比，也不是单场胜负预测。
                 </Typography>
               </Grid>
               <Grid size={{ xs: 12, md: 4 }}>
                 <Typography variant="subtitle2" gutterBottom>2. 组合分</Typography>
                 <Typography variant="body2" color="text.secondary">
-                  仅用于下面的搭配榜，表示武将配对、武将战法组合在一起时的额外帮助。它<strong>不是</strong>胜率百分比。
+                  仅用于下面的搭配榜，表示武将配对、武将战法组合在一起时的额外帮助。它与上面的单项模型权重分开计算。
                 </Typography>
               </Grid>
               <Grid size={{ xs: 12, md: 4 }}>
@@ -563,7 +563,7 @@ const Analytics = () => {
           <Typography component="h3" variant="h5">先看谁更值得选</Typography>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          单个武将、战法按胜率参考排名。想快速挑人挑战法，从这里开始。
+          单个武将、战法按模型权重从高到低排名。想快速挑人挑战法，从这里开始。
         </Typography>
         <Grid container spacing={3} sx={{ mb: 4 }}>
           <Grid size={{ xs: 12, md: 6 }}>
@@ -571,7 +571,7 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography component="h4" variant="h6">全部武将（按胜率参考排序）</Typography>
+                  <Typography component="h4" variant="h6">全部武将（按模型权重排序）</Typography>
                 </Box>
                 <ResponsiveDisclosure label="全部武将排名">
                 <ScrollableAnalyticsTable label="全部武将排名">
@@ -580,7 +580,7 @@ const Analytics = () => {
                       <TableRow>
                         <TableCell>排名</TableCell>
                         <TableCell>武将</TableCell>
-                        <TableCell align="right">胜率参考</TableCell>
+                        <TableCell align="right">模型权重</TableCell>
                         <TableCell align="right">参考场次</TableCell>
                       </TableRow>
                     </TableHead>
@@ -589,7 +589,15 @@ const Analytics = () => {
                         <TableRow key={h.name}>
                           <TableCell>{heroRankMap.get(h.name)}</TableCell>
                           <TableCell><Chip label={h.name} color="primary" size="small" /></TableCell>
-                          <TableCell align="right">{pct(h.smoothedWinRate)}</TableCell>
+                          <TableCell
+                            align="right"
+                            sx={{
+                              color: h.strength > 0 ? 'success.main' : h.strength < 0 ? 'error.main' : 'text.secondary',
+                              fontWeight: 'bold',
+                            }}
+                          >
+                            {fmtStrength(h.strength, 4)}
+                          </TableCell>
                           <TableCell align="right">{h.total}</TableCell>
                         </TableRow>
                       ))}
@@ -606,7 +614,7 @@ const Analytics = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <EmojiEventsIcon sx={{ mr: 1, color: 'warning.main' }} />
-                  <Typography component="h4" variant="h6">全部战法（按胜率参考排序）</Typography>
+                  <Typography component="h4" variant="h6">全部战法（按模型权重排序）</Typography>
                 </Box>
                 <ResponsiveDisclosure label="全部战法排名">
                 <ScrollableAnalyticsTable label="全部战法排名">
@@ -615,7 +623,7 @@ const Analytics = () => {
                       <TableRow>
                         <TableCell>排名</TableCell>
                         <TableCell>战法</TableCell>
-                        <TableCell align="right">胜率参考</TableCell>
+                        <TableCell align="right">模型权重</TableCell>
                         <TableCell align="right">参考场次</TableCell>
                       </TableRow>
                     </TableHead>
@@ -630,7 +638,15 @@ const Analytics = () => {
                               size="small"
                             />
                           </TableCell>
-                          <TableCell align="right">{pct(s.smoothedWinRate)}</TableCell>
+                          <TableCell
+                            align="right"
+                            sx={{
+                              color: s.strength > 0 ? 'success.main' : s.strength < 0 ? 'error.main' : 'text.secondary',
+                              fontWeight: 'bold',
+                            }}
+                          >
+                            {fmtStrength(s.strength, 4)}
+                          </TableCell>
                           <TableCell align="right">{s.total}</TableCell>
                         </TableRow>
                       ))}
@@ -794,7 +810,7 @@ const Analytics = () => {
           <AccordionDetails id="data-algo-details-content">
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
               推荐来自一个成对（对手感知）逻辑回归模型，并在按时间留出的一批对局上做过检验。
-              搭配榜里的“组合分”用来横向比较不同组合，<strong>不是</strong>对某个特定对手的胜率。
+              搭配榜里的“组合分”用来横向比较不同组合，<strong>不是</strong>对某个特定对手的获胜概率。
             </Typography>
 
             <Box sx={{ mb: 2 }}>

--- a/web/src/seo/config.ts
+++ b/web/src/seo/config.ts
@@ -32,7 +32,7 @@ export const SEO_ROUTES: readonly SeoRoute[] = [
     path: '/analytics',
     title: '三国谋定天下演武数据与武将战法排行｜演武参谋',
     description:
-      '查看三国谋定天下演武的武将、战法、搭配、使用率和历史胜率参考，并按赛季与卡池筛选战报数据。',
+      '查看三国谋定天下演武的武将与战法模型权重、搭配和使用率，并按赛季与卡池筛选战报数据。',
     heading: '数据洞察',
     navLabel: '数据洞察',
     index: true,

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -3272,13 +3272,12 @@ export interface AnalyticsResult {
 /**
  * Build the Analytics-page payload from the generated artifact. The `heroes` and
  * `skills` rankings are returned sorted by descending relative roster-strength
- * (`强度加成`), with deterministic tie-breakers (descending smoothed win rate,
- * then descending reference battles, then name) so consumers can render them
- * directly. The model column still exposes each item's relative roster-strength
+ * (`强度加成`), with deterministic tie-breakers (descending reference battles,
+ * then name) so consumers can render them directly. The model column still exposes
+ * each item's full-precision relative roster-strength
  * weight, and the smoothed-win-rate / reference-battle columns remain available.
  * Usage and synergy rankings keep their own orderings. Backtest metrics surface
- * model quality. No values or model semantics are changed — only the order of
- * the hero/skill arrays.
+ * model quality.
  */
 export function getAnalytics(
   data: RecommendationData,
@@ -3302,7 +3301,7 @@ export function getAnalytics(
     total: row.total,
     winRate: row.win_rate,
     smoothedWinRate: row.smoothed_win_rate,
-    strength: roundTo(weightOf(m, `${family}|${row.name}`), 4),
+    strength: weightOf(m, `${family}|${row.name}`),
     shadowTotal: row.shadow_total ?? 0,
   });
 
@@ -3310,9 +3309,8 @@ export function getAnalytics(
   // deterministic tie-breakers so equal-strength rows are stably ordered.
   const byStrength = (x: AnalyticsEntity, y: AnalyticsEntity): number =>
     y.strength - x.strength ||
-    y.smoothedWinRate - x.smoothedWinRate ||
     y.total - x.total ||
-    x.name.localeCompare(y.name);
+    x.name.localeCompare(y.name, 'zh-Hans-CN');
 
   const heroes = a.heroes.map((r) => toEntity(r, 'H')).sort(byStrength);
   const skills = a.skills.map((r) => toEntity(r, 'S')).sort(byStrength);

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -391,10 +391,10 @@ test.describe('Accessibility and responsive layout', () => {
     await expect(
       battleSection.getByRole('heading', { name: '三步看懂这些数字' })
     ).toBeVisible();
-    await expect(battleSection.getByText('胜率参考')).not.toHaveCount(0);
+    await expect(battleSection.getByText('模型权重')).not.toHaveCount(0);
     await expect(battleSection.getByText('组合分')).not.toHaveCount(0);
     await expect(battleSection.getByText('参考场次')).not.toHaveCount(0);
-    await expect(battleSection.getByText('强度加成')).toHaveCount(0);
+    await expect(battleSection.getByText('胜率参考')).toHaveCount(0);
 
     // Actionable sections come before the optional diagnostics section.
     await expect(battleSection.getByRole('heading', { name: '先看谁更值得选' })).toBeVisible();

--- a/web/tests/analyticsSearchKeepsTrueRank.spec.js
+++ b/web/tests/analyticsSearchKeepsTrueRank.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require('@playwright/test');
+const recommendationData = require('../src/recommendation_data.json');
 
 // Evidence-producing e2e for the 排名 (rank) fix on /analytics.
 //
@@ -53,7 +54,27 @@ async function addFilter(page, placeholder, typed, optionText) {
 const HERO_PH = '输入武将名或拼音...';
 const SKILL_PH = '输入战法名或拼音...';
 
-async function expectDescendingModelWeights(page, label) {
+function expectedModelRanking(family, prefix) {
+  return recommendationData.analytics[family]
+    .map((row) => ({
+      name: row.name,
+      total: row.total,
+      weight: recommendationData.model.weights[`${prefix}|${row.name}`] ?? 0,
+    }))
+    .sort(
+      (a, b) =>
+        b.weight - a.weight ||
+        b.total - a.total ||
+        a.name.localeCompare(b.name, 'zh-Hans-CN')
+    );
+}
+
+async function expectDescendingModelWeights(
+  page,
+  label,
+  expectedRows,
+  normalizeName = (name) => name
+) {
   const tableRegion = region(page, label);
   await expect(tableRegion).toBeVisible();
   await expect(
@@ -63,15 +84,27 @@ async function expectDescendingModelWeights(page, label) {
     tableRegion.getByRole('columnheader', { name: '胜率参考', exact: true })
   ).toHaveCount(0);
 
-  const cells = tableRegion.locator('tbody tr td:nth-child(3)');
-  const values = (await cells.allInnerTexts()).map((text) => {
+  const rows = tableRegion.locator('tbody tr');
+  const names = (await rows.locator('td:nth-child(2)').allInnerTexts()).map((name) =>
+    normalizeName(name.trim())
+  );
+  const displayedWeights = (
+    await rows.locator('td:nth-child(3)').allInnerTexts()
+  ).map((text) => {
     expect(text.trim()).toMatch(/^[+-]?\d+\.\d{4}$/);
     return Number(text.trim());
   });
-  expect(values.length).toBeGreaterThan(3);
-  values.forEach((value, index) => {
-    if (index > 0) expect(values[index - 1]).toBeGreaterThanOrEqual(value);
-  });
+
+  expect(names).toEqual(expectedRows.map((row) => row.name));
+  expect(displayedWeights).toEqual(expectedRows.map((row) => Number(row.weight.toFixed(4))));
+  expect(
+    expectedRows.some(
+      (row, index) =>
+        index > 0 &&
+        expectedRows[index - 1].weight !== row.weight &&
+        expectedRows[index - 1].weight.toFixed(4) === row.weight.toFixed(4)
+    )
+  ).toBe(true);
 }
 
 test('全部武将 / 全部战法 show model weights from high to low without win rates', async ({ page }) => {
@@ -87,8 +120,17 @@ test('全部武将 / 全部战法 show model weights from high to low without wi
   await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', /模型权重/);
   await expect(page.locator('meta[name="description"]')).not.toHaveAttribute('content', /胜率/);
 
-  await expectDescendingModelWeights(page, '全部武将排名');
-  await expectDescendingModelWeights(page, '全部战法排名');
+  await expectDescendingModelWeights(
+    page,
+    '全部武将排名',
+    expectedModelRanking('heroes', 'H')
+  );
+  await expectDescendingModelWeights(
+    page,
+    '全部战法排名',
+    expectedModelRanking('skills', 'S'),
+    stripShadow
+  );
 });
 
 // For a table: read the full ordering, pick a target row whose true rank > 1,

--- a/web/tests/analyticsSearchKeepsTrueRank.spec.js
+++ b/web/tests/analyticsSearchKeepsTrueRank.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test');
 const recommendationData = require('../src/recommendation_data.json');
+const database = require('../public/game-data/database.json');
 
 // Evidence-producing e2e for the 排名 (rank) fix on /analytics.
 //
@@ -10,7 +11,7 @@ const recommendationData = require('../src/recommendation_data.json');
 // (2) applies a filter and asserts each surviving row still shows its true rank
 // (never renumbered to 1..n). It also captures screenshots for visual review.
 const EVIDENCE_DIR =
-  '/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01KXVWZ55AJHR68TTDBNJQ4RKK';
+  '/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0F8NJFBMKMMCB3Z5P6N4D8R';
 
 // Locate a ranking table by its ScrollableAnalyticsTable aria-label region.
 const region = (page, label) =>
@@ -59,6 +60,7 @@ function expectedModelRanking(family, prefix) {
     .map((row) => ({
       name: row.name,
       total: row.total,
+      shadowTotal: row.shadow_total ?? 0,
       weight: recommendationData.model.weights[`${prefix}|${row.name}`] ?? 0,
     }))
     .sort(
@@ -83,6 +85,9 @@ async function expectDescendingModelWeights(
   await expect(
     tableRegion.getByRole('columnheader', { name: '胜率参考', exact: true })
   ).toHaveCount(0);
+  await expect(
+    tableRegion.getByRole('columnheader', { name: '参考场次', exact: true })
+  ).toBeVisible();
 
   const rows = tableRegion.locator('tbody tr');
   const names = (await rows.locator('td:nth-child(2)').allInnerTexts()).map((name) =>
@@ -94,9 +99,13 @@ async function expectDescendingModelWeights(
     expect(text.trim()).toMatch(/^[+-]?\d+\.\d{4}$/);
     return Number(text.trim());
   });
+  const displayedTotals = (await rows.locator('td:nth-child(4)').allInnerTexts()).map(
+    (text) => Number(text.trim())
+  );
 
   expect(names).toEqual(expectedRows.map((row) => row.name));
   expect(displayedWeights).toEqual(expectedRows.map((row) => Number(row.weight.toFixed(4))));
+  expect(displayedTotals).toEqual(expectedRows.map((row) => row.total));
   expect(
     expectedRows.some(
       (row, index) =>
@@ -108,6 +117,7 @@ async function expectDescendingModelWeights(
 }
 
 test('全部武将 / 全部战法 show model weights from high to low without win rates', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 1200 });
   await page.goto('/analytics');
 
   await expect(
@@ -116,21 +126,39 @@ test('全部武将 / 全部战法 show model weights from high to low without wi
   await expect(
     page.getByRole('heading', { name: '全部战法（按模型权重排序）', exact: true })
   ).toBeVisible();
-  await expect(page.getByText('胜率参考', { exact: true })).toHaveCount(0);
+  await expect(page.locator('body')).not.toContainText('胜率');
   await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', /模型权重/);
   await expect(page.locator('meta[name="description"]')).not.toHaveAttribute('content', /胜率/);
 
-  await expectDescendingModelWeights(
-    page,
-    '全部武将排名',
-    expectedModelRanking('heroes', 'H')
-  );
+  const expectedHeroes = expectedModelRanking('heroes', 'H');
+  const expectedSkills = expectedModelRanking('skills', 'S');
+  await expectDescendingModelWeights(page, '全部武将排名', expectedHeroes);
   await expectDescendingModelWeights(
     page,
     '全部战法排名',
-    expectedModelRanking('skills', 'S'),
+    expectedSkills,
     stripShadow
   );
+
+  const skillLabels = await region(page, '全部战法排名')
+    .locator('tbody tr td:nth-child(2)')
+    .allInnerTexts();
+  expect(skillLabels).toEqual(
+    expectedSkills.map((row) =>
+      row.shadowTotal > 0 || database.skills[row.name]?.shadow === true
+        ? `影 · ${row.name}`
+        : row.name
+    )
+  );
+
+  const cardFor = (heading) =>
+    heading.locator('xpath=ancestor::*[contains(@class,"MuiCard-root")][1]');
+  await cardFor(
+    page.getByRole('heading', { name: '全部武将（按模型权重排序）', exact: true })
+  ).screenshot({ path: `${EVIDENCE_DIR}/analytics-model-weight-heroes.png` });
+  await cardFor(
+    page.getByRole('heading', { name: '全部战法（按模型权重排序）', exact: true })
+  ).screenshot({ path: `${EVIDENCE_DIR}/analytics-model-weight-skills.png` });
 });
 
 // For a table: read the full ordering, pick a target row whose true rank > 1,

--- a/web/tests/analyticsSearchKeepsTrueRank.spec.js
+++ b/web/tests/analyticsSearchKeepsTrueRank.spec.js
@@ -53,6 +53,44 @@ async function addFilter(page, placeholder, typed, optionText) {
 const HERO_PH = '输入武将名或拼音...';
 const SKILL_PH = '输入战法名或拼音...';
 
+async function expectDescendingModelWeights(page, label) {
+  const tableRegion = region(page, label);
+  await expect(tableRegion).toBeVisible();
+  await expect(
+    tableRegion.getByRole('columnheader', { name: '模型权重', exact: true })
+  ).toBeVisible();
+  await expect(
+    tableRegion.getByRole('columnheader', { name: '胜率参考', exact: true })
+  ).toHaveCount(0);
+
+  const cells = tableRegion.locator('tbody tr td:nth-child(3)');
+  const values = (await cells.allInnerTexts()).map((text) => {
+    expect(text.trim()).toMatch(/^[+-]?\d+\.\d{4}$/);
+    return Number(text.trim());
+  });
+  expect(values.length).toBeGreaterThan(3);
+  values.forEach((value, index) => {
+    if (index > 0) expect(values[index - 1]).toBeGreaterThanOrEqual(value);
+  });
+}
+
+test('全部武将 / 全部战法 show model weights from high to low without win rates', async ({ page }) => {
+  await page.goto('/analytics');
+
+  await expect(
+    page.getByRole('heading', { name: '全部武将（按模型权重排序）', exact: true })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: '全部战法（按模型权重排序）', exact: true })
+  ).toBeVisible();
+  await expect(page.getByText('胜率参考', { exact: true })).toHaveCount(0);
+  await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', /模型权重/);
+  await expect(page.locator('meta[name="description"]')).not.toHaveAttribute('content', /胜率/);
+
+  await expectDescendingModelWeights(page, '全部武将排名');
+  await expectDescendingModelWeights(page, '全部战法排名');
+});
+
 // For a table: read the full ordering, pick a target row whose true rank > 1,
 // apply the given filter, then assert every surviving row keeps its full-list
 // rank (and specifically that the target's true rank is shown, not 1).


### PR DESCRIPTION
## Intent

Update https://sanmouyanwu.com/analytics so the 全部武将 and 全部战法 reference rankings display each hero's or skill's fitted model weight instead of historical win rates, sort both lists from highest model weight to lowest, preserve true full-list ranks when filtering, and remove win-rate wording from the analytics page and its SEO description. Keep reference battle counts and the existing shadow-skill labels, and do not regenerate or alter the recommendation model artifact.

## What Changed
- Display fitted model weights for hero and skill reference rankings, sorted highest to lowest using full-precision values while retaining reference battle counts and shadow-skill labels.
- Preserve full-list ranks when filtering and update analytics guidance and SEO copy to remove win-rate wording.
- Expand Playwright coverage for model-weight ordering, displayed values, labels, SEO metadata, and filtered ranks.

## Risk Assessment

✅ Low: The change is well-bounded, uses full-precision model coefficients for ordering while rounding only for display, preserves full-list ranks, counts, and shadow labels, removes win-rate wording, and leaves the model artifact unchanged.

## Testing

No baseline test output was supplied; after correcting two initial root-directory pnpm invocations and a test-only catalog-shadow expectation, targeted Vitest and end-to-end Playwright checks succeeded, visual evidence was inspected, and the recommendation artifact was confirmed unchanged; broad suites, builds, linting, and static analysis were intentionally not run in this targeted test phase.

- Evidence: 全部武将 model-weight ranking with reference battle counts (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0F8NJFBMKMMCB3Z5P6N4D8R/analytics-model-weight-heroes.png</code>)
- Evidence: 全部战法 model-weight ranking with reference counts and 影 labels (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0F8NJFBMKMMCB3Z5P6N4D8R/analytics-model-weight-skills.png</code>)
- Evidence: Filtered hero retains true full-list rank 5 (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0F8NJFBMKMMCB3Z5P6N4D8R/analytics-rank-heroes.png</code>)
- Evidence: Filtered shadow skill retains true full-list rank 5 (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0F8NJFBMKMMCB3Z5P6N4D8R/analytics-rank-skills.png</code>)
<details>
<summary>Evidence: Recommendation model artifact integrity</summary>

```text
base 724e18d5f9c66e2f1e862f865a08fe1511fe64eee4dece09a73fa03a832aeaee
target 724e18d5f9c66e2f1e862f865a08fe1511fe64eee4dece09a73fa03a832aeaee
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e8a56c8fd1ebb5c568844facd5204c508505b424","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `web/src/pages/Analytics.tsx:384` - The required criterion says to “sort both lists from highest model weight to lowest,” but this comparator receives `strength` values already rounded to four decimals by `getAnalytics`, then breaks collapsed ties using reference counts (`b.total - a.total`). This reverses real coefficients in the current artifact: 田丰 (-0.017623) appears before the stronger 庞德 (-0.017587), and 奇正相生 (-0.170284) before the stronger 任人唯贤 (-0.170263). Expose the raw coefficient from `getAnalytics`, sort on it, and round only when rendering; the new E2E assertion currently misses this because it compares the same rounded display values.

🔧 Fix: Sort analytics rankings by full-precision model weights
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t &#39;getAnalytics&#39;` — exercised analytics payload ordering and model-strength behavior.</code>
- <code>`cd web &amp;&amp; pnpm exec playwright test tests/analyticsSearchKeepsTrueRank.spec.js --grep &#39;全部武将 / 全部战法 (show|keep)&#39; --workers=1` — verified both complete lists use fitted weights in descending full-precision order, retain reference counts and shadow labels, omit win-rate wording, expose the updated SEO description, and preserve full-list ranks after filtering.</code>
- <code>`cd web &amp;&amp; pnpm exec playwright test tests/analyticsSearchKeepsTrueRank.spec.js --grep &#39;show model weights&#39; --workers=1` — regenerated unobstructed reviewer-visible ranking screenshots after increasing the evidence viewport.</code>
- <code>`git diff --quiet bfa7e2cf43db7f32a73f7d7fb4809a3cb3af2db2 1c6e29dff75867b314b871c6672f41851281f9a8 -- web/src/recommendation_data.json` and SHA-256 comparison — confirmed the recommendation model artifact is byte-identical to the base version.</code>
- `Manually inspected the generated hero, skill, and filtered-ranking screenshots for visible model-weight columns, descending ranks, reference battle counts, shadow-skill labels, and preserved rank 5 filtering examples.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
