### PR TITLE
feat(web): expose recommendation debug context

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -491,8 +491,12 @@ ranked scores, every activated model feature, support counts, skill-to-hero
 routing alternatives, and the separately labelled player-choice prediction.
 On Team Builder, it contains evidence gates, relevant guide routes, the selected
 teams' complete score rows, unplaced-item diagnostics, the original recommendation
-versus the edited layout, and a compact winner/runner-up optimiser trace. The
-trace is diagnostic only and does not change recommendation ranking.
+versus the edited layout, and a compact winner/runner-up optimiser trace. Each
+traced guide decision records the selected and rejected matches with the exact
+hero-count, qualified-skill-slot, championship, ranking, and stable-ID tie-break
+fields. Unplaced skills separate qualified routes to selected heroes from routes
+that exist only through unplaced heroes. The trace is diagnostic only and does
+not change recommendation ranking.
 
 The export is generated locally from data already loaded by the page. It does
 not upload anything and deliberately excludes telemetry/session identifiers,

--- a/web/README.md
+++ b/web/README.md
@@ -494,9 +494,12 @@ teams' complete score rows, unplaced-item diagnostics, the original recommendati
 versus the edited layout, and a compact winner/runner-up optimiser trace. Each
 traced guide decision records the selected and rejected matches with the exact
 hero-count, qualified-skill-slot, championship, ranking, and stable-ID tie-break
-fields. Unplaced skills separate qualified routes to selected heroes from routes
-that exist only through unplaced heroes. The trace is diagnostic only and does
-not change recommendation ranking.
+fields. It also records each bounded-search depth's proxy cutoff and exact-guide
+reservations, then carries the guide maximum matching and each selected model
+skill route with its strongest rejected routes, gain/support ordering, and guide-slot
+placement effect. Unplaced skills separate qualified routes to selected heroes
+from routes that exist only through unplaced heroes. The trace is diagnostic only
+and does not change recommendation ranking.
 
 The export is generated locally from data already loaded by the page. It does
 not upload anything and deliberately excludes telemetry/session identifiers,

--- a/web/README.md
+++ b/web/README.md
@@ -44,6 +44,10 @@ the model data is generated and community reports are imported.
   repair (or direct manual confirmation), strict final validation, current-model
   lineup scores, a separate contribution-season cookie, and a daily static
   contributor leaderboard at `/contributors`
+- **Recommendation debugging**: The draft recommendation and Team Builder
+  pages expose a local, read-only `sanmouDebug()` browser-console export with
+  the current inputs, exact feature weights/evidence, decision policy, and
+  compact formation alternatives for agent-assisted diagnosis
 - **Responsive Design**: Works on desktop, tablet, and mobile devices
 
 ## Tech Stack
@@ -467,6 +471,33 @@ JavaScript. The browser hydrates that same markup for client-side navigation
 and interaction; no runtime Node server is required on Cloudflare Pages.
 
 ## Development Notes
+
+### Recommendation debug context
+
+After calculating a draft recommendation or waiting for `/team-builder` to
+finish, open the browser developer console and run:
+
+```js
+copy(sanmouDebug())
+```
+
+`sanmouDebug()` logs the structured context and returns the same value as
+pretty-printed JSON, while Chrome DevTools' `copy(...)` helper places it on the
+clipboard. Paste that JSON into an agent together with the result you expected.
+For example: “I expected option A instead of B; explain why B won.”
+
+On the draft page, the export contains the current pool and offers, all three
+ranked scores, every activated model feature, support counts, skill-to-hero
+routing alternatives, and the separately labelled player-choice prediction.
+On Team Builder, it contains evidence gates, relevant guide routes, the selected
+teams' complete score rows, unplaced-item diagnostics, the original recommendation
+versus the edited layout, and a compact winner/runner-up optimiser trace. The
+trace is diagnostic only and does not change recommendation ranking.
+
+The export is generated locally from data already loaded by the page. It does
+not upload anything and deliberately excludes telemetry/session identifiers,
+cookies, unrelated local storage, and the full battle corpus/model maps. Calling
+it before a recommendation is ready returns a `not-ready` explanation instead.
 
 ### Pinyin Search
 Chinese hero and skill names can be searched using pinyin romanization for easier input.

--- a/web/README.md
+++ b/web/README.md
@@ -487,15 +487,17 @@ clipboard. Paste that JSON into an agent together with the result you expected.
 For example: “I expected option A instead of B; explain why B won.”
 
 On the draft page, the export contains the current pool and offers, all three
-ranked scores, every activated model feature, support counts, skill-to-hero
-routing alternatives, and the separately labelled player-choice prediction.
+ranked scores, every activated model feature, support counts, the authoritative
+skill-to-hero route order (including the current-pool-order tie-break for equal
+HS weights), and the separately labelled player-choice prediction.
 On Team Builder, it contains evidence gates, relevant guide routes, the selected
 teams' complete score rows, unplaced-item diagnostics, the original recommendation
 versus the edited layout, and a compact winner/runner-up optimiser trace. Each
 traced guide decision records the selected and rejected matches with the exact
 hero-count, qualified-skill-slot, championship, ranking, and stable-ID tie-break
 fields. It also records each bounded-search depth's proxy cutoff and exact-guide
-reservations, then carries the guide maximum matching and each selected model
+reservations, then carries the guide maximum-cardinality objective, occupied-skill
+conflicts, augmenting owner moves, final slot assignments, and each selected model
 skill route with its strongest rejected routes, gain/support ordering, and guide-slot
 placement effect. Unplaced skills separate qualified routes to selected heroes
 from routes that exist only through unplaced heroes. The trace is diagnostic only

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Container, Box, Button, Alert, CircularProgress, Typography, Paper, Snackbar } from "@mui/material";
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useGame } from "../../context/GameContext";
@@ -17,6 +17,11 @@ import type { OptionAnalysis } from "../../services/recommendationEngine";
 import type { PreferencePrediction } from "../../types/telemetryData";
 import { recordRoundTelemetry } from "../../services/telemetry";
 import { recordSuccessfulPromptCopy } from "../../services/googleAnalytics";
+import {
+  buildRoundRecommendationDebugContext,
+  registerSanmouDebugContext,
+  SANMOU_DEBUG_SCHEMA,
+} from "../../services/recommendationDebug";
 
 interface QualificationInterstitialProps {
   roundNumber: 7 | 9;
@@ -94,6 +99,41 @@ const GameBoard = () => {
     regularSkills,
     orangeRegularSkills,
   } = state;
+
+  useEffect(
+    () =>
+      registerSanmouDebugContext(() => {
+        if (!gameState) {
+          return {
+            schema: SANMOU_DEBUG_SCHEMA,
+            page: 'candidate-suggestion',
+            status: 'not-ready',
+            reason: 'Start a game before requesting recommendation debug context.',
+          };
+        }
+        if (gameState.round_number > TOTAL_ROUNDS) {
+          return {
+            schema: SANMOU_DEBUG_SCHEMA,
+            page: 'candidate-suggestion',
+            status: 'not-ready',
+            reason: 'The draft is complete and there is no active candidate recommendation.',
+          };
+        }
+        return buildRoundRecommendationDebugContext({
+          season: state.selectedSeason,
+          gameState,
+          roundType: getRoundType(gameState.round_number),
+          currentRoundInputs,
+          recommendation: currentRecommendation,
+        });
+      }),
+    [
+      currentRecommendation,
+      currentRoundInputs,
+      gameState,
+      state.selectedSeason,
+    ]
+  );
 
   if (!gameState) {
     return null;

--- a/web/src/components/game/__tests__/AnalysisGrid.test.tsx
+++ b/web/src/components/game/__tests__/AnalysisGrid.test.tsx
@@ -13,6 +13,7 @@ const option = (setIndex: number, score: number): OptionAnalysis => ({
   combo_tradeoffs: [],
   tradeoffs: [],
   evidence: { featureCount: 0, totalSupport: 0, minSupport: 0 },
+  debug: { rawScore: score / 10, evaluatedFeatures: [] },
 });
 
 describe('AnalysisGrid player preference display', () => {
@@ -161,11 +162,11 @@ describe('AnalysisGrid player preference display', () => {
     combinationAnalysis[0] = {
       ...combinationAnalysis[0],
       combo_synergies: [
-        { label: '甲 + 乙', family: 'HP', weight: 0.36, support: 20 },
-        { label: '戊 + 己', family: 'HP', weight: 0.45, support: 15 },
+        { featureId: 'HP|甲|乙', label: '甲 + 乙', family: 'HP', weight: 0.36, support: 20 },
+        { featureId: 'HP|戊|己', label: '戊 + 己', family: 'HP', weight: 0.45, support: 15 },
       ],
       combo_tradeoffs: [
-        { label: '丙 + 丁', family: 'HP', weight: -0.18, support: 10 },
+        { featureId: 'HP|丙|丁', label: '丙 + 丁', family: 'HP', weight: -0.18, support: 10 },
       ],
     };
 

--- a/web/src/pages/TeamBuilder.tsx
+++ b/web/src/pages/TeamBuilder.tsx
@@ -64,6 +64,10 @@ import {
 } from '../services/teamBuilderArrangement';
 import { summarizeTeamBuilderRecommendation } from '../services/teamBuilderMessaging';
 import {
+  buildTeamFormationDebugContext,
+  registerSanmouDebugContext,
+} from '../services/recommendationDebug';
+import {
   LocalTeamAgentError,
   createTeamAgentRequest,
   isTeamBuilderLayoutComplete,
@@ -528,6 +532,37 @@ const TeamBuilder = () => {
   const isSystemRecommendation =
     recommendedLayout !== null &&
     sameTeamBuilderLayout(layout, recommendedLayout);
+
+  useEffect(
+    () =>
+      registerSanmouDebugContext(() =>
+        buildTeamFormationDebugContext({
+          season: selectedSeason,
+          heroes,
+          skills,
+          supportItems,
+          formation,
+          resultReady:
+            hydratedKey === poolKey &&
+            (!isEligible || resultKey === poolKey),
+          currentLayout: layout,
+          currentLayoutMatchesRecommendation: isSystemRecommendation,
+        })
+      ),
+    [
+      formation,
+      heroes,
+      hydratedKey,
+      isEligible,
+      isSystemRecommendation,
+      layout,
+      poolKey,
+      resultKey,
+      selectedSeason,
+      skills,
+      supportItems,
+    ]
+  );
 
   return (
     <Container maxWidth="xl" disableGutters>

--- a/web/src/services/__tests__/recommendationDebug.test.ts
+++ b/web/src/services/__tests__/recommendationDebug.test.ts
@@ -174,6 +174,20 @@ describe('recommendation browser debug context', () => {
         candidateSelectionsEvaluated: 8,
         prioritizedExactGuideCoreCount: 1,
         rankingOrder: ['more usable exact 3/3 guide cores'],
+        beamPruning: [
+          {
+            depth: 1,
+            preCapCount: 80,
+            retainedCount: 64,
+            nominalCap: 64,
+            effectiveCap: 64,
+            proxyRankingOrder: ['higher unassigned hero model gain'],
+            nominalCutoff: null,
+            retainedCutoff: null,
+            exactGuideReservations: [],
+            retainedOnlyByReservationCount: 0,
+          },
+        ],
         topCandidates: [
           {
             rank: 1,
@@ -225,6 +239,54 @@ describe('recommendation browser debug context', () => {
                 prioritizedExactGuide: true,
               },
             ],
+            skillRouting: {
+              guideMatching: {
+                slotRankingOrder: [],
+                alternativeRankingOrder: [],
+                slots: [],
+              },
+              modelRouting: {
+                rankingOrder: ['higher incremental model gain'],
+                rejectedCandidateLimit: 8,
+                steps: [
+                  {
+                    step: 1,
+                    candidateCount: 2,
+                    selected: {
+                      hero: heroes[0],
+                      additions: [skills[0]],
+                      gain: 0.8,
+                      support: 24,
+                      stableKey: `${heroes[0]}|HS|${skills[0]}`,
+                      placements: [
+                        {
+                          skill: skills[0],
+                          slotIndex: 1,
+                          preferredGuideSlot: true,
+                        },
+                      ],
+                    },
+                    rejected: [
+                      {
+                        hero: heroes[1],
+                        additions: [skills[0]],
+                        gain: 0.7,
+                        support: 20,
+                        stableKey: `${heroes[1]}|HS|${skills[0]}`,
+                        placements: [
+                          {
+                            skill: skills[0],
+                            slotIndex: 0,
+                            preferredGuideSlot: false,
+                          },
+                        ],
+                      },
+                    ],
+                    omittedRejectedCount: 0,
+                  },
+                ],
+              },
+            },
           },
           {
             rank: 2,
@@ -238,6 +300,18 @@ describe('recommendation browser debug context', () => {
             heroSupport: 80,
             canonicalKey: 'runner-up',
             teams: [],
+            skillRouting: {
+              guideMatching: {
+                slotRankingOrder: [],
+                alternativeRankingOrder: [],
+                slots: [],
+              },
+              modelRouting: {
+                rankingOrder: [],
+                rejectedCandidateLimit: 8,
+                steps: [],
+              },
+            },
           },
         ],
       },
@@ -260,6 +334,13 @@ describe('recommendation browser debug context', () => {
       optimizer_trace: {
         candidateSelectionsEvaluated: 8,
         prioritizedExactGuideCoreCount: 1,
+        beamPruning: [
+          {
+            depth: 1,
+            preCapCount: 80,
+            retainedCount: 64,
+          },
+        ],
         winner: {
           teams: [
             {
@@ -271,6 +352,21 @@ describe('recommendation browser debug context', () => {
               },
             },
           ],
+          skillRouting: {
+            modelRouting: {
+              steps: [
+                {
+                  selected: {
+                    hero: heroes[0],
+                    placements: [
+                      { skill: skills[0], preferredGuideSlot: true },
+                    ],
+                  },
+                  rejected: [{ hero: heroes[1], gain: 0.7 }],
+                },
+              ],
+            },
+          },
         },
       },
       strongest_rejected_alternatives: [

--- a/web/src/services/__tests__/recommendationDebug.test.ts
+++ b/web/src/services/__tests__/recommendationDebug.test.ts
@@ -220,7 +220,17 @@ describe('recommendation browser debug context', () => {
   });
 
   test('exports formation policy, optimiser alternatives, gates, and current edits', () => {
-    const heroes = Object.keys(database.heroes).slice(0, 9);
+    const beamPrunedHero = Object.keys(database.heroes).find(
+      (hero) =>
+        (recommendationData.model.support[`H|${hero}`] ?? 0) >=
+        recommendationData.model.min_support_single
+    )!;
+    const heroes = [
+      beamPrunedHero,
+      ...Object.keys(database.heroes)
+        .filter((hero) => hero !== beamPrunedHero)
+        .slice(0, 8),
+    ];
     const skills = Object.keys(database.skills).slice(0, 18);
     const formation: FormationRecommendation = {
       incomplete: false,
@@ -266,6 +276,20 @@ describe('recommendation browser debug context', () => {
             retainedOnlyByReservationCount: 0,
           },
         ],
+        heroSelectionReachability: heroes.map((hero, index) => ({
+          hero,
+          qualifiedGroupCount: 1,
+          reachedFinalEvaluation: index !== 0,
+          depths: [
+            {
+              depth: 1,
+              generatedContainingSelectionCount: 1,
+              retainedContainingSelectionCount: index === 0 ? 0 : 1,
+              reservedContainingSelectionCount: 0,
+              entirelyProxyPruned: index === 0,
+            },
+          ],
+        })),
         topCandidates: [
           {
             rank: 1,
@@ -470,6 +494,25 @@ describe('recommendation browser debug context', () => {
     expect(gates.skills).toHaveLength(18);
     expect(gates.hero_skill_routes).toHaveLength(18);
     expect(context).not.toHaveProperty('strongest_rejected_alternatives');
+    const unplaced = context.unplaced_items as {
+      heroes: Array<Record<string, unknown>>;
+    };
+    expect(
+      unplaced.heroes.find(({ name }) => name === beamPrunedHero)
+    ).toMatchObject({
+      qualified_pair_or_trio_count: 1,
+      selection_search_reachability: {
+        reached_final_evaluation: false,
+        depths: [
+          {
+            generatedContainingSelectionCount: 1,
+            retainedContainingSelectionCount: 0,
+            entirelyProxyPruned: true,
+          },
+        ],
+      },
+      reason: 'qualified_groups_entirely_pruned_by_proxy_beam',
+    });
     const optimizer = context.optimizer_trace as Record<string, unknown>;
     expect(optimizer).not.toHaveProperty('topCandidates');
     expect(optimizer).toHaveProperty('winner');

--- a/web/src/services/__tests__/recommendationDebug.test.ts
+++ b/web/src/services/__tests__/recommendationDebug.test.ts
@@ -1,6 +1,7 @@
 import { database, recommendationData } from '../../data';
 import { createEmptyTeamBuilderLayout } from '../teamBuilderArrangement';
 import {
+  recommendHybridTeams,
   recommendSkillSet,
   type FormationRecommendation,
   type OptionAnalysis,
@@ -31,7 +32,7 @@ const emptyGuideMatchingTrace = () => ({
   slotCount: 0,
   uniqueSkillCount: 0,
   matchedSlotCount: 0,
-  eventLimit: 64,
+  eventLimit: 24,
   events: [],
   omittedEventCount: 0,
   finalAssignments: [],
@@ -242,7 +243,10 @@ describe('recommendation browser debug context', () => {
         policy: 'evidence-only-team-builder',
         heroPoolCount: 9,
         skillPoolCount: 18,
+        heroPoolCap: 15,
         boundedHeroCount: 9,
+        consideredHeroes: [...heroes].sort(),
+        excludedHeroes: [],
         qualifiedHeroPairs: 4,
         qualifiedHeroTrios: 1,
         candidateSelectionsEvaluated: 8,
@@ -297,6 +301,7 @@ describe('recommendation browser debug context', () => {
                     rankingScore: 3,
                     stableId: 'guide-1',
                   },
+                  rejectedCandidateLimit: 4,
                   rejected: [
                     {
                       guideId: 'guide-2',
@@ -309,6 +314,7 @@ describe('recommendation browser debug context', () => {
                       stableId: 'guide-2',
                     },
                   ],
+                  omittedRejectedCount: 0,
                 },
                 prioritizedExactGuide: true,
               },
@@ -322,7 +328,7 @@ describe('recommendation browser debug context', () => {
               },
               modelRouting: {
                 rankingOrder: ['higher incremental model gain'],
-                rejectedCandidateLimit: 8,
+                rejectedCandidateLimit: 4,
                 steps: [
                   {
                     step: 1,
@@ -384,7 +390,7 @@ describe('recommendation browser debug context', () => {
               },
               modelRouting: {
                 rankingOrder: [],
-                rejectedCandidateLimit: 8,
+                rejectedCandidateLimit: 4,
                 steps: [],
               },
             },
@@ -451,10 +457,8 @@ describe('recommendation browser debug context', () => {
             },
           },
         },
+        runner_up: { rank: 2, canonicalKey: 'runner-up' },
       },
-      strongest_rejected_alternatives: [
-        { rank: 2, canonicalKey: 'runner-up' },
-      ],
       current_layout: {
         matches_original_recommendation: false,
         user_edited: true,
@@ -465,6 +469,11 @@ describe('recommendation browser debug context', () => {
     expect(gates.hero_pairs).toHaveLength(36);
     expect(gates.skills).toHaveLength(18);
     expect(gates.hero_skill_routes).toHaveLength(18);
+    expect(context).not.toHaveProperty('strongest_rejected_alternatives');
+    const optimizer = context.optimizer_trace as Record<string, unknown>;
+    expect(optimizer).not.toHaveProperty('topCandidates');
+    expect(optimizer).toHaveProperty('winner');
+    expect(optimizer).toHaveProperty('runner_up');
   });
 
   test('distinguishes skill routes to selected heroes from routes only to unplaced heroes', () => {
@@ -522,6 +531,92 @@ describe('recommendation browser debug context', () => {
         unplaced_heroes: expect.arrayContaining(['司马懿']),
       },
       reason: 'evidence_qualified_routes_exist_only_to_unplaced_heroes',
+    });
+  });
+
+  test('uses the authoritative 15-hero boundary for gates, guides, routes, and unplaced reasons', () => {
+    const excludedHero = '司马懿';
+    const consideredHeroes = Array.from(
+      { length: 15 },
+      (_, index) => `h${String(index).padStart(2, '0')}`
+    );
+    const heroes = [...consideredHeroes, excludedHero];
+    const skills = [
+      '一计决胜',
+      ...Object.keys(database.skills)
+        .filter((skill) => skill !== '一计决胜')
+        .slice(0, 17),
+    ];
+    const formation = recommendHybridTeams(
+      heroes,
+      skills,
+      recommendationData,
+      recommendationData.catalog,
+      {},
+      database.team ?? []
+    );
+    const context = buildTeamFormationDebugContext({
+      season: 16,
+      heroes,
+      skills,
+      supportItems: new Set(),
+      formation,
+      resultReady: true,
+      currentLayout: createEmptyTeamBuilderLayout(),
+      currentLayoutMatchesRecommendation: true,
+    });
+
+    expect(formation.debug).toMatchObject({
+      heroPoolCap: 15,
+      consideredHeroes,
+      excludedHeroes: [
+        {
+          hero: excludedHero,
+          sortedPoolRank: 16,
+          reason: 'excluded_by_alphabetical_hero_pool_cap',
+        },
+      ],
+    });
+    const gates = context.evidence_gates as {
+      heroes: unknown[];
+      hero_pairs: unknown[];
+      hero_skill_routes: Array<{
+        skill: string;
+        routes: Array<{ hero: string }>;
+      }>;
+      pool_cap_exclusions: Array<{ hero: string }>;
+    };
+    expect(gates.heroes).toHaveLength(15);
+    expect(gates.hero_pairs).toHaveLength(105);
+    expect(gates.pool_cap_exclusions).toEqual([
+      expect.objectContaining({ hero: excludedHero }),
+    ]);
+    const skillRoutes = gates.hero_skill_routes.find(
+      ({ skill }) => skill === '一计决胜'
+    )!;
+    expect(skillRoutes.routes).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ hero: excludedHero })])
+    );
+    expect(
+      (context.relevant_guide_teams as Array<{ matched_heroes: string[] }>).some(
+        ({ matched_heroes }) => matched_heroes.includes(excludedHero)
+      )
+    ).toBe(false);
+    const unplaced = context.unplaced_items as {
+      heroes: Array<Record<string, unknown>>;
+      skills: Array<Record<string, unknown>>;
+    };
+    expect(unplaced.heroes.find(({ name }) => name === excludedHero)).toMatchObject({
+      individual_gate: null,
+      qualified_pair_or_trio_count: 0,
+      reason: 'excluded_by_alphabetical_hero_pool_cap',
+    });
+    expect(unplaced.skills.find(({ name }) => name === '一计决胜')).toMatchObject({
+      evidence_qualified_routes: {
+        selected_heroes: [],
+        unplaced_heroes: [],
+      },
+      reason: 'no_evidence_qualified_hero_skill_route',
     });
   });
 

--- a/web/src/services/__tests__/recommendationDebug.test.ts
+++ b/web/src/services/__tests__/recommendationDebug.test.ts
@@ -1,0 +1,269 @@
+import { database } from '../../data';
+import { createEmptyTeamBuilderLayout } from '../teamBuilderArrangement';
+import type {
+  FormationRecommendation,
+  OptionAnalysis,
+} from '../recommendationEngine';
+import {
+  SANMOU_DEBUG_SCHEMA,
+  buildRoundRecommendationDebugContext,
+  buildTeamFormationDebugContext,
+  clearSanmouDebugContextForTests,
+  registerSanmouDebugContext,
+} from '../recommendationDebug';
+
+const evaluatedFeature = (
+  featureId: string,
+  weight: number,
+  support: number
+) => ({
+  featureId,
+  label: featureId.split('|').slice(1).join(' + '),
+  family: featureId.split('|')[0],
+  weight,
+  support,
+  displayPoints: weight * 10,
+});
+
+const option = (
+  setIndex: number,
+  rank: number,
+  score: number,
+  featureId: string
+): OptionAnalysis => ({
+  set_index: setIndex,
+  items: [`item-${setIndex}`],
+  final_score: score,
+  rank,
+  item_scores: [
+    { item: `item-${setIndex}`, score, support: 10 + setIndex },
+  ],
+  synergies: [],
+  combo_synergies: [],
+  combo_tradeoffs: [],
+  tradeoffs: [],
+  evidence: {
+    featureCount: 1,
+    totalSupport: 10 + setIndex,
+    minSupport: 10 + setIndex,
+  },
+  debug: {
+    rawScore: score / 10,
+    evaluatedFeatures: [evaluatedFeature(featureId, score / 10, 10)],
+  },
+});
+
+describe('recommendation browser debug context', () => {
+  afterEach(() => {
+    clearSanmouDebugContextForTests();
+    vi.restoreAllMocks();
+  });
+
+  test('exports an exact, copy-ready round ranking and feature calculation', () => {
+    const analysis = [
+      option(0, 2, 7, 'H|甲'),
+      option(1, 1, 9, 'HP|乙|现有武将'),
+      option(2, 3, 3, 'H|丙'),
+    ];
+    const context = buildRoundRecommendationDebugContext({
+      season: 16,
+      roundType: 'hero',
+      gameState: {
+        current_heroes: ['现有武将'],
+        current_skills: ['现有战法'],
+        support_hero: '支援武将',
+        support_skills: ['支援战法'],
+        round_number: 4,
+        round_history: [],
+      },
+      currentRoundInputs: {
+        set1: ['甲'],
+        set2: ['乙'],
+        set3: ['丙'],
+      },
+      recommendation: {
+        recommended_set_index: 1,
+        analysis,
+        preference: {
+          top_index: 0,
+          probabilities: [0.5, 0.3, 0.2],
+        },
+      },
+    });
+
+    expect(context).toMatchObject({
+      schema: SANMOU_DEBUG_SCHEMA,
+      page: 'candidate-suggestion',
+      status: 'ready',
+      decision: {
+        recommended_index: 1,
+        recommended_label: 'B',
+        winner_margin_over_runner_up: 2,
+      },
+      player_preference_model: {
+        top_index: 0,
+        affects_ai_recommendation: false,
+      },
+    });
+    expect(
+      (context.options as Array<Record<string, unknown>>)[1]
+    ).toMatchObject({
+      option: 'B',
+      display_score: 9,
+      score_calculation: [
+        {
+          feature_id: 'HP|乙|现有武将',
+          meaning: '武将配合：乙 + 现有武将',
+          display_points: 9,
+          support: 10,
+        },
+      ],
+    });
+    expect(JSON.stringify(context)).not.toContain('model.weights');
+  });
+
+  test('reports not-ready context before a round recommendation exists', () => {
+    const context = buildRoundRecommendationDebugContext({
+      season: 1,
+      roundType: 'hero',
+      gameState: {
+        current_heroes: [],
+        current_skills: [],
+        support_hero: null,
+        support_skills: [],
+        round_number: 1,
+        round_history: [],
+      },
+      currentRoundInputs: { set1: [], set2: [], set3: [] },
+      recommendation: null,
+    });
+
+    expect(context).toMatchObject({
+      status: 'not-ready',
+      page: 'candidate-suggestion',
+    });
+  });
+
+  test('exports formation policy, optimiser alternatives, gates, and current edits', () => {
+    const heroes = Object.keys(database.heroes).slice(0, 9);
+    const skills = Object.keys(database.skills).slice(0, 18);
+    const formation: FormationRecommendation = {
+      incomplete: false,
+      options: [
+        {
+          teams: [
+            {
+              heroes: [],
+              strength: 0,
+              evidence: {
+                heroSynergy: [],
+                heroSkill: [],
+                skillSynergy: [],
+              },
+            },
+          ],
+        },
+      ],
+      debug: {
+        policy: 'evidence-only-team-builder',
+        heroPoolCount: 9,
+        skillPoolCount: 18,
+        boundedHeroCount: 9,
+        qualifiedHeroPairs: 4,
+        qualifiedHeroTrios: 1,
+        candidateSelectionsEvaluated: 8,
+        prioritizedExactGuideCoreCount: 1,
+        rankingOrder: ['more usable exact 3/3 guide cores'],
+        topCandidates: [
+          {
+            rank: 1,
+            exactGuideIds: ['guide-1'],
+            totalModelGain: 12.3,
+            rawTotalModelGain: 1.23,
+            exactChampionshipTeams: 0,
+            exactRankingScore: 3,
+            heroesPlaced: 3,
+            completeTrios: 1,
+            heroSupport: 90,
+            canonicalKey: heroes.slice(0, 3).join('|'),
+            teams: [],
+          },
+          {
+            rank: 2,
+            exactGuideIds: [],
+            totalModelGain: 13,
+            rawTotalModelGain: 1.3,
+            exactChampionshipTeams: 0,
+            exactRankingScore: 0,
+            heroesPlaced: 6,
+            completeTrios: 2,
+            heroSupport: 80,
+            canonicalKey: 'runner-up',
+            teams: [],
+          },
+        ],
+      },
+    };
+
+    const context = buildTeamFormationDebugContext({
+      season: 16,
+      heroes,
+      skills,
+      supportItems: new Set([heroes[0], skills[0]]),
+      formation,
+      resultReady: true,
+      currentLayout: createEmptyTeamBuilderLayout(),
+      currentLayoutMatchesRecommendation: false,
+    });
+
+    expect(context).toMatchObject({
+      page: 'team-formation-suggestion',
+      status: 'ready',
+      optimizer_trace: {
+        candidateSelectionsEvaluated: 8,
+        prioritizedExactGuideCoreCount: 1,
+      },
+      strongest_rejected_alternatives: [
+        { rank: 2, canonicalKey: 'runner-up' },
+      ],
+      current_layout: {
+        matches_original_recommendation: false,
+        user_edited: true,
+      },
+    });
+    const gates = context.evidence_gates as Record<string, unknown[]>;
+    expect(gates.heroes).toHaveLength(9);
+    expect(gates.hero_pairs).toHaveLength(36);
+    expect(gates.skills).toHaveLength(18);
+    expect(gates.hero_skill_routes).toHaveLength(18);
+  });
+
+  test('registers sanmouDebug as a pretty JSON console function and cleans stale owners safely', () => {
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const releaseFirst = registerSanmouDebugContext(() => ({
+      schema: SANMOU_DEBUG_SCHEMA,
+      page: 'first',
+      status: 'ready',
+    }));
+    const releaseSecond = registerSanmouDebugContext(() => ({
+      schema: SANMOU_DEBUG_SCHEMA,
+      page: 'second',
+      status: 'ready',
+    }));
+
+    releaseFirst();
+    const serialized = window.sanmouDebug?.();
+    expect(serialized).toBeTruthy();
+    expect(JSON.parse(serialized!)).toMatchObject({
+      page: 'second',
+      status: 'ready',
+    });
+    expect(serialized).toContain('\n  "page": "second"');
+
+    releaseSecond();
+    expect(JSON.parse(window.sanmouDebug!())).toMatchObject({
+      page: 'unsupported',
+      status: 'not-ready',
+    });
+  });
+});

--- a/web/src/services/__tests__/recommendationDebug.test.ts
+++ b/web/src/services/__tests__/recommendationDebug.test.ts
@@ -186,7 +186,45 @@ describe('recommendation browser debug context', () => {
             completeTrios: 1,
             heroSupport: 90,
             canonicalKey: heroes.slice(0, 3).join('|'),
-            teams: [],
+            teams: [
+              {
+                heroes: heroes.slice(0, 3),
+                skills: {},
+                guideId: 'guide-1',
+                guideMatchDecision: {
+                  rankingOrder: [
+                    'higher matched hero count',
+                    'higher evidence-qualified skill-slot count',
+                    'championship source before non-championship source',
+                    'higher guide ranking score (S=3, A=2, other=1)',
+                    'lower stable guide ID by locale order',
+                  ],
+                  selected: {
+                    guideId: 'guide-1',
+                    matchedHeroes: heroes.slice(0, 3),
+                    matchedHeroCount: 3,
+                    qualifiedSkillSlotCount: 2,
+                    championship: false,
+                    ranking: 'S',
+                    rankingScore: 3,
+                    stableId: 'guide-1',
+                  },
+                  rejected: [
+                    {
+                      guideId: 'guide-2',
+                      matchedHeroes: heroes.slice(0, 3),
+                      matchedHeroCount: 3,
+                      qualifiedSkillSlotCount: 1,
+                      championship: true,
+                      ranking: 'S',
+                      rankingScore: 3,
+                      stableId: 'guide-2',
+                    },
+                  ],
+                },
+                prioritizedExactGuide: true,
+              },
+            ],
           },
           {
             rank: 2,
@@ -222,6 +260,18 @@ describe('recommendation browser debug context', () => {
       optimizer_trace: {
         candidateSelectionsEvaluated: 8,
         prioritizedExactGuideCoreCount: 1,
+        winner: {
+          teams: [
+            {
+              guideMatchDecision: {
+                selected: { guideId: 'guide-1', qualifiedSkillSlotCount: 2 },
+                rejected: [
+                  { guideId: 'guide-2', qualifiedSkillSlotCount: 1 },
+                ],
+              },
+            },
+          ],
+        },
       },
       strongest_rejected_alternatives: [
         { rank: 2, canonicalKey: 'runner-up' },
@@ -236,6 +286,64 @@ describe('recommendation browser debug context', () => {
     expect(gates.hero_pairs).toHaveLength(36);
     expect(gates.skills).toHaveLength(18);
     expect(gates.hero_skill_routes).toHaveLength(18);
+  });
+
+  test('distinguishes skill routes to selected heroes from routes only to unplaced heroes', () => {
+    const heroes = [
+      '司马懿',
+      ...Object.keys(database.heroes)
+        .filter((hero) => hero !== '司马懿')
+        .slice(0, 8),
+    ];
+    const skills = [
+      '一计决胜',
+      ...Object.keys(database.skills)
+        .filter((skill) => skill !== '一计决胜')
+        .slice(0, 17),
+    ];
+    const formation: FormationRecommendation = {
+      incomplete: false,
+      options: [
+        {
+          teams: [
+            {
+              heroes: [],
+              strength: 0,
+              evidence: {
+                heroSynergy: [],
+                heroSkill: [],
+                skillSynergy: [],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const context = buildTeamFormationDebugContext({
+      season: 16,
+      heroes,
+      skills,
+      supportItems: new Set(),
+      formation,
+      resultReady: true,
+      currentLayout: createEmptyTeamBuilderLayout(),
+      currentLayoutMatchesRecommendation: true,
+    });
+    const unplacedSkills = (
+      context.unplaced_items as {
+        skills: Array<Record<string, unknown>>;
+      }
+    ).skills;
+    const skill = unplacedSkills.find(({ name }) => name === '一计决胜');
+
+    expect(skill).toMatchObject({
+      evidence_qualified_routes: {
+        selected_heroes: [],
+        unplaced_heroes: expect.arrayContaining(['司马懿']),
+      },
+      reason: 'evidence_qualified_routes_exist_only_to_unplaced_heroes',
+    });
   });
 
   test('registers sanmouDebug as a pretty JSON console function and cleans stale owners safely', () => {

--- a/web/src/services/__tests__/recommendationDebug.test.ts
+++ b/web/src/services/__tests__/recommendationDebug.test.ts
@@ -1,8 +1,9 @@
-import { database } from '../../data';
+import { database, recommendationData } from '../../data';
 import { createEmptyTeamBuilderLayout } from '../teamBuilderArrangement';
-import type {
-  FormationRecommendation,
-  OptionAnalysis,
+import {
+  recommendSkillSet,
+  type FormationRecommendation,
+  type OptionAnalysis,
 } from '../recommendationEngine';
 import {
   SANMOU_DEBUG_SCHEMA,
@@ -23,6 +24,17 @@ const evaluatedFeature = (
   weight,
   support,
   displayPoints: weight * 10,
+});
+
+const emptyGuideMatchingTrace = () => ({
+  objective: 'maximize assigned guide slots',
+  slotCount: 0,
+  uniqueSkillCount: 0,
+  matchedSlotCount: 0,
+  eventLimit: 64,
+  events: [],
+  omittedEventCount: 0,
+  finalAssignments: [],
 });
 
 const option = (
@@ -120,6 +132,68 @@ describe('recommendation browser debug context', () => {
       ],
     });
     expect(JSON.stringify(context)).not.toContain('model.weights');
+  });
+
+  test('exports the authoritative current-pool tie-break for equal skill routes', () => {
+    const result = recommendSkillSet(
+      [['虚构战法']],
+      ['乙', '甲'],
+      [],
+      recommendationData
+    );
+    const context = buildRoundRecommendationDebugContext({
+      season: 16,
+      roundType: 'skill',
+      gameState: {
+        current_heroes: ['乙', '甲'],
+        current_skills: [],
+        support_hero: null,
+        support_skills: [],
+        round_number: 2,
+        round_history: [],
+      },
+      currentRoundInputs: {
+        set1: ['虚构战法'],
+        set2: [],
+        set3: [],
+      },
+      recommendation: {
+        recommended_set_index: result.recommended_set,
+        analysis: result.analysis,
+      },
+    });
+    const route = (
+      context.options as Array<{
+        skill_routing: Array<Record<string, unknown>>;
+      }>
+    )[0].skill_routing[0];
+
+    expect(route).toMatchObject({
+      chosen_hero: '乙',
+      ranking_order: [
+        'higher hero-skill HS weight',
+        'earlier hero in current-pool order when HS weights tie',
+      ],
+      selection_reason:
+        'highest HS weight tied; earliest hero in current-pool order won',
+      tied_best_heroes: ['乙', '甲'],
+      alternatives: [
+        {
+          rank: 1,
+          hero: '乙',
+          current_pool_index: 0,
+          selected: true,
+          tied_for_best_weight: true,
+        },
+        {
+          rank: 2,
+          hero: '甲',
+          current_pool_index: 1,
+          selected: false,
+          tied_for_best_weight: true,
+        },
+      ],
+    });
   });
 
   test('reports not-ready context before a round recommendation exists', () => {
@@ -243,6 +317,7 @@ describe('recommendation browser debug context', () => {
               guideMatching: {
                 slotRankingOrder: [],
                 alternativeRankingOrder: [],
+                maximumCardinality: emptyGuideMatchingTrace(),
                 slots: [],
               },
               modelRouting: {
@@ -304,6 +379,7 @@ describe('recommendation browser debug context', () => {
               guideMatching: {
                 slotRankingOrder: [],
                 alternativeRankingOrder: [],
+                maximumCardinality: emptyGuideMatchingTrace(),
                 slots: [],
               },
               modelRouting: {
@@ -353,6 +429,13 @@ describe('recommendation browser debug context', () => {
             },
           ],
           skillRouting: {
+            guideMatching: {
+              maximumCardinality: {
+                objective: 'maximize assigned guide slots',
+                matchedSlotCount: 0,
+                finalAssignments: [],
+              },
+            },
             modelRouting: {
               steps: [
                 {

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -1861,6 +1861,10 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
     });
 
     expect(result.debug!.candidateSelectionsEvaluated).toBeGreaterThan(2);
+    expect(
+      result.debug!.heroSelectionReachability.find(({ hero }) => hero === 'b0')
+        ?.depths[0].reservedContainingSelectionCount
+    ).toBeGreaterThan(0);
     expect(result.debug!.topCandidates).toHaveLength(2);
     expect(result.debug!.topCandidates.map(({ rank }) => rank)).toEqual([1, 2]);
     const winnerAssignments = Object.assign(
@@ -1884,6 +1888,68 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
         expect(step.rejected.length).toBeLessThanOrEqual(4);
       }
     }
+  });
+
+  test('reports when every qualified group for a hero is pruned before final evaluation', () => {
+    const heroes = Array.from({ length: 9 }, (_, index) => `p${index}`);
+    const skills = Array.from({ length: 18 }, (_, index) => `ps${index}`);
+    const weights: Record<string, number> = {};
+    const support: Record<string, number> = {};
+    for (const hero of heroes) {
+      weights[`H|${hero}`] = hero === 'p8' ? -100 : 0.1;
+      support[`H|${hero}`] = 10;
+    }
+    for (let first = 0; first < heroes.length; first += 1) {
+      for (let second = first + 1; second < heroes.length; second += 1) {
+        const feature = `HP|${heroes[first]}|${heroes[second]}`;
+        weights[feature] = 0.1;
+        support[feature] = 16;
+      }
+    }
+    const data = makeData({
+      weights,
+      support,
+      n_features: Object.keys(weights).length,
+    });
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      []
+    );
+    const pruned = result.debug!.heroSelectionReachability.find(
+      ({ hero }) => hero === 'p8'
+    );
+    const retained = result.debug!.heroSelectionReachability.find(
+      ({ hero }) => hero === 'p0'
+    );
+
+    expect(pruned).toMatchObject({
+      qualifiedGroupCount: 36,
+      reachedFinalEvaluation: false,
+    });
+    expect(pruned?.depths[0]).toEqual({
+      depth: 1,
+      generatedContainingSelectionCount: 36,
+      retainedContainingSelectionCount: 0,
+      reservedContainingSelectionCount: 0,
+      entirelyProxyPruned: true,
+    });
+    expect(
+      pruned?.depths.every(
+        ({ retainedContainingSelectionCount }) =>
+          retainedContainingSelectionCount === 0
+      )
+    ).toBe(true);
+    expect(retained?.reachedFinalEvaluation).toBe(true);
+    expect(
+      result.debug!.topCandidates.flatMap(({ teams }) =>
+        teams.flatMap(({ heroes: teamHeroes }) => teamHeroes)
+      )
+    ).not.toContain('p8');
   });
 
   test('ranks total formation gain ahead of the number of complete trios', () => {

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -1167,6 +1167,7 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
         'HS|h0|s0': 10,
         'S|s1': 0.2,
         'HS|h0|s1': 0.3,
+        'HS|h2|s1': 0.1,
         'S|s2': 10,
         'HS|h0|s2': 10,
       },
@@ -1178,10 +1179,11 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
         'HS|h0|s0': 16,
         'S|s1': 10,
         'HS|h0|s1': 16,
+        'HS|h2|s1': 16,
         'S|s2': 10,
         'HS|h0|s2': 7,
       },
-      n_features: 9,
+      n_features: 10,
     });
     const partial = makeTeamComp(
       'partial-guide-gated',
@@ -1208,6 +1210,40 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
     expect(h0?.skills).not.toContain('s0');
     expect(h0?.skills).not.toContain('s2');
     expect(h0?.skills).toContain('s1');
+
+    const routing = result.debug?.topCandidates[0].skillRouting;
+    expect(routing?.guideMatching.slots).toEqual([]);
+    expect(routing?.modelRouting.rankingOrder).toEqual([
+      'higher incremental model gain',
+      'higher combined feature support',
+      'lower stable route key by locale order',
+    ]);
+    expect(routing?.modelRouting.steps[0]).toMatchObject({
+      candidateCount: 2,
+      selected: {
+        hero: 'h0',
+        additions: ['s1'],
+        gain: 0.5,
+        support: 26,
+        stableKey: 'h0|HS|s1',
+        placements: [
+          { skill: 's1', slotIndex: 0, preferredGuideSlot: false },
+        ],
+      },
+      rejected: [
+        {
+          hero: 'h2',
+          additions: ['s1'],
+          gain: 0.30000000000000004,
+          support: 26,
+          stableKey: 'h2|HS|s1',
+          placements: [
+            { skill: 's1', slotIndex: 0, preferredGuideSlot: false },
+          ],
+        },
+      ],
+      omittedRejectedCount: 0,
+    });
   });
 
   test('an absent guide hero neither appears nor reserves an otherwise qualified owned skill', () => {
@@ -1326,6 +1362,22 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
 
     expect(placed.find(({ name }) => name === 'h0')?.skills).toContain('s0');
     expect(placed.find(({ name }) => name === 'h3')?.skills).not.toContain('s0');
+
+    const guideSlots =
+      result.debug?.topCandidates[0].skillRouting.guideMatching.slots;
+    expect(guideSlots).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          hero: 'h0',
+          selected: expect.objectContaining({ skill: 's0' }),
+        }),
+        expect.objectContaining({
+          hero: 'h3',
+          selected: null,
+          rejected: [expect.objectContaining({ skill: 's0' })],
+        }),
+      ])
+    );
   });
 
   test('shows all three canonical slots when the complete guide trio is confident', () => {
@@ -1615,6 +1667,75 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
       'e1',
       'e2',
     ]);
+  });
+
+  test('captures bounded beam pruning and exact-guide reservation decisions', () => {
+    const beamHeroes = Array.from({ length: 9 }, (_, index) => `b${index}`);
+    const beamSkills = Array.from({ length: 18 }, (_, index) => `bs${index}`);
+    const weights: Record<string, number> = {};
+    const support: Record<string, number> = {};
+    for (const hero of beamHeroes) {
+      weights[`H|${hero}`] = 0.1;
+      support[`H|${hero}`] = 10;
+    }
+    for (let first = 0; first < beamHeroes.length; first += 1) {
+      for (let second = first + 1; second < beamHeroes.length; second += 1) {
+        const feature = `HP|${beamHeroes[first]}|${beamHeroes[second]}`;
+        weights[feature] = 0.1;
+        support[feature] = 16;
+      }
+    }
+    weights['S|bs0'] = 0.1;
+    support['S|bs0'] = 10;
+    weights['HS|b0|bs0'] = 0.1;
+    support['HS|b0|bs0'] = 16;
+    const data = makeData({
+      weights,
+      support,
+      n_features: Object.keys(weights).length,
+    });
+    const guide = makeTeamComp('beam-guide', ['b0', 'b1', 'b2'], [
+      [['bs0'], ['missing-0']],
+      [['missing-1'], ['missing-2']],
+      [['missing-3'], ['missing-4']],
+    ]);
+
+    const result = recommendHybridTeams(
+      beamHeroes,
+      beamSkills,
+      data,
+      data.catalog,
+      {},
+      [guide]
+    );
+    const firstDepth = result.debug?.beamPruning[0];
+
+    expect(firstDepth).toMatchObject({
+      depth: 1,
+      preCapCount: 120,
+      retainedCount: 64,
+      nominalCap: 64,
+      effectiveCap: 64,
+      proxyRankingOrder: [
+        'more usable exact 3/3 guide cores',
+        'higher unassigned hero model gain',
+        'more heroes placed',
+        'more complete trios',
+        'higher hero evidence support',
+        'lower stable canonical key by locale order',
+      ],
+      nominalCutoff: expect.objectContaining({ canonicalKey: expect.any(String) }),
+      retainedCutoff: expect.objectContaining({ canonicalKey: expect.any(String) }),
+      exactGuideReservations: [
+        expect.objectContaining({
+          guideId: 'beam-guide',
+          canonicalKey: 'b0|b1|b2',
+          proxyRank: 1,
+          outsideNominalCutoff: false,
+        }),
+      ],
+      retainedOnlyByReservationCount: 0,
+    });
   });
 
   test('ranks total formation gain ahead of the number of complete trios', () => {

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -1109,6 +1109,7 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
         rankingScore: 1,
         stableId: 'skill-winner',
       },
+      rejectedCandidateLimit: 4,
       rejected: [
         expect.objectContaining({
           guideId: 'championship',
@@ -1125,6 +1126,7 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
         expect.objectContaining({ guideId: 'stable-a', stableId: 'stable-a' }),
         expect.objectContaining({ guideId: 'stable-b', stableId: 'stable-b' }),
       ],
+      omittedRejectedCount: 0,
     });
   });
 
@@ -1857,6 +1859,31 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
       ],
       retainedOnlyByReservationCount: 0,
     });
+
+    expect(result.debug!.candidateSelectionsEvaluated).toBeGreaterThan(2);
+    expect(result.debug!.topCandidates).toHaveLength(2);
+    expect(result.debug!.topCandidates.map(({ rank }) => rank)).toEqual([1, 2]);
+    const winnerAssignments = Object.assign(
+      {},
+      ...result.debug!.topCandidates[0].teams.map(({ skills: assigned }) => assigned)
+    );
+    const outputAssignments = Object.fromEntries(
+      result.options[0].teams.flatMap(({ heroes: teamHeroes }) =>
+        teamHeroes.map(({ name, skillSlots }) => [name, skillSlots])
+      )
+    );
+    expect(winnerAssignments).toEqual(outputAssignments);
+    for (const candidate of result.debug!.topCandidates) {
+      expect(
+        candidate.skillRouting.guideMatching.maximumCardinality.events.length
+      ).toBeLessThanOrEqual(24);
+      for (const slot of candidate.skillRouting.guideMatching.slots) {
+        expect(slot.rejected.length).toBeLessThanOrEqual(4);
+      }
+      for (const step of candidate.skillRouting.modelRouting.steps) {
+        expect(step.rejected.length).toBeLessThanOrEqual(4);
+      }
+    }
   });
 
   test('ranks total formation gain ahead of the number of complete trios', () => {

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -136,6 +136,16 @@ describe('recommendSkillSet — best hero-routing', () => {
     // fire routed to mage (0.8) not tank (-0.3), plus standalone 0.2.
     const fireScore = set0.item_scores.find((s) => s.item === 'fire')!.score;
     expect(fireScore).toBeCloseTo((0.2 + 0.8) * 10, 5);
+    expect(set0.debug.skillRoutes?.find(({ skill }) => skill === 'fire')).toMatchObject({
+      chosenHero: 'mage',
+      standalone: { featureId: 'S|fire', weight: 0.2, support: 60 },
+      chosenRoute: { featureId: 'HS|mage|fire', weight: 0.8, support: 30 },
+      alternatives: [
+        { featureId: 'HS|mage|fire', weight: 0.8 },
+        { featureId: 'HS|tank|fire', weight: -0.3 },
+      ],
+      displayTotal: 10,
+    });
   });
 });
 
@@ -955,6 +965,20 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
     );
     const matched = result.options[0].teams[0];
 
+    expect(result.debug).toMatchObject({
+      policy: 'evidence-only-team-builder',
+      heroPoolCount: 9,
+      skillPoolCount: 18,
+      qualifiedHeroPairs: 1,
+      qualifiedHeroTrios: 0,
+      candidateSelectionsEvaluated: 1,
+    });
+    expect(result.debug?.topCandidates[0]).toMatchObject({
+      rank: 1,
+      heroesPlaced: 2,
+      completeTrios: 0,
+      canonicalKey: 'h0|h2',
+    });
     expect(matched.formation).toBe('局部阵');
     expect(matched.knownTeam).toMatchObject({
       id: 'partial',

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -994,6 +994,110 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
     expect(matched.heroes[1].skillSlots).toEqual(['s4', null]);
   });
 
+  test('captures the exact guide-match comparator and rejected candidates', () => {
+    const weights: Record<string, number> = {
+      'S|s0': 0.1,
+      'S|s1': 0.1,
+      'HS|h0|s0': 0.1,
+      'HS|h0|s1': 0.1,
+    };
+    const support: Record<string, number> = {
+      'S|s0': 10,
+      'S|s1': 10,
+      'HS|h0|s0': 16,
+      'HS|h0|s1': 16,
+    };
+    for (const hero of heroes.slice(0, 3)) {
+      weights[`H|${hero}`] = 0.2;
+      support[`H|${hero}`] = 10;
+    }
+    for (const [first, second] of [
+      ['h0', 'h1'],
+      ['h0', 'h2'],
+      ['h1', 'h2'],
+    ]) {
+      weights[`HP|${first}|${second}`] = 0.2;
+      support[`HP|${first}|${second}`] = 16;
+    }
+    const data = makeData({
+      weights,
+      support,
+      n_features: Object.keys(weights).length,
+    });
+    const oneQualifiedSlot: [string[], string[]] = [['s0'], ['missing']];
+    const noQualifiedSlots: [string[], string[]] = [
+      ['missing-0'],
+      ['missing-1'],
+    ];
+    const guide = (
+      id: string,
+      firstHeroSlots: [string[], string[]],
+      options: Parameters<typeof makeTeamComp>[3] = {}
+    ) =>
+      makeTeamComp(
+        id,
+        ['h0', 'h1', 'h2'],
+        [firstHeroSlots, noQualifiedSlots, noQualifiedSlots],
+        options
+      );
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      [
+        guide('stable-b', oneQualifiedSlot, { ranking: 'B' }),
+        guide('rank-s', oneQualifiedSlot, { ranking: 'S' }),
+        guide('skill-winner', [['s0'], ['s1']], { ranking: 'B' }),
+        guide('championship', oneQualifiedSlot, {
+          ranking: 'B',
+          sources: ['championship'],
+        }),
+        guide('stable-a', oneQualifiedSlot, { ranking: 'B' }),
+      ]
+    );
+
+    const decision =
+      result.debug?.topCandidates[0].teams[0].guideMatchDecision;
+    expect(decision).toEqual({
+      rankingOrder: [
+        'higher matched hero count',
+        'higher evidence-qualified skill-slot count',
+        'championship source before non-championship source',
+        'higher guide ranking score (S=3, A=2, other=1)',
+        'lower stable guide ID by locale order',
+      ],
+      selected: {
+        guideId: 'skill-winner',
+        matchedHeroes: ['h0', 'h1', 'h2'],
+        matchedHeroCount: 3,
+        qualifiedSkillSlotCount: 2,
+        championship: false,
+        ranking: 'B',
+        rankingScore: 1,
+        stableId: 'skill-winner',
+      },
+      rejected: [
+        expect.objectContaining({
+          guideId: 'championship',
+          qualifiedSkillSlotCount: 1,
+          championship: true,
+          rankingScore: 1,
+        }),
+        expect.objectContaining({
+          guideId: 'rank-s',
+          championship: false,
+          ranking: 'S',
+          rankingScore: 3,
+        }),
+        expect.objectContaining({ guideId: 'stable-a', stableId: 'stable-a' }),
+        expect.objectContaining({ guideId: 'stable-b', stableId: 'stable-b' }),
+      ],
+    });
+  });
+
   test('reserves qualified guide skills for a partial core before a stronger model pair', () => {
     const data = makeData({
       weights: {

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -141,10 +141,40 @@ describe('recommendSkillSet — best hero-routing', () => {
       standalone: { featureId: 'S|fire', weight: 0.2, support: 60 },
       chosenRoute: { featureId: 'HS|mage|fire', weight: 0.8, support: 30 },
       alternatives: [
-        { featureId: 'HS|mage|fire', weight: 0.8 },
-        { featureId: 'HS|tank|fire', weight: -0.3 },
+        {
+          hero: 'mage',
+          currentPoolIndex: 0,
+          rank: 1,
+          selected: true,
+          featureId: 'HS|mage|fire',
+          weight: 0.8,
+        },
+        {
+          hero: 'tank',
+          currentPoolIndex: 1,
+          rank: 2,
+          selected: false,
+          featureId: 'HS|tank|fire',
+          weight: -0.3,
+        },
       ],
       displayTotal: 10,
+    });
+  });
+
+  test('preserves current-pool order and records the tie-break for equal HS weights', () => {
+    const result = recommendSkillSet([['equal']], ['乙', '甲'], [], makeData());
+    const route = result.analysis[0].debug.skillRoutes?.[0];
+
+    expect(route).toMatchObject({
+      chosenHero: '乙',
+      selectionReason:
+        'highest HS weight tied; earliest hero in current-pool order won',
+      tiedBestHeroes: ['乙', '甲'],
+      alternatives: [
+        { hero: '乙', currentPoolIndex: 0, rank: 1, selected: true },
+        { hero: '甲', currentPoolIndex: 1, rank: 2, selected: false },
+      ],
     });
   });
 });
@@ -1376,6 +1406,97 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
           selected: null,
           rejected: [expect.objectContaining({ skill: 's0' })],
         }),
+      ])
+    );
+  });
+
+  test('traces augmenting reassignment when a later guide slot has one contested skill', () => {
+    const weights: Record<string, number> = {
+      'S|s0': 0.2,
+      'S|s1': 0.2,
+      'HS|h0|s0': 0.3,
+      'HS|h0|s1': 0.3,
+    };
+    const support: Record<string, number> = {
+      'S|s0': 10,
+      'S|s1': 10,
+      'HS|h0|s0': 16,
+      'HS|h0|s1': 16,
+    };
+    for (const hero of heroes.slice(0, 3)) {
+      weights[`H|${hero}`] = 0.2;
+      support[`H|${hero}`] = 10;
+    }
+    for (const [first, second] of [
+      ['h0', 'h1'],
+      ['h0', 'h2'],
+      ['h1', 'h2'],
+    ]) {
+      weights[`HP|${first}|${second}`] = 0.2;
+      support[`HP|${first}|${second}`] = 16;
+    }
+    const data = makeData({
+      weights,
+      support,
+      n_features: Object.keys(weights).length,
+    });
+    const guide = makeTeamComp(
+      'augmenting-guide',
+      ['h0', 'h1', 'h2'],
+      [
+        [['s0', 's1'], ['s0']],
+        [['missing-0'], ['missing-1']],
+        [['missing-2'], ['missing-3']],
+      ]
+    );
+
+    const result = recommendHybridTeams(
+      heroes,
+      skills,
+      data,
+      data.catalog,
+      {},
+      [guide]
+    );
+    const matching =
+      result.debug?.topCandidates[0].skillRouting.guideMatching
+        .maximumCardinality;
+
+    expect(
+      result.options[0].teams[0].heroes.find(({ name }) => name === 'h0')
+        ?.skillSlots
+    ).toEqual(['s1', 's0']);
+    expect(matching).toMatchObject({
+      matchedSlotCount: 2,
+      finalAssignments: [
+        {
+          slotKey: 'conservative|0|augmenting-guide|h0|0',
+          skill: 's1',
+        },
+        {
+          slotKey: 'conservative|0|augmenting-guide|h0|1',
+          skill: 's0',
+        },
+      ],
+    });
+    expect(matching?.events).toEqual(
+      expect.arrayContaining([
+        {
+          type: 'occupied-skill-conflict',
+          rootSlotKey: 'conservative|0|augmenting-guide|h0|1',
+          requestingSlotKey: 'conservative|0|augmenting-guide|h0|1',
+          skill: 's0',
+          occupyingSlotKey: 'conservative|0|augmenting-guide|h0|0',
+          resolvedByOwnerMove: true,
+        },
+        {
+          type: 'augmenting-owner-move',
+          rootSlotKey: 'conservative|0|augmenting-guide|h0|1',
+          requestedBySlotKey: 'conservative|0|augmenting-guide|h0|1',
+          ownerSlotKey: 'conservative|0|augmenting-guide|h0|0',
+          fromSkill: 's0',
+          toSkill: 's1',
+        },
       ])
     );
   });

--- a/web/src/services/recommendationDebug.ts
+++ b/web/src/services/recommendationDebug.ts
@@ -355,6 +355,12 @@ export function buildTeamFormationDebugContext({
   const excludedHeroByName = new Map(
     excludedHeroes.map((exclusion) => [exclusion.hero, exclusion])
   );
+  const heroReachabilityByName = new Map(
+    (formation?.debug?.heroSelectionReachability ?? []).map((reachability) => [
+      reachability.hero,
+      reachability,
+    ])
+  );
   const heroSet = new Set(consideredHeroes);
   const skillSet = new Set(uniqueSkills);
   const teams = selectedAssignedTeams(formation);
@@ -365,10 +371,6 @@ export function buildTeamFormationDebugContext({
     teams.flatMap((team) => team.heroes.flatMap(({ skills: assigned }) => assigned))
   );
   const pairGroups = combinations(consideredHeroes, 2);
-  const trioGroups = combinations(consideredHeroes, 3);
-  const qualifiedGroups = [...pairGroups, ...trioGroups].filter((group) =>
-    groupPasses(group, m)
-  );
 
   const base = {
     schema: SANMOU_DEBUG_SCHEMA,
@@ -522,19 +524,33 @@ export function buildTeamFormationDebugContext({
             };
           }
           const gate = featureGate(m, heroId(hero));
-          const qualifiedGroupCount = qualifiedGroups.filter((group) =>
-            group.includes(hero)
-          ).length;
+          const reachability = heroReachabilityByName.get(hero);
+          const qualifiedGroupCount =
+            reachability?.qualifiedGroupCount ??
+            ([
+              ...pairGroups,
+              ...combinations(consideredHeroes, 3),
+            ].filter(
+              (group) => group.includes(hero) && groupPasses(group, m)
+            ).length);
           return {
             name: hero,
             support_item: supportItems.has(hero),
             individual_gate: gate,
             qualified_pair_or_trio_count: qualifiedGroupCount,
+            selection_search_reachability: reachability
+              ? {
+                  reached_final_evaluation: reachability.reachedFinalEvaluation,
+                  depths: reachability.depths.map((depth) => ({ ...depth })),
+                }
+              : null,
             reason: !gate.passed
               ? 'atomic_hero_evidence_gate_failed'
               : qualifiedGroupCount === 0
                 ? 'no_fully_evidence_qualified_pair_or_trio'
-                : 'eligible_groups_existed_but_lost_global_ranking',
+                : reachability && !reachability.reachedFinalEvaluation
+                  ? 'qualified_groups_entirely_pruned_by_proxy_beam'
+                  : 'eligible_groups_reached_final_evaluation_but_lost_global_ranking',
           };
         }),
       skills: uniqueSkills

--- a/web/src/services/recommendationDebug.ts
+++ b/web/src/services/recommendationDebug.ts
@@ -194,7 +194,15 @@ export function buildRoundRecommendationDebugContext({
                 support: route.chosenRoute.support,
               }
             : null,
+          ranking_order: [...route.rankingOrder],
+          selection_reason: route.selectionReason,
+          tied_best_heroes: [...route.tiedBestHeroes],
           alternatives: route.alternatives.map((alternative) => ({
+            rank: alternative.rank,
+            hero: alternative.hero,
+            current_pool_index: alternative.currentPoolIndex,
+            selected: alternative.selected,
+            tied_for_best_weight: alternative.tiedForBestWeight,
             feature_id: alternative.featureId,
             weight: alternative.weight,
             display_points: alternative.displayPoints,

--- a/web/src/services/recommendationDebug.ts
+++ b/web/src/services/recommendationDebug.ts
@@ -515,21 +515,32 @@ export function buildTeamFormationDebugContext({
         .filter((skill) => !selectedSkills.has(skill))
         .map((skill) => {
           const gate = featureGate(m, skillId(skill));
-          const eligibleHeroes = uniqueHeroes.filter(
+          const evidenceQualifiedHeroes = uniqueHeroes.filter(
             (hero) =>
               recommendationData.catalog.default_skill[hero] !== skill &&
               featureGate(m, heroSkillId(hero, skill)).passed
+          );
+          const selectedHeroRoutes = evidenceQualifiedHeroes.filter((hero) =>
+            selectedHeroes.has(hero)
+          );
+          const unplacedHeroRoutes = evidenceQualifiedHeroes.filter(
+            (hero) => !selectedHeroes.has(hero)
           );
           return {
             name: skill,
             support_item: supportItems.has(skill),
             individual_gate: gate,
-            eligible_hero_routes: eligibleHeroes,
+            evidence_qualified_routes: {
+              selected_heroes: selectedHeroRoutes,
+              unplaced_heroes: unplacedHeroRoutes,
+            },
             reason: !gate.passed
               ? 'atomic_skill_evidence_gate_failed'
-              : eligibleHeroes.length === 0
-                ? 'no_evidence_qualified_hero_skill_route'
-                : 'eligible_routes_existed_but_lost_assignment_or_capacity_ranking',
+              : selectedHeroRoutes.length > 0
+                ? 'routes_to_selected_heroes_lost_assignment_or_capacity_ranking'
+                : unplacedHeroRoutes.length > 0
+                  ? 'evidence_qualified_routes_exist_only_to_unplaced_heroes'
+                  : 'no_evidence_qualified_hero_skill_route',
           };
         }),
     },

--- a/web/src/services/recommendationDebug.ts
+++ b/web/src/services/recommendationDebug.ts
@@ -350,7 +350,12 @@ export function buildTeamFormationDebugContext({
   const m = recommendationData.model;
   const uniqueHeroes = [...new Set(heroes)];
   const uniqueSkills = [...new Set(skills)];
-  const heroSet = new Set(uniqueHeroes);
+  const consideredHeroes = formation?.debug?.consideredHeroes ?? uniqueHeroes;
+  const excludedHeroes = formation?.debug?.excludedHeroes ?? [];
+  const excludedHeroByName = new Map(
+    excludedHeroes.map((exclusion) => [exclusion.hero, exclusion])
+  );
+  const heroSet = new Set(consideredHeroes);
   const skillSet = new Set(uniqueSkills);
   const teams = selectedAssignedTeams(formation);
   const selectedHeroes = new Set(
@@ -359,8 +364,8 @@ export function buildTeamFormationDebugContext({
   const selectedSkills = new Set(
     teams.flatMap((team) => team.heroes.flatMap(({ skills: assigned }) => assigned))
   );
-  const pairGroups = combinations(uniqueHeroes, 2);
-  const trioGroups = combinations(uniqueHeroes, 3);
+  const pairGroups = combinations(consideredHeroes, 2);
+  const trioGroups = combinations(consideredHeroes, 3);
   const qualifiedGroups = [...pairGroups, ...trioGroups].filter((group) =>
     groupPasses(group, m)
   );
@@ -390,13 +395,15 @@ export function buildTeamFormationDebugContext({
     };
   }
 
-  const heroGates = uniqueHeroes.map((hero) => featureGate(m, heroId(hero)));
+  const heroGates = consideredHeroes.map((hero) =>
+    featureGate(m, heroId(hero))
+  );
   const heroPairGates = pairGroups.map(([first, second]) =>
     featureGate(m, heroPairId(first, second))
   );
   const skillGates = uniqueSkills.map((skill) => featureGate(m, skillId(skill)));
   const heroSkillGates = uniqueSkills.map((skill) => {
-    const allRoutes = uniqueHeroes.map((hero) => ({
+    const allRoutes = consideredHeroes.map((hero) => ({
       hero,
       is_signature_skill:
         recommendationData.catalog.default_skill[hero] === skill,
@@ -430,6 +437,7 @@ export function buildTeamFormationDebugContext({
     ? (({ topCandidates, ...summary }) => ({
         ...summary,
         winner: topCandidates[0] ?? null,
+        runner_up: topCandidates[1] ?? null,
       }))(formation.debug)
     : null;
 
@@ -484,14 +492,13 @@ export function buildTeamFormationDebugContext({
     },
     optimizer_trace: optimizerTrace,
     recommended_teams: recommendedTeams,
-    strongest_rejected_alternatives:
-      formation.debug?.topCandidates.slice(1) ?? [],
     evidence_gates: {
       heroes: heroGates,
       hero_pairs: heroPairGates,
       skills: skillGates,
       hero_skill_routes: heroSkillGates,
       observed_skill_pairs: supportedSkillPairs,
+      pool_cap_exclusions: excludedHeroes.map((exclusion) => ({ ...exclusion })),
     },
     relevant_guide_teams: relevantGuideTeams(
       database.team ?? [],
@@ -503,6 +510,17 @@ export function buildTeamFormationDebugContext({
       heroes: uniqueHeroes
         .filter((hero) => !selectedHeroes.has(hero))
         .map((hero) => {
+          const exclusion = excludedHeroByName.get(hero);
+          if (exclusion) {
+            return {
+              name: hero,
+              support_item: supportItems.has(hero),
+              individual_gate: null,
+              qualified_pair_or_trio_count: 0,
+              pool_cap_exclusion: { ...exclusion },
+              reason: 'excluded_by_alphabetical_hero_pool_cap',
+            };
+          }
           const gate = featureGate(m, heroId(hero));
           const qualifiedGroupCount = qualifiedGroups.filter((group) =>
             group.includes(hero)
@@ -523,7 +541,7 @@ export function buildTeamFormationDebugContext({
         .filter((skill) => !selectedSkills.has(skill))
         .map((skill) => {
           const gate = featureGate(m, skillId(skill));
-          const evidenceQualifiedHeroes = uniqueHeroes.filter(
+          const evidenceQualifiedHeroes = consideredHeroes.filter(
             (hero) =>
               recommendationData.catalog.default_skill[hero] !== skill &&
               featureGate(m, heroSkillId(hero, skill)).passed

--- a/web/src/services/recommendationDebug.ts
+++ b/web/src/services/recommendationDebug.ts
@@ -1,0 +1,605 @@
+import { database, recommendationData } from '../data';
+import type { TeamComp } from '../types/domain';
+import type {
+  CurrentRoundInputs,
+  GameState,
+  Recommendation,
+  RoundType,
+} from '../types/game';
+import type { FeatureFamily, PairedModel } from '../types/recommendation';
+import type {
+  FormationRecommendation,
+  OptionAnalysis,
+  ProjectedTeam,
+} from './recommendationEngine';
+import {
+  teamBuilderConfidenceSupport,
+} from './recommendationEngine';
+import {
+  heroId,
+  heroPairId,
+  heroSkillId,
+  skillId,
+  teamFeatureIds,
+} from './recommendationModel';
+import type { TeamBuilderLayout } from './teamBuilderArrangement';
+
+export const SANMOU_DEBUG_SCHEMA = 'sanmou-recommendation-debug/v1' as const;
+
+const displayPoints = (weight: number): number =>
+  Math.round(weight * 100) / 10;
+
+const featureFamily = (featureId: string): FeatureFamily =>
+  featureId.split('|')[0] as FeatureFamily;
+
+const featureMeaning = (featureId: string): string => {
+  const [family, ...names] = featureId.split('|');
+  if (family === 'H') return `武将个体：${names[0]}`;
+  if (family === 'S') return `战法个体：${names[0]}`;
+  if (family === 'HP') return `武将配合：${names.join(' + ')}`;
+  if (family === 'HS') return `武将与战法：${names[0]} · ${names[1]}`;
+  if (family === 'SP')
+    return `战法搭配：${names[0]} · ${names.slice(1).join(' + ')}`;
+  return featureId;
+};
+
+const modelMetadata = () => ({
+  model_type: recommendationData.schema.model_type,
+  schema_version: recommendationData.schema.version,
+  catalog_version: recommendationData.catalog.catalog_version,
+  corpus_version: recommendationData.battle_counts.corpus_version,
+  total_battles: recommendationData.battle_counts.total_battles,
+  minimum_support: {
+    H: recommendationData.model.min_support_single,
+    S: recommendationData.model.min_support_single,
+    HP: recommendationData.model.min_support_pair,
+    HS: recommendationData.model.min_support_pair,
+    SP: recommendationData.model.min_support_pair,
+  },
+  score_scale: 'display points = raw fitted weight × 10, rounded to one decimal',
+  score_meaning:
+    'Relative roster strength against the learned metagame; not an opponent-specific win probability.',
+});
+
+export interface RoundDebugInput {
+  season: number;
+  gameState: GameState;
+  roundType: RoundType;
+  currentRoundInputs: CurrentRoundInputs;
+  recommendation: Recommendation | null;
+}
+
+export function buildRoundRecommendationDebugContext({
+  season,
+  gameState,
+  roundType,
+  currentRoundInputs,
+  recommendation,
+}: RoundDebugInput): Record<string, unknown> {
+  const offeredSets = [
+    currentRoundInputs.set1 ?? [],
+    currentRoundInputs.set2 ?? [],
+    currentRoundInputs.set3 ?? [],
+  ];
+  const base = {
+    schema: SANMOU_DEBUG_SCHEMA,
+    page: 'candidate-suggestion',
+    model: modelMetadata(),
+    input: {
+      season,
+      round: gameState.round_number,
+      round_type: roundType,
+      current_pool: {
+        heroes: [...gameState.current_heroes],
+        skills: [...gameState.current_skills],
+        support_hero: gameState.support_hero,
+        support_skills: [...gameState.support_skills],
+        heroes_used_for_scoring: [
+          ...gameState.current_heroes,
+          ...(gameState.support_hero ? [gameState.support_hero] : []),
+        ],
+        skills_used_for_scoring: [
+          ...gameState.current_skills,
+          ...gameState.support_skills,
+        ],
+      },
+      offered_sets: offeredSets.map((items, index) => ({
+        index,
+        label: String.fromCharCode(65 + index),
+        items: [...items],
+      })),
+    },
+  };
+
+  const analysis = recommendation?.analysis as OptionAnalysis[] | undefined;
+  if (!recommendation || !Array.isArray(analysis) || analysis.length === 0) {
+    return {
+      ...base,
+      status: 'not-ready',
+      reason: 'No recommendation has been calculated for the current offers.',
+      next_step:
+        'Complete all three option sets and click 获取 AI 推荐, then run sanmouDebug() again.',
+    };
+  }
+
+  const recommendedIndex = recommendation.recommended_set_index;
+  const ranked = [...analysis].sort((left, right) => left.rank - right.rank);
+  const winner =
+    typeof recommendedIndex === 'number'
+      ? analysis.find(({ set_index }) => set_index === recommendedIndex)
+      : undefined;
+  const runnerUp = ranked.find(({ set_index }) => set_index !== recommendedIndex);
+
+  return {
+    ...base,
+    status: 'ready',
+    decision: {
+      recommended_index: recommendedIndex,
+      recommended_label:
+        typeof recommendedIndex === 'number'
+          ? String.fromCharCode(65 + recommendedIndex)
+          : null,
+      ranking_rule: [
+        'higher final_score',
+        'higher total evidence support when displayed scores tie',
+        'lower option index when still tied',
+      ],
+      ranking: ranked.map((option) => ({
+        rank: option.rank,
+        option: String.fromCharCode(65 + option.set_index),
+        final_score: option.final_score,
+        raw_score: option.debug?.rawScore ?? null,
+        total_support: option.evidence.totalSupport,
+        minimum_support_in_active_evidence: option.evidence.minSupport,
+      })),
+      winner_margin_over_runner_up:
+        winner && runnerUp
+          ? Math.round((winner.final_score - runnerUp.final_score) * 10) / 10
+          : null,
+    },
+    options: analysis.map((option) => ({
+      option: String.fromCharCode(65 + option.set_index),
+      index: option.set_index,
+      rank: option.rank,
+      items: [...option.items],
+      raw_score: option.debug?.rawScore ?? null,
+      display_score: option.final_score,
+      item_scores: option.item_scores.map((item) => ({ ...item })),
+      evidence: { ...option.evidence },
+      score_calculation:
+        option.debug?.evaluatedFeatures.map((feature) => ({
+          feature_id: feature.featureId,
+          meaning: featureMeaning(feature.featureId),
+          family: feature.family,
+          weight: feature.weight,
+          display_points: feature.displayPoints,
+          support: feature.support,
+          contributes_to_score: feature.weight !== 0,
+        })) ?? [],
+      skill_routing:
+        option.debug?.skillRoutes?.map((route) => ({
+          skill: route.skill,
+          standalone: {
+            feature_id: route.standalone.featureId,
+            weight: route.standalone.weight,
+            display_points: route.standalone.displayPoints,
+            support: route.standalone.support,
+          },
+          chosen_hero: route.chosenHero,
+          chosen_route: route.chosenRoute
+            ? {
+                feature_id: route.chosenRoute.featureId,
+                weight: route.chosenRoute.weight,
+                display_points: route.chosenRoute.displayPoints,
+                support: route.chosenRoute.support,
+              }
+            : null,
+          alternatives: route.alternatives.map((alternative) => ({
+            feature_id: alternative.featureId,
+            weight: alternative.weight,
+            display_points: alternative.displayPoints,
+            support: alternative.support,
+          })),
+          raw_total: route.rawTotal,
+          display_total: route.displayTotal,
+        })) ?? [],
+    })),
+    player_preference_model: recommendation.preference
+      ? {
+          ...(recommendation.preference as Record<string, unknown>),
+          affects_ai_recommendation: false,
+          note:
+            'This separately labelled model describes historical player choices and never changes the paired-model AI recommendation.',
+        }
+      : {
+          available: false,
+          affects_ai_recommendation: false,
+        },
+  };
+}
+
+interface FeatureGate {
+  feature_id: string;
+  meaning: string;
+  family: FeatureFamily;
+  weight: number;
+  display_points: number;
+  support: number;
+  required_support: number;
+  passed: boolean;
+}
+
+const featureGate = (m: PairedModel, featureId: string): FeatureGate => {
+  const family = featureFamily(featureId);
+  const support = m.support[featureId] ?? 0;
+  const requiredSupport = teamBuilderConfidenceSupport(m, family);
+  const weight = m.weights[featureId] ?? 0;
+  return {
+    feature_id: featureId,
+    meaning: featureMeaning(featureId),
+    family,
+    weight,
+    display_points: displayPoints(weight),
+    support,
+    required_support: requiredSupport,
+    passed: support >= requiredSupport,
+  };
+};
+
+const combinations = (items: string[], size: 2 | 3): string[][] => {
+  const result: string[][] = [];
+  for (let first = 0; first < items.length; first += 1) {
+    for (let second = first + 1; second < items.length; second += 1) {
+      if (size === 2) {
+        result.push([items[first], items[second]]);
+        continue;
+      }
+      for (let third = second + 1; third < items.length; third += 1) {
+        result.push([items[first], items[second], items[third]]);
+      }
+    }
+  }
+  return result;
+};
+
+const groupPasses = (heroes: string[], m: PairedModel): boolean => {
+  if (heroes.some((hero) => !featureGate(m, heroId(hero)).passed)) return false;
+  for (let first = 0; first < heroes.length; first += 1) {
+    for (let second = first + 1; second < heroes.length; second += 1) {
+      if (!featureGate(m, heroPairId(heroes[first], heroes[second])).passed)
+        return false;
+    }
+  }
+  return true;
+};
+
+const selectedAssignedTeams = (
+  formation: FormationRecommendation | null
+): ProjectedTeam[] =>
+  formation && !formation.incomplete ? formation.options[0]?.teams ?? [] : [];
+
+const relevantGuideTeams = (
+  teamComps: TeamComp[],
+  heroPool: Set<string>,
+  skillPool: Set<string>,
+  m: PairedModel
+) =>
+  teamComps.flatMap((comp) => {
+    const matchedHeroes = comp.members
+      .map(({ hero }) => hero)
+      .filter((hero) => heroPool.has(hero));
+    if (matchedHeroes.length < 2) return [];
+    return [
+      {
+        id: comp.id,
+        ranking: comp.ranking,
+        sources: [...comp.sources],
+        formation: comp.formation,
+        matched_heroes: matchedHeroes,
+        members: comp.members.map((member) => ({
+          hero: member.hero,
+          hero_owned: heroPool.has(member.hero),
+          skill_slots: member.skillSlots.map((alternatives) =>
+            alternatives
+              .filter((skill) => skillPool.has(skill))
+              .map((skill) => ({
+                skill,
+                skill_gate: featureGate(m, skillId(skill)),
+                hero_skill_gate: featureGate(
+                  m,
+                  heroSkillId(member.hero, skill)
+                ),
+                is_signature_skill:
+                  recommendationData.catalog.default_skill[member.hero] === skill,
+              }))
+          ),
+        })),
+      },
+    ];
+  });
+
+export interface FormationDebugInput {
+  season: number;
+  heroes: string[];
+  skills: string[];
+  supportItems: Set<string>;
+  formation: FormationRecommendation | null;
+  resultReady: boolean;
+  currentLayout: TeamBuilderLayout;
+  currentLayoutMatchesRecommendation: boolean;
+}
+
+export function buildTeamFormationDebugContext({
+  season,
+  heroes,
+  skills,
+  supportItems,
+  formation,
+  resultReady,
+  currentLayout,
+  currentLayoutMatchesRecommendation,
+}: FormationDebugInput): Record<string, unknown> {
+  const m = recommendationData.model;
+  const uniqueHeroes = [...new Set(heroes)];
+  const uniqueSkills = [...new Set(skills)];
+  const heroSet = new Set(uniqueHeroes);
+  const skillSet = new Set(uniqueSkills);
+  const teams = selectedAssignedTeams(formation);
+  const selectedHeroes = new Set(
+    teams.flatMap((team) => team.heroes.map(({ name }) => name))
+  );
+  const selectedSkills = new Set(
+    teams.flatMap((team) => team.heroes.flatMap(({ skills: assigned }) => assigned))
+  );
+  const pairGroups = combinations(uniqueHeroes, 2);
+  const trioGroups = combinations(uniqueHeroes, 3);
+  const qualifiedGroups = [...pairGroups, ...trioGroups].filter((group) =>
+    groupPasses(group, m)
+  );
+
+  const base = {
+    schema: SANMOU_DEBUG_SCHEMA,
+    page: 'team-formation-suggestion',
+    model: modelMetadata(),
+    input: {
+      season,
+      heroes: uniqueHeroes,
+      skills: uniqueSkills,
+      support_items: [...supportItems].sort(),
+    },
+  };
+
+  if (!resultReady || !formation) {
+    return {
+      ...base,
+      status: 'not-ready',
+      reason:
+        uniqueHeroes.length < 9 || uniqueSkills.length < 18
+          ? `Automatic recommendation needs at least 9 heroes and 18 skills; current pool has ${uniqueHeroes.length} heroes and ${uniqueSkills.length} skills.`
+          : 'The team recommendation is still being calculated.',
+      next_step:
+        'Wait for the team formation page to finish loading, then run sanmouDebug() again.',
+    };
+  }
+
+  const heroGates = uniqueHeroes.map((hero) => featureGate(m, heroId(hero)));
+  const heroPairGates = pairGroups.map(([first, second]) =>
+    featureGate(m, heroPairId(first, second))
+  );
+  const skillGates = uniqueSkills.map((skill) => featureGate(m, skillId(skill)));
+  const heroSkillGates = uniqueSkills.map((skill) => {
+    const allRoutes = uniqueHeroes.map((hero) => ({
+      hero,
+      is_signature_skill:
+        recommendationData.catalog.default_skill[hero] === skill,
+      gate: featureGate(m, heroSkillId(hero, skill)),
+    }));
+    const observedRoutes = allRoutes.filter(
+      ({ gate }) => gate.support > 0 || gate.weight !== 0
+    );
+    return {
+      skill,
+      routes: observedRoutes,
+      omitted_zero_evidence_routes: allRoutes.length - observedRoutes.length,
+      omitted_route_meaning:
+        'The omitted hero routes have zero support and zero fitted weight.',
+    };
+  });
+  const supportedSkillPairs = Object.keys({ ...m.support, ...m.weights })
+    .filter((featureId) => {
+      const [family, hero, first, second] = featureId.split('|');
+      return (
+        family === 'SP' &&
+        heroSet.has(hero) &&
+        skillSet.has(first) &&
+        skillSet.has(second)
+      );
+    })
+    .sort()
+    .map((featureId) => featureGate(m, featureId));
+
+  const optimizerTrace = formation.debug
+    ? (({ topCandidates, ...summary }) => ({
+        ...summary,
+        winner: topCandidates[0] ?? null,
+      }))(formation.debug)
+    : null;
+
+  const recommendedTeams = teams.map((team, index) => {
+    const assigned = team.heroes.map((hero) => ({
+      name: hero.name,
+      skills: [...hero.skills],
+    }));
+    const scoreRows = [...teamFeatureIds(assigned)]
+      .map((featureId) => featureGate(m, featureId))
+      .sort((left, right) =>
+        right.weight !== left.weight
+          ? right.weight - left.weight
+          : left.feature_id.localeCompare(right.feature_id)
+      );
+    return {
+      team: index + 1,
+      heroes: team.heroes.map((hero) => ({
+        name: hero.name,
+        skills: [...hero.skills],
+        skill_slots: hero.skillSlots ? [...hero.skillSlots] : undefined,
+        skill_score: hero.skillScore,
+        slot_index: hero.slotIndex,
+      })),
+      strength: team.strength,
+      formation: team.formation ?? null,
+      guide_match: team.knownTeam ? { ...team.knownTeam } : null,
+      full_score_breakdown: scoreRows,
+      score_check: {
+        raw_sum: scoreRows.reduce((sum, row) => sum + row.weight, 0),
+        displayed_sum_before_final_rounding: scoreRows.reduce(
+          (sum, row) => sum + row.display_points,
+          0
+        ),
+      },
+    };
+  });
+
+  return {
+    ...base,
+    status: formation.incomplete ? 'incomplete' : 'ready',
+    policy: {
+      name: 'evidence-only-team-builder',
+      rules: [
+        'Every placed hero must independently pass its H evidence gate.',
+        'Every hero pair inside a selected pair/trio must independently pass its HP evidence gate.',
+        'Every placed skill must independently pass both its S and assigned-hero HS evidence gates.',
+        'Positive, zero, and negative supported weights remain eligible and affect ranking.',
+        'A usable exact 3/3 guide core is ranked before fully assigned model gain.',
+        'Guide data preserves qualified slots but never bypasses an evidence gate.',
+      ],
+    },
+    optimizer_trace: optimizerTrace,
+    recommended_teams: recommendedTeams,
+    strongest_rejected_alternatives:
+      formation.debug?.topCandidates.slice(1) ?? [],
+    evidence_gates: {
+      heroes: heroGates,
+      hero_pairs: heroPairGates,
+      skills: skillGates,
+      hero_skill_routes: heroSkillGates,
+      observed_skill_pairs: supportedSkillPairs,
+    },
+    relevant_guide_teams: relevantGuideTeams(
+      database.team ?? [],
+      heroSet,
+      skillSet,
+      m
+    ),
+    unplaced_items: {
+      heroes: uniqueHeroes
+        .filter((hero) => !selectedHeroes.has(hero))
+        .map((hero) => {
+          const gate = featureGate(m, heroId(hero));
+          const qualifiedGroupCount = qualifiedGroups.filter((group) =>
+            group.includes(hero)
+          ).length;
+          return {
+            name: hero,
+            support_item: supportItems.has(hero),
+            individual_gate: gate,
+            qualified_pair_or_trio_count: qualifiedGroupCount,
+            reason: !gate.passed
+              ? 'atomic_hero_evidence_gate_failed'
+              : qualifiedGroupCount === 0
+                ? 'no_fully_evidence_qualified_pair_or_trio'
+                : 'eligible_groups_existed_but_lost_global_ranking',
+          };
+        }),
+      skills: uniqueSkills
+        .filter((skill) => !selectedSkills.has(skill))
+        .map((skill) => {
+          const gate = featureGate(m, skillId(skill));
+          const eligibleHeroes = uniqueHeroes.filter(
+            (hero) =>
+              recommendationData.catalog.default_skill[hero] !== skill &&
+              featureGate(m, heroSkillId(hero, skill)).passed
+          );
+          return {
+            name: skill,
+            support_item: supportItems.has(skill),
+            individual_gate: gate,
+            eligible_hero_routes: eligibleHeroes,
+            reason: !gate.passed
+              ? 'atomic_skill_evidence_gate_failed'
+              : eligibleHeroes.length === 0
+                ? 'no_evidence_qualified_hero_skill_route'
+                : 'eligible_routes_existed_but_lost_assignment_or_capacity_ranking',
+          };
+        }),
+    },
+    current_layout: {
+      matches_original_recommendation: currentLayoutMatchesRecommendation,
+      user_edited: !currentLayoutMatchesRecommendation,
+      layout: currentLayout,
+    },
+  };
+}
+
+type DebugContextFactory = () => Record<string, unknown>;
+let activeDebugFactory: DebugContextFactory | null = null;
+let activeRegistration: symbol | null = null;
+
+const noActiveDebugContext = (): Record<string, unknown> => ({
+  schema: SANMOU_DEBUG_SCHEMA,
+  page: 'unsupported',
+  status: 'not-ready',
+  reason:
+    'Open the candidate suggestion or team formation suggestion page before running sanmouDebug().',
+});
+
+declare global {
+  interface Window {
+    /** Returns pretty, copy-ready JSON and logs the corresponding object. */
+    sanmouDebug?: () => string;
+  }
+}
+
+const installGlobalDebugFunction = (): void => {
+  if (typeof window === 'undefined') return;
+  window.sanmouDebug = () => {
+    let context: Record<string, unknown>;
+    try {
+      context = activeDebugFactory?.() ?? noActiveDebugContext();
+    } catch (error) {
+      context = {
+        schema: SANMOU_DEBUG_SCHEMA,
+        page: 'unknown',
+        status: 'error',
+        reason:
+          error instanceof Error ? error.message : 'Unknown debug export error',
+      };
+    }
+    console.info(
+      'Sanmou recommendation debug context. Copy with: copy(sanmouDebug())',
+      context
+    );
+    return JSON.stringify(context, null, 2);
+  };
+};
+
+export function registerSanmouDebugContext(
+  factory: DebugContextFactory
+): () => void {
+  if (typeof window === 'undefined') return () => undefined;
+  const registration = Symbol('sanmou-debug-registration');
+  activeRegistration = registration;
+  activeDebugFactory = factory;
+  installGlobalDebugFunction();
+  return () => {
+    if (activeRegistration !== registration) return;
+    activeRegistration = null;
+    activeDebugFactory = null;
+  };
+}
+
+export function clearSanmouDebugContextForTests(): void {
+  activeRegistration = null;
+  activeDebugFactory = null;
+  if (typeof window !== 'undefined') delete window.sanmouDebug;
+}

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -771,6 +771,87 @@ export interface FormationDebugTeam {
   prioritizedExactGuide: boolean;
 }
 
+export interface FormationSelectionProxyDebug {
+  exactGuideCount: number;
+  heroGain: number;
+  heroesPlaced: number;
+  completeTrios: number;
+  heroSupport: number;
+  canonicalKey: string;
+}
+
+export interface FormationBeamPruningDebug {
+  depth: number;
+  preCapCount: number;
+  retainedCount: number;
+  nominalCap: number;
+  effectiveCap: number;
+  proxyRankingOrder: string[];
+  nominalCutoff: FormationSelectionProxyDebug | null;
+  retainedCutoff: FormationSelectionProxyDebug | null;
+  exactGuideReservations: Array<{
+    guideId: string;
+    canonicalKey: string;
+    proxyRank: number;
+    outsideNominalCutoff: boolean;
+  }>;
+  retainedOnlyByReservationCount: number;
+}
+
+export interface FormationGuideSkillCandidateDebug {
+  skill: string;
+  gain: number;
+  support: number;
+  stableKey: string;
+}
+
+export interface FormationGuideSkillSlotDebug {
+  slotKey: string;
+  hero: string;
+  slotIndex: number;
+  priority: {
+    matchedHeroCount: number;
+    qualifiedSkillSlotCount: number;
+    championship: boolean;
+    rankingScore: number;
+    stableKey: string;
+  };
+  selected: FormationGuideSkillCandidateDebug | null;
+  rejected: FormationGuideSkillCandidateDebug[];
+}
+
+export interface FormationSkillRouteCandidateDebug {
+  hero: string;
+  additions: string[];
+  gain: number;
+  support: number;
+  stableKey: string;
+  placements: Array<{
+    skill: string;
+    slotIndex: number;
+    preferredGuideSlot: boolean;
+  }>;
+}
+
+export interface FormationSkillRoutingDebug {
+  guideMatching: {
+    slotRankingOrder: string[];
+    alternativeRankingOrder: string[];
+    slots: FormationGuideSkillSlotDebug[];
+  };
+  modelRouting: {
+    rankingOrder: string[];
+    rejectedCandidateLimit: number;
+    steps: Array<{
+      step: number;
+      candidateCount: number;
+      selected: FormationSkillRouteCandidateDebug;
+      rejected: FormationSkillRouteCandidateDebug[];
+      omittedRejectedCount: number;
+    }>;
+  };
+}
+
 export interface FormationDebugCandidate {
   rank: number;
   exactGuideIds: string[];
@@ -783,6 +864,7 @@ export interface FormationDebugCandidate {
   heroSupport: number;
   canonicalKey: string;
   teams: FormationDebugTeam[];
+  skillRouting: FormationSkillRoutingDebug;
 }
 
 export interface FormationDecisionDebug {
@@ -795,6 +877,7 @@ export interface FormationDecisionDebug {
   candidateSelectionsEvaluated: number;
   prioritizedExactGuideCoreCount: number;
   rankingOrder: string[];
+  beamPruning: FormationBeamPruningDebug[];
   /** Winner plus the strongest rejected candidates, in exact optimiser order. */
   topCandidates: FormationDebugCandidate[];
 }
@@ -2692,6 +2775,15 @@ interface ConservativeGroupSelection {
  */
 const CONSERVATIVE_SELECTION_BEAM_CAP = 64;
 
+const CONSERVATIVE_SELECTION_PROXY_RANKING_ORDER = [
+  'more usable exact 3/3 guide cores',
+  'higher unassigned hero model gain',
+  'more heroes placed',
+  'more complete trios',
+  'higher hero evidence support',
+  'lower stable canonical key by locale order',
+];
+
 const exactGuideIdsFor = (groups: ConservativeTeamGroup[]): string[] =>
   groups
     .filter(({ prioritizedExactGuide }) => prioritizedExactGuide)
@@ -2721,6 +2813,17 @@ function makeConservativeGroupSelection(
   };
 }
 
+const conservativeSelectionProxyDebug = (
+  selection: ConservativeGroupSelection
+): FormationSelectionProxyDebug => ({
+  exactGuideCount: selection.exactGuideIds.length,
+  heroGain: selection.heroGain,
+  heroesPlaced: selection.heroesPlaced,
+  completeTrios: selection.completeTrios,
+  heroSupport: selection.heroSupport,
+  canonicalKey: selection.key,
+});
+
 /** Proxy ordering for the bounded search; final ordering uses assigned skills. */
 function compareConservativeSelectionProxy(
   left: ConservativeGroupSelection,
@@ -2740,10 +2843,35 @@ function compareConservativeSelectionProxy(
 }
 
 function capConservativeSelections(
-  selections: ConservativeGroupSelection[]
-): ConservativeGroupSelection[] {
+  selections: ConservativeGroupSelection[],
+  depth: number
+): {
+  retained: ConservativeGroupSelection[];
+  debug: FormationBeamPruningDebug;
+} {
   const ordered = [...selections].sort(compareConservativeSelectionProxy);
-  if (ordered.length <= CONSERVATIVE_SELECTION_BEAM_CAP) return ordered;
+  const proxyRank = new Map(
+    ordered.map((selection, index) => [selection.key, index + 1])
+  );
+  if (ordered.length <= CONSERVATIVE_SELECTION_BEAM_CAP) {
+    return {
+      retained: ordered,
+      debug: {
+        depth,
+        preCapCount: ordered.length,
+        retainedCount: ordered.length,
+        nominalCap: CONSERVATIVE_SELECTION_BEAM_CAP,
+        effectiveCap: CONSERVATIVE_SELECTION_BEAM_CAP,
+        proxyRankingOrder: [...CONSERVATIVE_SELECTION_PROXY_RANKING_ORDER],
+        nominalCutoff: null,
+        retainedCutoff: ordered.length
+          ? conservativeSelectionProxyDebug(ordered.at(-1)!)
+          : null,
+        exactGuideReservations: [],
+        retainedOnlyByReservationCount: 0,
+      },
+    };
+  }
 
   // A low raw-weight exact team must not disappear merely because a different
   // exact or model-only core sorts above it. Keep one best extension containing
@@ -2760,20 +2888,58 @@ function capConservativeSelections(
     [...reserved.values()].map((selection) => [selection.key, selection])
   ).values()];
   const pickedKeys = new Set(picked.map(({ key }) => key));
+  const effectiveCap = Math.max(
+    CONSERVATIVE_SELECTION_BEAM_CAP,
+    reserved.size
+  );
   for (const selection of ordered) {
-    if (picked.length >= Math.max(CONSERVATIVE_SELECTION_BEAM_CAP, reserved.size))
-      break;
+    if (picked.length >= effectiveCap) break;
     if (pickedKeys.has(selection.key)) continue;
     picked.push(selection);
     pickedKeys.add(selection.key);
   }
-  return picked.sort(compareConservativeSelectionProxy);
+  const retained = picked.sort(compareConservativeSelectionProxy);
+  const exactGuideReservations = [...reserved.entries()].map(
+    ([guideId, selection]) => ({
+      guideId,
+      canonicalKey: selection.key,
+      proxyRank: proxyRank.get(selection.key)!,
+      outsideNominalCutoff:
+        proxyRank.get(selection.key)! > CONSERVATIVE_SELECTION_BEAM_CAP,
+    })
+  );
+  return {
+    retained,
+    debug: {
+      depth,
+      preCapCount: ordered.length,
+      retainedCount: retained.length,
+      nominalCap: CONSERVATIVE_SELECTION_BEAM_CAP,
+      effectiveCap,
+      proxyRankingOrder: [...CONSERVATIVE_SELECTION_PROXY_RANKING_ORDER],
+      nominalCutoff: conservativeSelectionProxyDebug(
+        ordered[CONSERVATIVE_SELECTION_BEAM_CAP - 1]
+      ),
+      retainedCutoff: retained.length
+        ? conservativeSelectionProxyDebug(retained.at(-1)!)
+        : null,
+      exactGuideReservations,
+      retainedOnlyByReservationCount: new Set(
+        exactGuideReservations
+          .filter(({ outsideNominalCutoff }) => outsideNominalCutoff)
+          .map(({ canonicalKey }) => canonicalKey)
+      ).size,
+    },
+  };
 }
 
 /** Enumerate bounded, disjoint selections of one to three mixed pairs/trios. */
 function enumerateConservativeGroupSelections(
   candidateGroups: ConservativeTeamGroup[]
-): ConservativeGroupSelection[] {
+): {
+  selections: ConservativeGroupSelection[];
+  beamPruning: FormationBeamPruningDebug[];
+} {
   const candidates = [...candidateGroups].sort((left, right) =>
     left.group.key.localeCompare(right.group.key)
   );
@@ -2781,6 +2947,7 @@ function enumerateConservativeGroupSelections(
     makeConservativeGroupSelection([], 0),
   ];
   const selections: ConservativeGroupSelection[] = [];
+  const beamPruning: FormationBeamPruningDebug[] = [];
 
   for (let depth = 0; depth < 3; depth += 1) {
     const nextByKey = new Map<string, ConservativeGroupSelection>();
@@ -2794,12 +2961,17 @@ function enumerateConservativeGroupSelections(
         nextByKey.set(extended.key, extended);
       }
     }
-    frontier = capConservativeSelections([...nextByKey.values()]);
+    const capped = capConservativeSelections(
+      [...nextByKey.values()],
+      depth + 1
+    );
+    frontier = capped.retained;
+    beamPruning.push(capped.debug);
     if (frontier.length === 0) break;
     selections.push(...frontier);
   }
 
-  return selections;
+  return { selections, beamPruning };
 }
 
 interface ConservativeHeroPlacement {
@@ -2845,6 +3017,7 @@ interface ConservativeGuideSkillSlot extends KnownSkillSlot {
   potentialSkillSlots: number;
   championship: boolean;
   rankingScore: number;
+  alternativeDecisions: FormationGuideSkillCandidateDebug[];
 }
 
 function compareConservativeGuideSkillSlots(
@@ -2887,31 +3060,30 @@ function conservativeGuideSkillSlots(
               skill !== catalog.default_skill[member.hero] &&
               isConfidentGuideSkillRoute(m, member.hero, skill)
           )
-          .sort((left, right) => {
-            const leftGain =
-              weightOf(m, skillId(left)) +
-              weightOf(m, heroSkillId(member.hero, left));
-            const rightGain =
-              weightOf(m, skillId(right)) +
-              weightOf(m, heroSkillId(member.hero, right));
-            if (Math.abs(leftGain - rightGain) > 1e-9)
-              return rightGain - leftGain;
-            const leftSupport =
-              supportOf(m, skillId(left)) +
-              supportOf(m, heroSkillId(member.hero, left));
-            const rightSupport =
-              supportOf(m, skillId(right)) +
-              supportOf(m, heroSkillId(member.hero, right));
-            return leftSupport !== rightSupport
-              ? rightSupport - leftSupport
-              : left.localeCompare(right);
-          });
+          .map((skill) => ({
+            skill,
+            gain:
+              weightOf(m, skillId(skill)) +
+              weightOf(m, heroSkillId(member.hero, skill)),
+            support:
+              supportOf(m, skillId(skill)) +
+              supportOf(m, heroSkillId(member.hero, skill)),
+            stableKey: skill,
+          }))
+          .sort((left, right) =>
+            Math.abs(left.gain - right.gain) > 1e-9
+              ? right.gain - left.gain
+              : left.support !== right.support
+                ? right.support - left.support
+                : left.stableKey.localeCompare(right.stableKey)
+          );
         return {
           key: `conservative|${teamIndex}|${guide.comp.id}|${member.hero}|${slotIndex}`,
           teamKey: group.key,
           hero: member.hero,
           slotIndex,
-          alternatives: eligible,
+          alternatives: eligible.map(({ skill }) => skill),
+          alternativeDecisions: eligible,
           matchedHeroCount: guide.matchedHeroes.length,
           potentialSkillSlots: guide.potentialSkillSlots,
           championship: isChampionshipComp(guide.comp),
@@ -2943,12 +3115,19 @@ function compareConservativeSkillCandidates(
   return left.key.localeCompare(right.key);
 }
 
+const CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT = 8;
+
+interface ConservativeSkillAssignmentResult {
+  assignments: Map<string, ConservativeSkillSlots>;
+  debug: FormationSkillRoutingDebug;
+}
+
 function assignConservativeSkills(
   teamGroups: ConservativeTeamGroup[],
   skillPool: string[],
   m: PairedModel,
   catalog: RecommendationCatalog
-): Map<string, ConservativeSkillSlots> {
+): ConservativeSkillAssignmentResult {
   const heroes = teamGroups.flatMap(({ group }) => group.heroes);
   const heroSet = new Set(heroes);
   const availableSkills = new Set(skillPool);
@@ -2969,6 +3148,28 @@ function assignConservativeSkills(
   );
   const guideSlotByKey = new Map(guideSlots.map((slot) => [slot.key, slot]));
   const guideMatching = maximumKnownSlotMatching(guideSlots);
+  const guideMatchingDebug = guideSlots.map((slot) => {
+    const selectedSkill = guideMatching.get(slot.key);
+    const selected =
+      slot.alternativeDecisions.find(({ skill }) => skill === selectedSkill) ??
+      null;
+    return {
+      slotKey: slot.key,
+      hero: slot.hero,
+      slotIndex: slot.slotIndex,
+      priority: {
+        matchedHeroCount: slot.matchedHeroCount,
+        qualifiedSkillSlotCount: slot.potentialSkillSlots,
+        championship: slot.championship,
+        rankingScore: slot.rankingScore,
+        stableKey: slot.key,
+      },
+      selected,
+      rejected: slot.alternativeDecisions.filter(
+        ({ skill }) => skill !== selectedSkill
+      ),
+    };
+  });
   for (const [slotKey, skill] of guideMatching) {
     const slot = guideSlotByKey.get(slotKey);
     if (!slot) continue;
@@ -2997,6 +3198,36 @@ function assignConservativeSkills(
     );
     return slotIndex >= 0 ? slotIndex : null;
   };
+
+  const modelRoutingSteps: FormationSkillRoutingDebug['modelRouting']['steps'] = [];
+  const candidatePlacements = (
+    candidate: ConservativeSkillCandidate,
+    sourceSlots: ConservativeSkillSlots
+  ): FormationSkillRouteCandidateDebug['placements'] => {
+    const projected: ConservativeSkillSlots = [...sourceSlots];
+    return candidate.additions.flatMap((skill) => {
+      const preferred = preferredGuideSlot(candidate.hero, skill, projected);
+      const slotIndex = preferred ?? projected.indexOf(null);
+      if (slotIndex < 0) return [];
+      projected[slotIndex] = skill;
+      return [{
+        skill,
+        slotIndex,
+        preferredGuideSlot: preferred !== null,
+      }];
+    });
+  };
+  const candidateDebug = (
+    candidate: ConservativeSkillCandidate,
+    sourceSlots: ConservativeSkillSlots
+  ): FormationSkillRouteCandidateDebug => ({
+    hero: candidate.hero,
+    additions: [...candidate.additions],
+    gain: candidate.gain,
+    support: candidate.support,
+    stableKey: candidate.key,
+    placements: candidatePlacements(candidate, sourceSlots),
+  });
 
   const spFeatures = Object.entries(m.weights).flatMap(
     ([featureId]): { hero: string; first: string; second: string; feature: ConfidentFeature }[] => {
@@ -3092,21 +3323,60 @@ function assignConservativeSkills(
     const best = candidates[0];
     if (!best) break;
     const slots = assigned.get(best.hero)!;
-    for (const skill of best.additions) {
-      const index =
-        preferredGuideSlot(best.hero, skill, slots) ?? slots.indexOf(null);
-      if (index < 0) break;
-      slots[index] = skill;
+    const selected = candidateDebug(best, slots);
+    modelRoutingSteps.push({
+      step: modelRoutingSteps.length + 1,
+      candidateCount: candidates.length,
+      selected,
+      rejected: candidates
+        .slice(1, CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT + 1)
+        .map((candidate) => candidateDebug(candidate, assigned.get(candidate.hero)!)),
+      omittedRejectedCount: Math.max(
+        0,
+        candidates.length - 1 - CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT
+      ),
+    });
+    for (const { skill, slotIndex } of selected.placements) {
+      slots[slotIndex] = skill;
       usedSkills.add(skill);
     }
   }
-  return assigned;
+  return {
+    assignments: assigned,
+    debug: {
+      guideMatching: {
+        slotRankingOrder: [
+          'higher matched hero count',
+          'higher evidence-qualified guide-slot count',
+          'championship source before non-championship source',
+          'higher guide ranking score',
+          'lower stable slot key by locale order',
+        ],
+        alternativeRankingOrder: [
+          'higher standalone S plus assigned-hero HS gain',
+          'higher combined S plus HS support',
+          'lower stable skill key by locale order',
+        ],
+        slots: guideMatchingDebug,
+      },
+      modelRouting: {
+        rankingOrder: [
+          'higher incremental model gain',
+          'higher combined feature support',
+          'lower stable route key by locale order',
+        ],
+        rejectedCandidateLimit: CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT,
+        steps: modelRoutingSteps,
+      },
+    },
+  };
 }
 
 interface EvaluatedConservativeSelection {
   selection: ConservativeGroupSelection;
   teamGroups: ConservativeTeamGroup[];
   skillAssignments: Map<string, ConservativeSkillSlots>;
+  skillRouting: FormationSkillRoutingDebug;
   totalFormationGain: number;
   exactChampionshipTeams: number;
   exactRankingScore: number;
@@ -3128,12 +3398,13 @@ function evaluateConservativeSelection(
   catalog: RecommendationCatalog
 ): EvaluatedConservativeSelection {
   const teamGroups = orderConservativeTeamGroups(selection.groups);
-  const skillAssignments = assignConservativeSkills(
+  const skillAssignment = assignConservativeSkills(
     teamGroups,
     skills,
     m,
     catalog
   );
+  const skillAssignments = skillAssignment.assignments;
   const totalFormationGain = teamGroups.reduce(
     (sum, { group }) =>
       sum +
@@ -3155,6 +3426,7 @@ function evaluateConservativeSelection(
     selection,
     teamGroups,
     skillAssignments,
+    skillRouting: skillAssignment.debug,
     totalFormationGain,
     exactChampionshipTeams: exactGroups.filter(({ guide }) =>
       isChampionshipComp(guide!.comp)
@@ -3242,6 +3514,7 @@ function conservativeCandidateDebug(
         : {}),
       prioritizedExactGuide,
     })),
+    skillRouting: candidate.skillRouting,
   };
 }
 
@@ -3324,7 +3597,8 @@ function recommendConservativeHybridTeams(
         guide.potentialSkillSlots > 0,
     };
   });
-  const evaluated = enumerateConservativeGroupSelections(candidateGroups)
+  const selectionSearch = enumerateConservativeGroupSelections(candidateGroups);
+  const evaluated = selectionSearch.selections
     .map((selection) =>
       evaluateConservativeSelection(selection, skills, m, catalog)
     )
@@ -3425,6 +3699,7 @@ function recommendConservativeHybridTeams(
       'higher hero evidence support',
       'stable canonical key',
     ],
+    beamPruning: selectionSearch.beamPruning,
     topCandidates: evaluated
       .slice(0, 8)
       .map((candidate, index) =>

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -746,10 +746,28 @@ export interface FormationOption {
   teams: ProjectedTeam[];
 }
 
+export interface FormationGuideMatchCandidateDebug {
+  guideId: string;
+  matchedHeroes: string[];
+  matchedHeroCount: number;
+  qualifiedSkillSlotCount: number;
+  championship: boolean;
+  ranking: TeamRanking;
+  rankingScore: number;
+  stableId: string;
+}
+
+export interface FormationGuideMatchDecisionDebug {
+  rankingOrder: string[];
+  selected: FormationGuideMatchCandidateDebug;
+  rejected: FormationGuideMatchCandidateDebug[];
+}
+
 export interface FormationDebugTeam {
   heroes: string[];
   skills: Record<string, [string | null, string | null]>;
   guideId?: string;
+  guideMatchDecision?: FormationGuideMatchDecisionDebug;
   prioritizedExactGuide: boolean;
 }
 
@@ -2536,11 +2554,46 @@ function confidentHeroGroups(
   );
 }
 
-interface ConservativeGuideMatch {
+interface ConservativeGuideMatchCandidate {
   comp: TeamComp;
   matchedHeroes: string[];
   potentialSkillSlots: number;
+  debug: FormationGuideMatchCandidateDebug;
 }
+
+interface ConservativeGuideMatch extends ConservativeGuideMatchCandidate {
+  decision: FormationGuideMatchDecisionDebug;
+}
+
+const CONSERVATIVE_GUIDE_MATCH_RANKING_ORDER = [
+  'higher matched hero count',
+  'higher evidence-qualified skill-slot count',
+  'championship source before non-championship source',
+  'higher guide ranking score (S=3, A=2, other=1)',
+  'lower stable guide ID by locale order',
+];
+
+const compareConservativeGuideMatches = (
+  left: ConservativeGuideMatchCandidate,
+  right: ConservativeGuideMatchCandidate
+): number => {
+  if (left.debug.matchedHeroCount !== right.debug.matchedHeroCount)
+    return right.debug.matchedHeroCount - left.debug.matchedHeroCount;
+  if (
+    left.debug.qualifiedSkillSlotCount !==
+    right.debug.qualifiedSkillSlotCount
+  ) {
+    return (
+      right.debug.qualifiedSkillSlotCount -
+      left.debug.qualifiedSkillSlotCount
+    );
+  }
+  if (left.debug.championship !== right.debug.championship)
+    return Number(right.debug.championship) - Number(left.debug.championship);
+  if (left.debug.rankingScore !== right.debug.rankingScore)
+    return right.debug.rankingScore - left.debug.rankingScore;
+  return left.debug.stableId.localeCompare(right.debug.stableId);
+};
 
 const isConfidentGuideSkillRoute = (
   m: PairedModel,
@@ -2580,24 +2633,38 @@ function bestConservativeGuideMatch(
         ).length,
       0
     );
-    return [{ comp, matchedHeroes, potentialSkillSlots }];
+    return [
+      {
+        comp,
+        matchedHeroes,
+        potentialSkillSlots,
+        debug: {
+          guideId: comp.id,
+          matchedHeroes: [...matchedHeroes],
+          matchedHeroCount: matchedHeroes.length,
+          qualifiedSkillSlotCount: potentialSkillSlots,
+          championship: isChampionshipComp(comp),
+          ranking: comp.ranking,
+          rankingScore: teamRankingScore(comp.ranking),
+          stableId: comp.id,
+        },
+      },
+    ];
   });
-  candidates.sort((left, right) => {
-    if (left.matchedHeroes.length !== right.matchedHeroes.length)
-      return right.matchedHeroes.length - left.matchedHeroes.length;
-    if (left.potentialSkillSlots !== right.potentialSkillSlots)
-      return right.potentialSkillSlots - left.potentialSkillSlots;
-    const championshipDelta =
-      Number(isChampionshipComp(right.comp)) -
-      Number(isChampionshipComp(left.comp));
-    if (championshipDelta !== 0) return championshipDelta;
-    const rankingDelta =
-      teamRankingScore(right.comp.ranking) -
-      teamRankingScore(left.comp.ranking);
-    if (rankingDelta !== 0) return rankingDelta;
-    return left.comp.id.localeCompare(right.comp.id);
-  });
-  return candidates[0];
+  candidates.sort(compareConservativeGuideMatches);
+  const selected = candidates[0];
+  if (!selected) return undefined;
+  return {
+    ...selected,
+    decision: {
+      rankingOrder: [...CONSERVATIVE_GUIDE_MATCH_RANKING_ORDER],
+      selected: { ...selected.debug, matchedHeroes: [...selected.matchedHeroes] },
+      rejected: candidates.slice(1).map((candidate) => ({
+        ...candidate.debug,
+        matchedHeroes: [...candidate.matchedHeroes],
+      })),
+    },
+  };
 }
 
 interface ConservativeTeamGroup {
@@ -3157,7 +3224,22 @@ function conservativeCandidateDebug(
           ],
         ])
       ),
-      ...(guide ? { guideId: guide.comp.id } : {}),
+      ...(guide
+        ? {
+            guideId: guide.comp.id,
+            guideMatchDecision: {
+              rankingOrder: [...guide.decision.rankingOrder],
+              selected: {
+                ...guide.decision.selected,
+                matchedHeroes: [...guide.decision.selected.matchedHeroes],
+              },
+              rejected: guide.decision.rejected.map((candidate) => ({
+                ...candidate,
+                matchedHeroes: [...candidate.matchedHeroes],
+              })),
+            },
+          }
+        : {}),
       prioritizedExactGuide,
     })),
   };

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -66,12 +66,23 @@ export interface EvaluatedFeature extends Contribution {
   displayPoints: number;
 }
 
+export interface SkillRouteCandidateDebug extends EvaluatedFeature {
+  hero: string;
+  currentPoolIndex: number;
+  rank: number;
+  selected: boolean;
+  tiedForBestWeight: boolean;
+}
+
 export interface SkillRouteDebug {
   skill: string;
   standalone: EvaluatedFeature;
   chosenHero: string | null;
   chosenRoute: EvaluatedFeature | null;
-  alternatives: EvaluatedFeature[];
+  rankingOrder: string[];
+  selectionReason: string;
+  tiedBestHeroes: string[];
+  alternatives: SkillRouteCandidateDebug[];
   rawTotal: number;
   displayTotal: number;
 }
@@ -242,17 +253,54 @@ function bestHeroForSkill(
   skill: string,
   heroes: string[],
   m: PairedModel
-): { hero: string | null; weight: number } {
-  let best: string | null = null;
-  let bestW = -Infinity;
-  for (const hero of heroes) {
-    const w = weightOf(m, heroSkillId(hero, skill));
-    if (w > bestW) {
-      bestW = w;
-      best = hero;
-    }
-  }
-  return { hero: best, weight: best === null ? 0 : bestW };
+): {
+  hero: string | null;
+  weight: number;
+  rankingOrder: string[];
+  selectionReason: string;
+  tiedBestHeroes: string[];
+  routes: SkillRouteCandidateDebug[];
+} {
+  const ranked = heroes
+    .map((hero, currentPoolIndex) => ({
+      hero,
+      currentPoolIndex,
+      route: evaluatedFeature(m, heroSkillId(hero, skill)),
+    }))
+    .sort((left, right) =>
+      right.route.weight !== left.route.weight
+        ? right.route.weight - left.route.weight
+        : left.currentPoolIndex - right.currentPoolIndex
+    );
+  const chosen = ranked[0] ?? null;
+  const tiedBestHeroes = chosen
+    ? ranked
+        .filter(({ route }) => route.weight === chosen.route.weight)
+        .map(({ hero }) => hero)
+    : [];
+  return {
+    hero: chosen?.hero ?? null,
+    weight: chosen?.route.weight ?? 0,
+    rankingOrder: [
+      'higher hero-skill HS weight',
+      'earlier hero in current-pool order when HS weights tie',
+    ],
+    selectionReason:
+      tiedBestHeroes.length > 1
+        ? 'highest HS weight tied; earliest hero in current-pool order won'
+        : chosen
+          ? 'highest HS weight'
+          : 'no current hero was available',
+    tiedBestHeroes,
+    routes: ranked.map(({ hero, currentPoolIndex, route }, index) => ({
+      ...route,
+      hero,
+      currentPoolIndex,
+      rank: index + 1,
+      selected: index === 0,
+      tiedForBestWeight: chosen !== null && route.weight === chosen.route.weight,
+    })),
+  };
 }
 
 /**
@@ -386,19 +434,9 @@ export function recommendSkillSet(
     const skillRoutes: SkillRouteDebug[] = [];
     const item_scores = skills.map((skill) => {
       const standaloneFeature = evaluatedFeature(m, skillId(skill));
-      const { hero, weight } = bestHeroForSkill(skill, currentHeroes, m);
-      const chosenRoute = hero
-        ? evaluatedFeature(m, heroSkillId(hero, skill))
-        : null;
-      const alternatives = currentHeroes
-        .map((candidateHero) =>
-          evaluatedFeature(m, heroSkillId(candidateHero, skill))
-        )
-        .sort((left, right) =>
-          right.weight !== left.weight
-            ? right.weight - left.weight
-            : left.featureId.localeCompare(right.featureId)
-        );
+      const routeDecision = bestHeroForSkill(skill, currentHeroes, m);
+      const { hero, weight } = routeDecision;
+      const chosenRoute = routeDecision.routes[0] ?? null;
       const total = standaloneFeature.weight + weight;
       delta += total;
       evaluatedFeatures.push(standaloneFeature);
@@ -411,7 +449,10 @@ export function recommendSkillSet(
         standalone: standaloneFeature,
         chosenHero: hero,
         chosenRoute,
-        alternatives,
+        rankingOrder: routeDecision.rankingOrder,
+        selectionReason: routeDecision.selectionReason,
+        tiedBestHeroes: routeDecision.tiedBestHeroes,
+        alternatives: routeDecision.routes,
         rawTotal: total,
         displayTotal: displayScore(total),
       });
@@ -833,10 +874,46 @@ export interface FormationSkillRouteCandidateDebug {
   }>;
 }
 
+export interface FormationGuideMatchingTrace {
+  objective: string;
+  slotCount: number;
+  uniqueSkillCount: number;
+  matchedSlotCount: number;
+  eventLimit: number;
+  events: Array<
+    | {
+        type: 'occupied-skill-conflict';
+        rootSlotKey: string;
+        requestingSlotKey: string;
+        skill: string;
+        occupyingSlotKey: string;
+        resolvedByOwnerMove: boolean;
+      }
+    | {
+        type: 'augmenting-owner-move';
+        rootSlotKey: string;
+        requestedBySlotKey: string;
+        ownerSlotKey: string;
+        fromSkill: string;
+        toSkill: string;
+      }
+    | {
+        type: 'slot-assigned';
+        rootSlotKey: string;
+        slotKey: string;
+        skill: string;
+        reason: 'unoccupied-skill' | 'owner-moved-by-augmenting-path';
+      }
+  >;
+  omittedEventCount: number;
+  finalAssignments: Array<{ slotKey: string; skill: string | null }>;
+}
+
 export interface FormationSkillRoutingDebug {
   guideMatching: {
     slotRankingOrder: string[];
     alternativeRankingOrder: string[];
+    maximumCardinality: FormationGuideMatchingTrace;
     slots: FormationGuideSkillSlotDebug[];
   };
   modelRouting: {
@@ -1020,17 +1097,37 @@ const knownSlots = (
  * skills. This resolves alternatives across all selected guide teams together,
  * so a skill is never promised to two heroes.
  */
+const MAXIMUM_KNOWN_SLOT_MATCHING_EVENT_LIMIT = 64;
+
+interface KnownSlotMatchingResult {
+  assignments: Map<string, string>;
+  debug?: FormationGuideMatchingTrace;
+}
+
 function maximumKnownSlotMatching(
-  slots: KnownSkillSlot[]
-): Map<string, string> {
+  slots: KnownSkillSlot[],
+  captureDebug = false
+): KnownSlotMatchingResult {
   const slotByKey = new Map(slots.map((slot) => [slot.key, slot]));
   const skillOwner = new Map<string, string>();
   const slotSkill = new Map<string, string>();
+  const events: FormationGuideMatchingTrace['events'] = [];
+  let omittedEventCount = 0;
+  const record = (event: FormationGuideMatchingTrace['events'][number]) => {
+    if (!captureDebug) return;
+    if (events.length < MAXIMUM_KNOWN_SLOT_MATCHING_EVENT_LIMIT) {
+      events.push(event);
+    } else {
+      omittedEventCount += 1;
+    }
+  };
 
   const assign = (
     slotKey: string,
     seenSlots: Set<string>,
-    seenSkills: Set<string>
+    seenSkills: Set<string>,
+    rootSlotKey: string,
+    requestedBySlotKey: string | null
   ): boolean => {
     if (seenSlots.has(slotKey)) return false;
     seenSlots.add(slotKey);
@@ -1042,11 +1139,51 @@ function maximumKnownSlotMatching(
       if (seenSkills.has(skill)) continue;
       seenSkills.add(skill);
       const owner = skillOwner.get(skill);
-      if (
-        owner === undefined ||
-        assign(owner, seenSlots, seenSkills)
-      ) {
-        if (previousSkill !== undefined) skillOwner.delete(previousSkill);
+      let ownerMoved = false;
+      if (owner !== undefined) {
+        const conflict: FormationGuideMatchingTrace['events'][number] = {
+          type: 'occupied-skill-conflict',
+          rootSlotKey,
+          requestingSlotKey: slotKey,
+          skill,
+          occupyingSlotKey: owner,
+          resolvedByOwnerMove: false,
+        };
+        record(conflict);
+        ownerMoved = assign(
+          owner,
+          seenSlots,
+          seenSkills,
+          rootSlotKey,
+          slotKey
+        );
+        if (conflict.type === 'occupied-skill-conflict') {
+          conflict.resolvedByOwnerMove = ownerMoved;
+        }
+      }
+      if (owner === undefined || ownerMoved) {
+        if (previousSkill !== undefined) {
+          skillOwner.delete(previousSkill);
+          record({
+            type: 'augmenting-owner-move',
+            rootSlotKey,
+            requestedBySlotKey: requestedBySlotKey ?? rootSlotKey,
+            ownerSlotKey: slotKey,
+            fromSkill: previousSkill,
+            toSkill: skill,
+          });
+        } else {
+          record({
+            type: 'slot-assigned',
+            rootSlotKey,
+            slotKey,
+            skill,
+            reason:
+              owner === undefined
+                ? 'unoccupied-skill'
+                : 'owner-moved-by-augmenting-path',
+          });
+        }
         skillOwner.set(skill, slotKey);
         slotSkill.set(slotKey, skill);
         return true;
@@ -1055,13 +1192,28 @@ function maximumKnownSlotMatching(
     return false;
   };
 
-  // Process higher-priority slots first. A later slot can take an occupied
-  // skill only when the earlier owner can move to an alternative, preserving
-  // both maximum cardinality and the priority of a sole contested claim.
   for (const slot of slots) {
-    assign(slot.key, new Set(), new Set());
+    assign(slot.key, new Set(), new Set(), slot.key, null);
   }
-  return slotSkill;
+  const result: KnownSlotMatchingResult = { assignments: slotSkill };
+  if (captureDebug) {
+    result.debug = {
+      objective:
+        'maximize assigned guide slots; process higher-priority slots first and move an existing owner only along an augmenting path',
+      slotCount: slots.length,
+      uniqueSkillCount: new Set(slots.flatMap(({ alternatives }) => alternatives))
+        .size,
+      matchedSlotCount: slotSkill.size,
+      eventLimit: MAXIMUM_KNOWN_SLOT_MATCHING_EVENT_LIMIT,
+      events,
+      omittedEventCount,
+      finalAssignments: slots.map(({ key }) => ({
+        slotKey: key,
+        skill: slotSkill.get(key) ?? null,
+      })),
+    };
+  }
+  return result;
 }
 
 function compareKnownPreferences(
@@ -1103,7 +1255,7 @@ function buildKnownTeamIndex(
     };
     const localMatchedSkillSlots = maximumKnownSlotMatching(
       knownSlots(provisional, skillPool, catalog)
-    ).size;
+    ).assignments.size;
     // A hero trio with no usable guide skill is a pure model fallback, not a
     // database-backed match.
     if (localMatchedSkillSlots === 0) continue;
@@ -1157,7 +1309,7 @@ function selectKnownPreferences(
     const slots = ordered.flatMap((preference) =>
       knownSlots(preference, skillSet, catalog)
     );
-    const matching = maximumKnownSlotMatching(slots);
+    const matching = maximumKnownSlotMatching(slots).assignments;
     const matchedByTeam = new Map<string, number>();
     for (const slot of slots) {
       if (!matching.has(slot.key)) continue;
@@ -1278,7 +1430,7 @@ function assignSkills(
   const guideSlots = orderedPreferences.flatMap((preference) =>
     knownSlots(preference, skillSet, catalog)
   );
-  const guideMatching = maximumKnownSlotMatching(guideSlots);
+  const guideMatching = maximumKnownSlotMatching(guideSlots).assignments;
   const guideSlotByKey = new Map(guideSlots.map((slot) => [slot.key, slot]));
   const preferredSlotSkills = new Map<string, [string | null, string | null]>();
   const lockedSkills = new Map<string, Set<string>>();
@@ -3147,7 +3299,8 @@ function assignConservativeSkills(
     catalog
   );
   const guideSlotByKey = new Map(guideSlots.map((slot) => [slot.key, slot]));
-  const guideMatching = maximumKnownSlotMatching(guideSlots);
+  const guideMatchingResult = maximumKnownSlotMatching(guideSlots, true);
+  const guideMatching = guideMatchingResult.assignments;
   const guideMatchingDebug = guideSlots.map((slot) => {
     const selectedSkill = guideMatching.get(slot.key);
     const selected =
@@ -3357,6 +3510,7 @@ function assignConservativeSkills(
           'higher combined S plus HS support',
           'lower stable skill key by locale order',
         ],
+        maximumCardinality: guideMatchingResult.debug!,
         slots: guideMatchingDebug,
       },
       modelRouting: {

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -841,6 +841,21 @@ export interface FormationBeamPruningDebug {
   retainedOnlyByReservationCount: number;
 }
 
+export interface FormationHeroBeamDepthDebug {
+  depth: number;
+  generatedContainingSelectionCount: number;
+  retainedContainingSelectionCount: number;
+  reservedContainingSelectionCount: number;
+  entirelyProxyPruned: boolean;
+}
+
+export interface FormationHeroSearchReachabilityDebug {
+  hero: string;
+  qualifiedGroupCount: number;
+  reachedFinalEvaluation: boolean;
+  depths: FormationHeroBeamDepthDebug[];
+}
+
 export interface FormationGuideSkillCandidateDebug {
   skill: string;
   gain: number;
@@ -966,6 +981,7 @@ export interface FormationDecisionDebug {
   prioritizedExactGuideCoreCount: number;
   rankingOrder: string[];
   beamPruning: FormationBeamPruningDebug[];
+  heroSelectionReachability: FormationHeroSearchReachabilityDebug[];
   /** Detailed traces for only the winner and immediate runner-up. */
   topCandidates: FormationDebugCandidate[];
 }
@@ -1122,16 +1138,19 @@ function maximumKnownSlotMatching(
   const slotByKey = new Map(slots.map((slot) => [slot.key, slot]));
   const skillOwner = new Map<string, string>();
   const slotSkill = new Map<string, string>();
-  const events: FormationGuideMatchingTrace['events'] = [];
+  const events: FormationGuideMatchingTrace['events'] | undefined = captureDebug
+    ? []
+    : undefined;
   let omittedEventCount = 0;
-  const record = (event: FormationGuideMatchingTrace['events'][number]) => {
-    if (!captureDebug) return;
-    if (events.length < MAXIMUM_KNOWN_SLOT_MATCHING_EVENT_LIMIT) {
-      events.push(event);
-    } else {
-      omittedEventCount += 1;
-    }
-  };
+  const record = captureDebug
+    ? (event: FormationGuideMatchingTrace['events'][number]) => {
+        if (events!.length < MAXIMUM_KNOWN_SLOT_MATCHING_EVENT_LIMIT) {
+          events!.push(event);
+        } else {
+          omittedEventCount += 1;
+        }
+      }
+    : undefined;
 
   const assign = (
     slotKey: string,
@@ -1151,16 +1170,24 @@ function maximumKnownSlotMatching(
       seenSkills.add(skill);
       const owner = skillOwner.get(skill);
       let ownerMoved = false;
+      let conflict:
+        | Extract<
+            FormationGuideMatchingTrace['events'][number],
+            { type: 'occupied-skill-conflict' }
+          >
+        | undefined;
       if (owner !== undefined) {
-        const conflict: FormationGuideMatchingTrace['events'][number] = {
-          type: 'occupied-skill-conflict',
-          rootSlotKey,
-          requestingSlotKey: slotKey,
-          skill,
-          occupyingSlotKey: owner,
-          resolvedByOwnerMove: false,
-        };
-        record(conflict);
+        if (record) {
+          conflict = {
+            type: 'occupied-skill-conflict',
+            rootSlotKey,
+            requestingSlotKey: slotKey,
+            skill,
+            occupyingSlotKey: owner,
+            resolvedByOwnerMove: false,
+          };
+          record(conflict);
+        }
         ownerMoved = assign(
           owner,
           seenSlots,
@@ -1168,22 +1195,22 @@ function maximumKnownSlotMatching(
           rootSlotKey,
           slotKey
         );
-        if (conflict.type === 'occupied-skill-conflict') {
-          conflict.resolvedByOwnerMove = ownerMoved;
-        }
+        if (conflict) conflict.resolvedByOwnerMove = ownerMoved;
       }
       if (owner === undefined || ownerMoved) {
         if (previousSkill !== undefined) {
           skillOwner.delete(previousSkill);
-          record({
-            type: 'augmenting-owner-move',
-            rootSlotKey,
-            requestedBySlotKey: requestedBySlotKey ?? rootSlotKey,
-            ownerSlotKey: slotKey,
-            fromSkill: previousSkill,
-            toSkill: skill,
-          });
-        } else {
+          if (record) {
+            record({
+              type: 'augmenting-owner-move',
+              rootSlotKey,
+              requestedBySlotKey: requestedBySlotKey ?? rootSlotKey,
+              ownerSlotKey: slotKey,
+              fromSkill: previousSkill,
+              toSkill: skill,
+            });
+          }
+        } else if (record) {
           record({
             type: 'slot-assigned',
             rootSlotKey,
@@ -1216,7 +1243,7 @@ function maximumKnownSlotMatching(
         .size,
       matchedSlotCount: slotSkill.size,
       eventLimit: MAXIMUM_KNOWN_SLOT_MATCHING_EVENT_LIMIT,
-      events,
+      events: events!,
       omittedEventCount,
       finalAssignments: slots.map(({ key }) => ({
         slotKey: key,
@@ -3124,10 +3151,12 @@ function capConservativeSelections(
 
 /** Enumerate bounded, disjoint selections of one to three mixed pairs/trios. */
 function enumerateConservativeGroupSelections(
-  candidateGroups: ConservativeTeamGroup[]
+  candidateGroups: ConservativeTeamGroup[],
+  consideredHeroes: string[]
 ): {
   selections: ConservativeGroupSelection[];
   beamPruning: FormationBeamPruningDebug[];
+  heroReachability: FormationHeroSearchReachabilityDebug[];
 } {
   const candidates = [...candidateGroups].sort((left, right) =>
     left.group.key.localeCompare(right.group.key)
@@ -3137,6 +3166,14 @@ function enumerateConservativeGroupSelections(
   ];
   const selections: ConservativeGroupSelection[] = [];
   const beamPruning: FormationBeamPruningDebug[] = [];
+  const heroReachability = consideredHeroes.map((hero) => ({
+    hero,
+    qualifiedGroupCount: candidates.filter(({ group }) =>
+      group.heroes.includes(hero)
+    ).length,
+    reachedFinalEvaluation: false,
+    depths: [] as FormationHeroBeamDepthDebug[],
+  }));
 
   for (let depth = 0; depth < 3; depth += 1) {
     const nextByKey = new Map<string, ConservativeGroupSelection>();
@@ -3150,17 +3187,66 @@ function enumerateConservativeGroupSelections(
         nextByKey.set(extended.key, extended);
       }
     }
-    const capped = capConservativeSelections(
-      [...nextByKey.values()],
-      depth + 1
+    const generated = [...nextByKey.values()];
+    const capped = capConservativeSelections(generated, depth + 1);
+    const reservedKeys = new Set(
+      capped.debug.exactGuideReservations.map(({ canonicalKey }) => canonicalKey)
     );
+    const generatedCounts = new Map(
+      consideredHeroes.map((hero) => [hero, 0])
+    );
+    const retainedCounts = new Map(
+      consideredHeroes.map((hero) => [hero, 0])
+    );
+    const reservedCounts = new Map(
+      consideredHeroes.map((hero) => [hero, 0])
+    );
+    const countContainingHeroes = (
+      selection: ConservativeGroupSelection,
+      counts: Map<string, number>
+    ) => {
+      for (const { group } of selection.groups) {
+        for (const hero of group.heroes) {
+          counts.set(hero, (counts.get(hero) ?? 0) + 1);
+        }
+      }
+    };
+    for (const selection of generated) {
+      countContainingHeroes(selection, generatedCounts);
+    }
+    for (const selection of capped.retained) {
+      countContainingHeroes(selection, retainedCounts);
+      if (reservedKeys.has(selection.key)) {
+        countContainingHeroes(selection, reservedCounts);
+      }
+    }
+    for (const reachability of heroReachability) {
+      const generatedContainingSelectionCount =
+        generatedCounts.get(reachability.hero) ?? 0;
+      const retainedContainingSelectionCount =
+        retainedCounts.get(reachability.hero) ?? 0;
+      const reservedContainingSelectionCount =
+        reservedCounts.get(reachability.hero) ?? 0;
+      reachability.depths.push({
+        depth: depth + 1,
+        generatedContainingSelectionCount,
+        retainedContainingSelectionCount,
+        reservedContainingSelectionCount,
+        entirelyProxyPruned:
+          generatedContainingSelectionCount > 0 &&
+          retainedContainingSelectionCount === 0,
+      });
+      if (retainedContainingSelectionCount > 0) {
+        reachability.reachedFinalEvaluation = true;
+      }
+    }
     frontier = capped.retained;
     beamPruning.push(capped.debug);
     if (frontier.length === 0) break;
     selections.push(...frontier);
   }
 
-  return { selections, beamPruning };
+  return { selections, beamPruning, heroReachability };
 }
 
 interface ConservativeHeroPlacement {
@@ -3340,23 +3426,24 @@ function assignConservativeSkills(
   const guideSlotByKey = new Map(guideSlots.map((slot) => [slot.key, slot]));
   const guideMatchingResult = maximumKnownSlotMatching(guideSlots, captureDebug);
   const guideMatching = guideMatchingResult.assignments;
-  const guideSkillDebug = (
-    slot: ConservativeGuideSkillSlot,
-    skill: string
-  ): FormationGuideSkillCandidateDebug => ({
-    skill,
-    gain:
-      weightOf(m, skillId(skill)) + weightOf(m, heroSkillId(slot.hero, skill)),
-    support:
-      supportOf(m, skillId(skill)) + supportOf(m, heroSkillId(slot.hero, skill)),
-    stableKey: skill,
-  });
   const guideMatchingDebug = captureDebug
     ? guideSlots.map((slot) => {
         const selectedSkill = guideMatching.get(slot.key);
         const rejected = slot.alternatives.filter(
           (skill) => skill !== selectedSkill
         );
+        const describeSkill = (
+          skill: string
+        ): FormationGuideSkillCandidateDebug => ({
+          skill,
+          gain:
+            weightOf(m, skillId(skill)) +
+            weightOf(m, heroSkillId(slot.hero, skill)),
+          support:
+            supportOf(m, skillId(skill)) +
+            supportOf(m, heroSkillId(slot.hero, skill)),
+          stableKey: skill,
+        });
         return {
           slotKey: slot.key,
           hero: slot.hero,
@@ -3368,18 +3455,18 @@ function assignConservativeSkills(
             rankingScore: slot.rankingScore,
             stableKey: slot.key,
           },
-          selected: selectedSkill ? guideSkillDebug(slot, selectedSkill) : null,
+          selected: selectedSkill ? describeSkill(selectedSkill) : null,
           rejectedCandidateLimit: CONSERVATIVE_GUIDE_SLOT_REJECTED_LIMIT,
           rejected: rejected
             .slice(0, CONSERVATIVE_GUIDE_SLOT_REJECTED_LIMIT)
-            .map((skill) => guideSkillDebug(slot, skill)),
+            .map(describeSkill),
           omittedRejectedCount: Math.max(
             0,
             rejected.length - CONSERVATIVE_GUIDE_SLOT_REJECTED_LIMIT
           ),
         };
       })
-    : [];
+    : undefined;
   for (const [slotKey, skill] of guideMatching) {
     const slot = guideSlotByKey.get(slotKey);
     if (!slot) continue;
@@ -3409,35 +3496,42 @@ function assignConservativeSkills(
     return slotIndex >= 0 ? slotIndex : null;
   };
 
-  const modelRoutingSteps: FormationSkillRoutingDebug['modelRouting']['steps'] = [];
-  const candidatePlacements = (
-    candidate: ConservativeSkillCandidate,
-    sourceSlots: ConservativeSkillSlots
-  ): FormationSkillRouteCandidateDebug['placements'] => {
-    const projected: ConservativeSkillSlots = [...sourceSlots];
-    return candidate.additions.flatMap((skill) => {
-      const preferred = preferredGuideSlot(candidate.hero, skill, projected);
-      const slotIndex = preferred ?? projected.indexOf(null);
-      if (slotIndex < 0) return [];
-      projected[slotIndex] = skill;
-      return [{
-        skill,
-        slotIndex,
-        preferredGuideSlot: preferred !== null,
-      }];
-    });
-  };
-  const candidateDebug = (
-    candidate: ConservativeSkillCandidate,
-    sourceSlots: ConservativeSkillSlots
-  ): FormationSkillRouteCandidateDebug => ({
-    hero: candidate.hero,
-    additions: [...candidate.additions],
-    gain: candidate.gain,
-    support: candidate.support,
-    stableKey: candidate.key,
-    placements: candidatePlacements(candidate, sourceSlots),
-  });
+  const modelRoutingSteps = captureDebug
+    ? ([] as FormationSkillRoutingDebug['modelRouting']['steps'])
+    : undefined;
+  const candidateDebug = captureDebug
+    ? (
+        candidate: ConservativeSkillCandidate,
+        sourceSlots: ConservativeSkillSlots
+      ): FormationSkillRouteCandidateDebug => {
+        const projected: ConservativeSkillSlots = [...sourceSlots];
+        const placements = candidate.additions.flatMap((skill) => {
+          const preferred = preferredGuideSlot(
+            candidate.hero,
+            skill,
+            projected
+          );
+          const slotIndex = preferred ?? projected.indexOf(null);
+          if (slotIndex < 0) return [];
+          projected[slotIndex] = skill;
+          return [
+            {
+              skill,
+              slotIndex,
+              preferredGuideSlot: preferred !== null,
+            },
+          ];
+        });
+        return {
+          hero: candidate.hero,
+          additions: [...candidate.additions],
+          gain: candidate.gain,
+          support: candidate.support,
+          stableKey: candidate.key,
+          placements,
+        };
+      }
+    : undefined;
 
   const spFeatures = Object.entries(m.weights).flatMap(
     ([featureId]): { hero: string; first: string; second: string; feature: ConfidentFeature }[] => {
@@ -3533,7 +3627,7 @@ function assignConservativeSkills(
     const best = candidates[0];
     if (!best) break;
     const slots = assigned.get(best.hero)!;
-    if (captureDebug) {
+    if (candidateDebug && modelRoutingSteps) {
       const selected = candidateDebug(best, slots);
       modelRoutingSteps.push({
         step: modelRoutingSteps.length + 1,
@@ -3563,40 +3657,39 @@ function assignConservativeSkills(
       usedSkills.add(skill);
     }
   }
-  return {
+  const result: ConservativeSkillAssignmentResult = {
     assignments: assigned,
-    ...(captureDebug
-      ? {
-          debug: {
-            guideMatching: {
-              slotRankingOrder: [
-                'higher matched hero count',
-                'higher evidence-qualified guide-slot count',
-                'championship source before non-championship source',
-                'higher guide ranking score',
-                'lower stable slot key by locale order',
-              ],
-              alternativeRankingOrder: [
-                'higher standalone S plus assigned-hero HS gain',
-                'higher combined S plus HS support',
-                'lower stable skill key by locale order',
-              ],
-              maximumCardinality: guideMatchingResult.debug!,
-              slots: guideMatchingDebug,
-            },
-            modelRouting: {
-              rankingOrder: [
-                'higher incremental model gain',
-                'higher combined feature support',
-                'lower stable route key by locale order',
-              ],
-              rejectedCandidateLimit: CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT,
-              steps: modelRoutingSteps,
-            },
-          },
-        }
-      : {}),
   };
+  if (captureDebug) {
+    result.debug = {
+      guideMatching: {
+        slotRankingOrder: [
+          'higher matched hero count',
+          'higher evidence-qualified guide-slot count',
+          'championship source before non-championship source',
+          'higher guide ranking score',
+          'lower stable slot key by locale order',
+        ],
+        alternativeRankingOrder: [
+          'higher standalone S plus assigned-hero HS gain',
+          'higher combined S plus HS support',
+          'lower stable skill key by locale order',
+        ],
+        maximumCardinality: guideMatchingResult.debug!,
+        slots: guideMatchingDebug!,
+      },
+      modelRouting: {
+        rankingOrder: [
+          'higher incremental model gain',
+          'higher combined feature support',
+          'lower stable route key by locale order',
+        ],
+        rejectedCandidateLimit: CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT,
+        steps: modelRoutingSteps!,
+      },
+    };
+  }
+  return result;
 }
 
 interface EvaluatedConservativeSelection {
@@ -3835,7 +3928,10 @@ function recommendConservativeHybridTeams(
         guide.potentialSkillSlots > 0,
     };
   });
-  const selectionSearch = enumerateConservativeGroupSelections(candidateGroups);
+  const selectionSearch = enumerateConservativeGroupSelections(
+    candidateGroups,
+    boundedHeroes
+  );
   const evaluated = selectionSearch.selections
     .map((selection) =>
       evaluateConservativeSelection(selection, skills, m, catalog)
@@ -3944,6 +4040,7 @@ function recommendConservativeHybridTeams(
       'stable canonical key',
     ],
     beamPruning: selectionSearch.beamPruning,
+    heroSelectionReachability: selectionSearch.heroReachability,
     topCandidates: detailedCandidates.map((candidate, index) =>
       conservativeCandidateDebug(
         candidate,

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -49,6 +49,8 @@ import {
 // --------------------------------------------------------------------------- #
 
 export interface Contribution {
+  /** Canonical model feature id, e.g. `HP|祝融|貂蝉`. */
+  featureId: string;
   /** Human-readable label, e.g. a hero pair "祝融 + 貂蝉" or a hero-skill pair. */
   label: string;
   /** Feature family (H/S/HP/HS/SP). */
@@ -57,6 +59,30 @@ export interface Contribution {
   weight: number;
   /** Support/evidence: battles this feature was observed in. */
   support: number;
+}
+
+export interface EvaluatedFeature extends Contribution {
+  /** Player-facing points (`weight * 10`, rounded to one decimal). */
+  displayPoints: number;
+}
+
+export interface SkillRouteDebug {
+  skill: string;
+  standalone: EvaluatedFeature;
+  chosenHero: string | null;
+  chosenRoute: EvaluatedFeature | null;
+  alternatives: EvaluatedFeature[];
+  rawTotal: number;
+  displayTotal: number;
+}
+
+export interface OptionDecisionDebug {
+  /** Unrounded raw score before the player-facing ×10 conversion. */
+  rawScore: number;
+  /** Every newly activated feature, including neutral/missing-weight rows. */
+  evaluatedFeatures: EvaluatedFeature[];
+  /** Present for skill rounds to show the exact best-hero routing decision. */
+  skillRoutes?: SkillRouteDebug[];
 }
 
 export interface OptionAnalysis {
@@ -81,6 +107,8 @@ export interface OptionAnalysis {
   tradeoffs: Contribution[];
   /** Aggregate evidence behind the option's score. */
   evidence: { featureCount: number; totalSupport: number; minSupport: number };
+  /** Console-debug trace; not rendered in the player-facing recommendation UI. */
+  debug: OptionDecisionDebug;
 }
 
 export interface SetRecommendation {
@@ -129,21 +157,40 @@ function marginalContributions(
   baseTeam: AssignedHero[],
   combinedTeam: AssignedHero[],
   m: PairedModel
-): { delta: number; contributions: Contribution[] } {
+): {
+  delta: number;
+  contributions: Contribution[];
+  evaluatedFeatures: EvaluatedFeature[];
+} {
   const baseFeatures = teamFeatureIds(baseTeam);
   const combined = teamFeatureIds(combinedTeam);
   const contributions: Contribution[] = [];
+  const evaluatedFeatures: EvaluatedFeature[] = [];
   let delta = 0;
   for (const fid of combined) {
     if (baseFeatures.has(fid)) continue;
     const w = weightOf(m, fid);
+    const { label, family } = labelFeature(fid);
+    const evaluated = {
+      featureId: fid,
+      label,
+      family,
+      weight: w,
+      support: supportOf(m, fid),
+      displayPoints: displayScore(w),
+    };
+    evaluatedFeatures.push(evaluated);
     if (w === 0) continue;
     delta += w;
-    const { label, family } = labelFeature(fid);
-    contributions.push({ label, family, weight: w, support: supportOf(m, fid) });
+    contributions.push(evaluated);
   }
   contributions.sort((a, b) => b.weight - a.weight);
-  return { delta, contributions };
+  evaluatedFeatures.sort((a, b) =>
+    b.weight !== a.weight
+      ? b.weight - a.weight
+      : a.featureId.localeCompare(b.featureId)
+  );
+  return { delta, contributions, evaluatedFeatures };
 }
 
 const roundTo = (x: number, dp = 2): number => {
@@ -153,6 +200,22 @@ const roundTo = (x: number, dp = 2): number => {
 
 /** Scale a raw roster-strength delta to a friendlier 0-ish..N display number. */
 const displayScore = (x: number): number => roundTo(x * 10, 1);
+
+const evaluatedFeature = (
+  m: PairedModel,
+  featureId: string
+): EvaluatedFeature => {
+  const { label, family } = labelFeature(featureId);
+  const weight = weightOf(m, featureId);
+  return {
+    featureId,
+    label,
+    family,
+    weight,
+    support: supportOf(m, featureId),
+    displayPoints: displayScore(weight),
+  };
+};
 
 /**
  * Top positive *combo* contributions (pair/hero-skill families) from the full,
@@ -256,7 +319,8 @@ export function recommendHeroSet(
       ...baseTeam,
       ...heroes.map((name) => ({ name, skills: [] as string[] })),
     ];
-    const { delta, contributions } = marginalContributions(baseTeam, combined, m);
+    const { delta, contributions, evaluatedFeatures } =
+      marginalContributions(baseTeam, combined, m);
 
     // Per-hero marginal contribution (each hero added on top of base+others).
     const item_scores = heroes.map((hero) => {
@@ -285,6 +349,10 @@ export function recommendHeroSet(
       combo_tradeoffs: topComboTradeoffs(contributions),
       tradeoffs: contributions.filter((c) => c.weight < 0).slice(0, 3),
       evidence: ev,
+      debug: {
+        rawScore: delta,
+        evaluatedFeatures,
+      },
     };
   });
 
@@ -314,26 +382,52 @@ export function recommendSkillSet(
   const analysis: OptionAnalysis[] = availableSets.map((skills, setIndex) => {
     let delta = 0;
     const contributions: Contribution[] = [];
+    const evaluatedFeatures: EvaluatedFeature[] = [];
+    const skillRoutes: SkillRouteDebug[] = [];
     const item_scores = skills.map((skill) => {
-      const standalone = weightOf(m, skillId(skill));
+      const standaloneFeature = evaluatedFeature(m, skillId(skill));
       const { hero, weight } = bestHeroForSkill(skill, currentHeroes, m);
-      const total = standalone + weight;
+      const chosenRoute = hero
+        ? evaluatedFeature(m, heroSkillId(hero, skill))
+        : null;
+      const alternatives = currentHeroes
+        .map((candidateHero) =>
+          evaluatedFeature(m, heroSkillId(candidateHero, skill))
+        )
+        .sort((left, right) =>
+          right.weight !== left.weight
+            ? right.weight - left.weight
+            : left.featureId.localeCompare(right.featureId)
+        );
+      const total = standaloneFeature.weight + weight;
       delta += total;
-      if (standalone !== 0) {
-        contributions.push({ label: skill, family: 'S', weight: standalone, support: supportOf(m, skillId(skill)) });
-      }
-      if (hero && weight !== 0) {
-        contributions.push({
-          label: `${hero} · ${skill}`,
-          family: 'HS',
-          weight,
-          support: supportOf(m, heroSkillId(hero, skill)),
-        });
-      }
-      return { item: skill, score: displayScore(total), support: supportOf(m, skillId(skill)) };
+      evaluatedFeatures.push(standaloneFeature);
+      if (chosenRoute) evaluatedFeatures.push(chosenRoute);
+      if (standaloneFeature.weight !== 0) contributions.push(standaloneFeature);
+      if (chosenRoute && chosenRoute.weight !== 0)
+        contributions.push(chosenRoute);
+      skillRoutes.push({
+        skill,
+        standalone: standaloneFeature,
+        chosenHero: hero,
+        chosenRoute,
+        alternatives,
+        rawTotal: total,
+        displayTotal: displayScore(total),
+      });
+      return {
+        item: skill,
+        score: displayScore(total),
+        support: standaloneFeature.support,
+      };
     });
 
     contributions.sort((a, b) => b.weight - a.weight);
+    evaluatedFeatures.sort((left, right) =>
+      right.weight !== left.weight
+        ? right.weight - left.weight
+        : left.featureId.localeCompare(right.featureId)
+    );
     return {
       set_index: setIndex,
       items: skills,
@@ -348,6 +442,11 @@ export function recommendSkillSet(
         featureCount: contributions.length,
         totalSupport: contributions.reduce((a, c) => a + c.support, 0),
         minSupport: contributions.length ? Math.min(...contributions.map((c) => c.support)) : 0,
+      },
+      debug: {
+        rawScore: delta,
+        evaluatedFeatures,
+        skillRoutes,
       },
     };
   });
@@ -647,6 +746,41 @@ export interface FormationOption {
   teams: ProjectedTeam[];
 }
 
+export interface FormationDebugTeam {
+  heroes: string[];
+  skills: Record<string, [string | null, string | null]>;
+  guideId?: string;
+  prioritizedExactGuide: boolean;
+}
+
+export interface FormationDebugCandidate {
+  rank: number;
+  exactGuideIds: string[];
+  totalModelGain: number;
+  rawTotalModelGain: number;
+  exactChampionshipTeams: number;
+  exactRankingScore: number;
+  heroesPlaced: number;
+  completeTrios: number;
+  heroSupport: number;
+  canonicalKey: string;
+  teams: FormationDebugTeam[];
+}
+
+export interface FormationDecisionDebug {
+  policy: 'evidence-only-team-builder';
+  heroPoolCount: number;
+  skillPoolCount: number;
+  boundedHeroCount: number;
+  qualifiedHeroPairs: number;
+  qualifiedHeroTrios: number;
+  candidateSelectionsEvaluated: number;
+  prioritizedExactGuideCoreCount: number;
+  rankingOrder: string[];
+  /** Winner plus the strongest rejected candidates, in exact optimiser order. */
+  topCandidates: FormationDebugCandidate[];
+}
+
 export interface FormationRecommendation {
   /**
    * Up to three deterministic, distinct feasible formation options, ordered
@@ -658,6 +792,8 @@ export interface FormationRecommendation {
   options: FormationOption[];
   /** True when the pool wasn't large enough to run formation recommendation. */
   incomplete: boolean;
+  /** Compact optimiser trace used only by the browser-console debug export. */
+  debug?: FormationDecisionDebug;
 }
 
 /** Optional per-hero camp metadata sourced from database.json. */
@@ -2995,6 +3131,38 @@ function compareEvaluatedConservativeSelections(
   return left.selection.key.localeCompare(right.selection.key);
 }
 
+function conservativeCandidateDebug(
+  candidate: EvaluatedConservativeSelection,
+  rank: number
+): FormationDebugCandidate {
+  return {
+    rank,
+    exactGuideIds: [...candidate.selection.exactGuideIds],
+    totalModelGain: displayScore(candidate.totalFormationGain),
+    rawTotalModelGain: candidate.totalFormationGain,
+    exactChampionshipTeams: candidate.exactChampionshipTeams,
+    exactRankingScore: candidate.exactRankingScore,
+    heroesPlaced: candidate.selection.heroesPlaced,
+    completeTrios: candidate.selection.completeTrios,
+    heroSupport: candidate.selection.heroSupport,
+    canonicalKey: candidate.selection.key,
+    teams: candidate.teamGroups.map(({ group, guide, prioritizedExactGuide }) => ({
+      heroes: [...group.heroes],
+      skills: Object.fromEntries(
+        group.heroes.map((hero) => [
+          hero,
+          [...(candidate.skillAssignments.get(hero) ?? [null, null])] as [
+            string | null,
+            string | null,
+          ],
+        ])
+      ),
+      ...(guide ? { guideId: guide.comp.id } : {}),
+      prioritizedExactGuide,
+    })),
+  };
+}
+
 function buildConfidentTeamEvidence(
   team: AssignedHero[],
   m: PairedModel
@@ -3150,7 +3318,39 @@ function recommendConservativeHybridTeams(
     });
   }
 
-  return { options: [{ teams }], incomplete: false };
+  const debug: FormationDecisionDebug = {
+    policy: 'evidence-only-team-builder',
+    heroPoolCount: heroes.length,
+    skillPoolCount: skills.length,
+    boundedHeroCount: boundedHeroes.length,
+    qualifiedHeroPairs: candidateGroups.filter(
+      ({ group }) => group.heroes.length === 2
+    ).length,
+    qualifiedHeroTrios: candidateGroups.filter(
+      ({ group }) => group.heroes.length === 3
+    ).length,
+    candidateSelectionsEvaluated: evaluated.length,
+    prioritizedExactGuideCoreCount: candidateGroups.filter(
+      ({ prioritizedExactGuide }) => prioritizedExactGuide
+    ).length,
+    rankingOrder: [
+      'more usable exact 3/3 guide cores',
+      'higher fully assigned total model gain',
+      'more exact championship teams',
+      'higher exact guide ranking score',
+      'more heroes placed',
+      'more complete trios',
+      'higher hero evidence support',
+      'stable canonical key',
+    ],
+    topCandidates: evaluated
+      .slice(0, 8)
+      .map((candidate, index) =>
+        conservativeCandidateDebug(candidate, index + 1)
+      ),
+  };
+
+  return { options: [{ teams }], incomplete: false, debug };
 }
 
 /**

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -801,7 +801,9 @@ export interface FormationGuideMatchCandidateDebug {
 export interface FormationGuideMatchDecisionDebug {
   rankingOrder: string[];
   selected: FormationGuideMatchCandidateDebug;
+  rejectedCandidateLimit: number;
   rejected: FormationGuideMatchCandidateDebug[];
+  omittedRejectedCount: number;
 }
 
 export interface FormationDebugTeam {
@@ -858,7 +860,9 @@ export interface FormationGuideSkillSlotDebug {
     stableKey: string;
   };
   selected: FormationGuideSkillCandidateDebug | null;
+  rejectedCandidateLimit: number;
   rejected: FormationGuideSkillCandidateDebug[];
+  omittedRejectedCount: number;
 }
 
 export interface FormationSkillRouteCandidateDebug {
@@ -948,14 +952,21 @@ export interface FormationDecisionDebug {
   policy: 'evidence-only-team-builder';
   heroPoolCount: number;
   skillPoolCount: number;
+  heroPoolCap: number;
   boundedHeroCount: number;
+  consideredHeroes: string[];
+  excludedHeroes: Array<{
+    hero: string;
+    sortedPoolRank: number;
+    reason: 'excluded_by_alphabetical_hero_pool_cap';
+  }>;
   qualifiedHeroPairs: number;
   qualifiedHeroTrios: number;
   candidateSelectionsEvaluated: number;
   prioritizedExactGuideCoreCount: number;
   rankingOrder: string[];
   beamPruning: FormationBeamPruningDebug[];
-  /** Winner plus the strongest rejected candidates, in exact optimiser order. */
+  /** Detailed traces for only the winner and immediate runner-up. */
   topCandidates: FormationDebugCandidate[];
 }
 
@@ -1097,7 +1108,7 @@ const knownSlots = (
  * skills. This resolves alternatives across all selected guide teams together,
  * so a skill is never promised to two heroes.
  */
-const MAXIMUM_KNOWN_SLOT_MATCHING_EVENT_LIMIT = 64;
+const MAXIMUM_KNOWN_SLOT_MATCHING_EVENT_LIMIT = 24;
 
 interface KnownSlotMatchingResult {
   assignments: Map<string, string>;
@@ -2789,15 +2800,10 @@ function confidentHeroGroups(
   );
 }
 
-interface ConservativeGuideMatchCandidate {
+interface ConservativeGuideMatch {
   comp: TeamComp;
   matchedHeroes: string[];
   potentialSkillSlots: number;
-  debug: FormationGuideMatchCandidateDebug;
-}
-
-interface ConservativeGuideMatch extends ConservativeGuideMatchCandidate {
-  decision: FormationGuideMatchDecisionDebug;
 }
 
 const CONSERVATIVE_GUIDE_MATCH_RANKING_ORDER = [
@@ -2809,25 +2815,68 @@ const CONSERVATIVE_GUIDE_MATCH_RANKING_ORDER = [
 ];
 
 const compareConservativeGuideMatches = (
-  left: ConservativeGuideMatchCandidate,
-  right: ConservativeGuideMatchCandidate
+  left: ConservativeGuideMatch,
+  right: ConservativeGuideMatch
 ): number => {
-  if (left.debug.matchedHeroCount !== right.debug.matchedHeroCount)
-    return right.debug.matchedHeroCount - left.debug.matchedHeroCount;
-  if (
-    left.debug.qualifiedSkillSlotCount !==
-    right.debug.qualifiedSkillSlotCount
-  ) {
-    return (
-      right.debug.qualifiedSkillSlotCount -
-      left.debug.qualifiedSkillSlotCount
-    );
-  }
-  if (left.debug.championship !== right.debug.championship)
-    return Number(right.debug.championship) - Number(left.debug.championship);
-  if (left.debug.rankingScore !== right.debug.rankingScore)
-    return right.debug.rankingScore - left.debug.rankingScore;
-  return left.debug.stableId.localeCompare(right.debug.stableId);
+  if (left.matchedHeroes.length !== right.matchedHeroes.length)
+    return right.matchedHeroes.length - left.matchedHeroes.length;
+  if (left.potentialSkillSlots !== right.potentialSkillSlots)
+    return right.potentialSkillSlots - left.potentialSkillSlots;
+  const championshipDelta =
+    Number(isChampionshipComp(right.comp)) -
+    Number(isChampionshipComp(left.comp));
+  if (championshipDelta !== 0) return championshipDelta;
+  const rankingDelta =
+    teamRankingScore(right.comp.ranking) -
+    teamRankingScore(left.comp.ranking);
+  if (rankingDelta !== 0) return rankingDelta;
+  return left.comp.id.localeCompare(right.comp.id);
+};
+
+const conservativeGuideMatchCandidateDebug = (
+  candidate: ConservativeGuideMatch
+): FormationGuideMatchCandidateDebug => ({
+  guideId: candidate.comp.id,
+  matchedHeroes: [...candidate.matchedHeroes],
+  matchedHeroCount: candidate.matchedHeroes.length,
+  qualifiedSkillSlotCount: candidate.potentialSkillSlots,
+  championship: isChampionshipComp(candidate.comp),
+  ranking: candidate.comp.ranking,
+  rankingScore: teamRankingScore(candidate.comp.ranking),
+  stableId: candidate.comp.id,
+});
+
+const CONSERVATIVE_GUIDE_MATCH_REJECTED_LIMIT = 4;
+
+const conservativeGuideMatchDecisionDebug = (
+  selected: ConservativeGuideMatch,
+  teamComps: TeamComp[],
+  heroes: string[],
+  skillPool: Set<string>,
+  catalog: RecommendationCatalog,
+  m: PairedModel
+): FormationGuideMatchDecisionDebug => {
+  const selectedId = selected.comp.id;
+  const candidates = conservativeGuideMatchCandidates(
+    heroes,
+    teamComps,
+    skillPool,
+    catalog,
+    m
+  );
+  const rejected = candidates.filter(({ comp }) => comp.id !== selectedId);
+  return {
+    rankingOrder: [...CONSERVATIVE_GUIDE_MATCH_RANKING_ORDER],
+    selected: conservativeGuideMatchCandidateDebug(selected),
+    rejectedCandidateLimit: CONSERVATIVE_GUIDE_MATCH_REJECTED_LIMIT,
+    rejected: rejected
+      .slice(0, CONSERVATIVE_GUIDE_MATCH_REJECTED_LIMIT)
+      .map(conservativeGuideMatchCandidateDebug),
+    omittedRejectedCount: Math.max(
+      0,
+      rejected.length - CONSERVATIVE_GUIDE_MATCH_REJECTED_LIMIT
+    ),
+  };
 };
 
 const isConfidentGuideSkillRoute = (
@@ -2843,6 +2892,37 @@ const isConfidentGuideSkillRoute = (
  * Guide data never places a hero: at least two members must already have
  * independently cleared H and every within-group HP confidence gate.
  */
+function conservativeGuideMatchCandidates(
+  heroes: string[],
+  teamComps: TeamComp[],
+  skillPool: Set<string>,
+  catalog: RecommendationCatalog,
+  m: PairedModel
+): ConservativeGuideMatch[] {
+  const heroSet = new Set(heroes);
+  return teamComps
+    .flatMap((comp) => {
+      const matchedMembers = comp.members.filter(({ hero }) => heroSet.has(hero));
+      if (matchedMembers.length < 2) return [];
+      const matchedHeroes = matchedMembers.map(({ hero }) => hero);
+      const potentialSkillSlots = matchedMembers.reduce(
+        (count, member) =>
+          count +
+          member.skillSlots.filter((alternatives) =>
+            alternatives.some(
+              (skill) =>
+                skillPool.has(skill) &&
+                skill !== catalog.default_skill[member.hero] &&
+                isConfidentGuideSkillRoute(m, member.hero, skill)
+            )
+          ).length,
+        0
+      );
+      return [{ comp, matchedHeroes, potentialSkillSlots }];
+    })
+    .sort(compareConservativeGuideMatches);
+}
+
 function bestConservativeGuideMatch(
   heroes: string[],
   teamComps: TeamComp[],
@@ -2850,56 +2930,13 @@ function bestConservativeGuideMatch(
   catalog: RecommendationCatalog,
   m: PairedModel
 ): ConservativeGuideMatch | undefined {
-  const heroSet = new Set(heroes);
-  const candidates = teamComps.flatMap((comp) => {
-    const matchedMembers = comp.members.filter(({ hero }) => heroSet.has(hero));
-    if (matchedMembers.length < 2) return [];
-    const matchedHeroes = matchedMembers.map(({ hero }) => hero);
-    const potentialSkillSlots = matchedMembers.reduce(
-      (count, member) =>
-        count +
-        member.skillSlots.filter((alternatives) =>
-          alternatives.some(
-            (skill) =>
-              skillPool.has(skill) &&
-              skill !== catalog.default_skill[member.hero] &&
-              isConfidentGuideSkillRoute(m, member.hero, skill)
-          )
-        ).length,
-      0
-    );
-    return [
-      {
-        comp,
-        matchedHeroes,
-        potentialSkillSlots,
-        debug: {
-          guideId: comp.id,
-          matchedHeroes: [...matchedHeroes],
-          matchedHeroCount: matchedHeroes.length,
-          qualifiedSkillSlotCount: potentialSkillSlots,
-          championship: isChampionshipComp(comp),
-          ranking: comp.ranking,
-          rankingScore: teamRankingScore(comp.ranking),
-          stableId: comp.id,
-        },
-      },
-    ];
-  });
-  candidates.sort(compareConservativeGuideMatches);
-  const selected = candidates[0];
-  if (!selected) return undefined;
-  return {
-    ...selected,
-    decision: {
-      rankingOrder: [...CONSERVATIVE_GUIDE_MATCH_RANKING_ORDER],
-      selected: { ...selected.debug, matchedHeroes: [...selected.matchedHeroes] },
-      rejected: candidates.slice(1).map((candidate) => ({
-        ...candidate.debug,
-        matchedHeroes: [...candidate.matchedHeroes],
-      })),
-    },
-  };
+  return conservativeGuideMatchCandidates(
+    heroes,
+    teamComps,
+    skillPool,
+    catalog,
+    m
+  )[0];
 }
 
 interface ConservativeTeamGroup {
@@ -3169,7 +3206,6 @@ interface ConservativeGuideSkillSlot extends KnownSkillSlot {
   potentialSkillSlots: number;
   championship: boolean;
   rankingScore: number;
-  alternativeDecisions: FormationGuideSkillCandidateDebug[];
 }
 
 function compareConservativeGuideSkillSlots(
@@ -3212,30 +3248,31 @@ function conservativeGuideSkillSlots(
               skill !== catalog.default_skill[member.hero] &&
               isConfidentGuideSkillRoute(m, member.hero, skill)
           )
-          .map((skill) => ({
-            skill,
-            gain:
-              weightOf(m, skillId(skill)) +
-              weightOf(m, heroSkillId(member.hero, skill)),
-            support:
-              supportOf(m, skillId(skill)) +
-              supportOf(m, heroSkillId(member.hero, skill)),
-            stableKey: skill,
-          }))
-          .sort((left, right) =>
-            Math.abs(left.gain - right.gain) > 1e-9
-              ? right.gain - left.gain
-              : left.support !== right.support
-                ? right.support - left.support
-                : left.stableKey.localeCompare(right.stableKey)
-          );
+          .sort((left, right) => {
+            const leftGain =
+              weightOf(m, skillId(left)) +
+              weightOf(m, heroSkillId(member.hero, left));
+            const rightGain =
+              weightOf(m, skillId(right)) +
+              weightOf(m, heroSkillId(member.hero, right));
+            if (Math.abs(leftGain - rightGain) > 1e-9)
+              return rightGain - leftGain;
+            const leftSupport =
+              supportOf(m, skillId(left)) +
+              supportOf(m, heroSkillId(member.hero, left));
+            const rightSupport =
+              supportOf(m, skillId(right)) +
+              supportOf(m, heroSkillId(member.hero, right));
+            return leftSupport !== rightSupport
+              ? rightSupport - leftSupport
+              : left.localeCompare(right);
+          });
         return {
           key: `conservative|${teamIndex}|${guide.comp.id}|${member.hero}|${slotIndex}`,
           teamKey: group.key,
           hero: member.hero,
           slotIndex,
-          alternatives: eligible.map(({ skill }) => skill),
-          alternativeDecisions: eligible,
+          alternatives: eligible,
           matchedHeroCount: guide.matchedHeroes.length,
           potentialSkillSlots: guide.potentialSkillSlots,
           championship: isChampionshipComp(guide.comp),
@@ -3267,18 +3304,20 @@ function compareConservativeSkillCandidates(
   return left.key.localeCompare(right.key);
 }
 
-const CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT = 8;
+const CONSERVATIVE_GUIDE_SLOT_REJECTED_LIMIT = 4;
+const CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT = 4;
 
 interface ConservativeSkillAssignmentResult {
   assignments: Map<string, ConservativeSkillSlots>;
-  debug: FormationSkillRoutingDebug;
+  debug?: FormationSkillRoutingDebug;
 }
 
 function assignConservativeSkills(
   teamGroups: ConservativeTeamGroup[],
   skillPool: string[],
   m: PairedModel,
-  catalog: RecommendationCatalog
+  catalog: RecommendationCatalog,
+  captureDebug = false
 ): ConservativeSkillAssignmentResult {
   const heroes = teamGroups.flatMap(({ group }) => group.heroes);
   const heroSet = new Set(heroes);
@@ -3299,30 +3338,48 @@ function assignConservativeSkills(
     catalog
   );
   const guideSlotByKey = new Map(guideSlots.map((slot) => [slot.key, slot]));
-  const guideMatchingResult = maximumKnownSlotMatching(guideSlots, true);
+  const guideMatchingResult = maximumKnownSlotMatching(guideSlots, captureDebug);
   const guideMatching = guideMatchingResult.assignments;
-  const guideMatchingDebug = guideSlots.map((slot) => {
-    const selectedSkill = guideMatching.get(slot.key);
-    const selected =
-      slot.alternativeDecisions.find(({ skill }) => skill === selectedSkill) ??
-      null;
-    return {
-      slotKey: slot.key,
-      hero: slot.hero,
-      slotIndex: slot.slotIndex,
-      priority: {
-        matchedHeroCount: slot.matchedHeroCount,
-        qualifiedSkillSlotCount: slot.potentialSkillSlots,
-        championship: slot.championship,
-        rankingScore: slot.rankingScore,
-        stableKey: slot.key,
-      },
-      selected,
-      rejected: slot.alternativeDecisions.filter(
-        ({ skill }) => skill !== selectedSkill
-      ),
-    };
+  const guideSkillDebug = (
+    slot: ConservativeGuideSkillSlot,
+    skill: string
+  ): FormationGuideSkillCandidateDebug => ({
+    skill,
+    gain:
+      weightOf(m, skillId(skill)) + weightOf(m, heroSkillId(slot.hero, skill)),
+    support:
+      supportOf(m, skillId(skill)) + supportOf(m, heroSkillId(slot.hero, skill)),
+    stableKey: skill,
   });
+  const guideMatchingDebug = captureDebug
+    ? guideSlots.map((slot) => {
+        const selectedSkill = guideMatching.get(slot.key);
+        const rejected = slot.alternatives.filter(
+          (skill) => skill !== selectedSkill
+        );
+        return {
+          slotKey: slot.key,
+          hero: slot.hero,
+          slotIndex: slot.slotIndex,
+          priority: {
+            matchedHeroCount: slot.matchedHeroCount,
+            qualifiedSkillSlotCount: slot.potentialSkillSlots,
+            championship: slot.championship,
+            rankingScore: slot.rankingScore,
+            stableKey: slot.key,
+          },
+          selected: selectedSkill ? guideSkillDebug(slot, selectedSkill) : null,
+          rejectedCandidateLimit: CONSERVATIVE_GUIDE_SLOT_REJECTED_LIMIT,
+          rejected: rejected
+            .slice(0, CONSERVATIVE_GUIDE_SLOT_REJECTED_LIMIT)
+            .map((skill) => guideSkillDebug(slot, skill)),
+          omittedRejectedCount: Math.max(
+            0,
+            rejected.length - CONSERVATIVE_GUIDE_SLOT_REJECTED_LIMIT
+          ),
+        };
+      })
+    : [];
   for (const [slotKey, skill] of guideMatching) {
     const slot = guideSlotByKey.get(slotKey);
     if (!slot) continue;
@@ -3476,53 +3533,69 @@ function assignConservativeSkills(
     const best = candidates[0];
     if (!best) break;
     const slots = assigned.get(best.hero)!;
-    const selected = candidateDebug(best, slots);
-    modelRoutingSteps.push({
-      step: modelRoutingSteps.length + 1,
-      candidateCount: candidates.length,
-      selected,
-      rejected: candidates
-        .slice(1, CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT + 1)
-        .map((candidate) => candidateDebug(candidate, assigned.get(candidate.hero)!)),
-      omittedRejectedCount: Math.max(
-        0,
-        candidates.length - 1 - CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT
-      ),
-    });
-    for (const { skill, slotIndex } of selected.placements) {
+    if (captureDebug) {
+      const selected = candidateDebug(best, slots);
+      modelRoutingSteps.push({
+        step: modelRoutingSteps.length + 1,
+        candidateCount: candidates.length,
+        selected,
+        rejected: candidates
+          .slice(1, CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT + 1)
+          .map((candidate) =>
+            candidateDebug(candidate, assigned.get(candidate.hero)!)
+          ),
+        omittedRejectedCount: Math.max(
+          0,
+          candidates.length - 1 - CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT
+        ),
+      });
+      for (const { skill, slotIndex } of selected.placements) {
+        slots[slotIndex] = skill;
+        usedSkills.add(skill);
+      }
+      continue;
+    }
+    for (const skill of best.additions) {
+      const slotIndex =
+        preferredGuideSlot(best.hero, skill, slots) ?? slots.indexOf(null);
+      if (slotIndex < 0) break;
       slots[slotIndex] = skill;
       usedSkills.add(skill);
     }
   }
   return {
     assignments: assigned,
-    debug: {
-      guideMatching: {
-        slotRankingOrder: [
-          'higher matched hero count',
-          'higher evidence-qualified guide-slot count',
-          'championship source before non-championship source',
-          'higher guide ranking score',
-          'lower stable slot key by locale order',
-        ],
-        alternativeRankingOrder: [
-          'higher standalone S plus assigned-hero HS gain',
-          'higher combined S plus HS support',
-          'lower stable skill key by locale order',
-        ],
-        maximumCardinality: guideMatchingResult.debug!,
-        slots: guideMatchingDebug,
-      },
-      modelRouting: {
-        rankingOrder: [
-          'higher incremental model gain',
-          'higher combined feature support',
-          'lower stable route key by locale order',
-        ],
-        rejectedCandidateLimit: CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT,
-        steps: modelRoutingSteps,
-      },
-    },
+    ...(captureDebug
+      ? {
+          debug: {
+            guideMatching: {
+              slotRankingOrder: [
+                'higher matched hero count',
+                'higher evidence-qualified guide-slot count',
+                'championship source before non-championship source',
+                'higher guide ranking score',
+                'lower stable slot key by locale order',
+              ],
+              alternativeRankingOrder: [
+                'higher standalone S plus assigned-hero HS gain',
+                'higher combined S plus HS support',
+                'lower stable skill key by locale order',
+              ],
+              maximumCardinality: guideMatchingResult.debug!,
+              slots: guideMatchingDebug,
+            },
+            modelRouting: {
+              rankingOrder: [
+                'higher incremental model gain',
+                'higher combined feature support',
+                'lower stable route key by locale order',
+              ],
+              rejectedCandidateLimit: CONSERVATIVE_MODEL_ROUTE_REJECTED_LIMIT,
+              steps: modelRoutingSteps,
+            },
+          },
+        }
+      : {}),
   };
 }
 
@@ -3530,7 +3603,7 @@ interface EvaluatedConservativeSelection {
   selection: ConservativeGroupSelection;
   teamGroups: ConservativeTeamGroup[];
   skillAssignments: Map<string, ConservativeSkillSlots>;
-  skillRouting: FormationSkillRoutingDebug;
+  skillRouting?: FormationSkillRoutingDebug;
   totalFormationGain: number;
   exactChampionshipTeams: number;
   exactRankingScore: number;
@@ -3549,14 +3622,16 @@ function evaluateConservativeSelection(
   selection: ConservativeGroupSelection,
   skills: string[],
   m: PairedModel,
-  catalog: RecommendationCatalog
+  catalog: RecommendationCatalog,
+  captureDebug = false
 ): EvaluatedConservativeSelection {
   const teamGroups = orderConservativeTeamGroups(selection.groups);
   const skillAssignment = assignConservativeSkills(
     teamGroups,
     skills,
     m,
-    catalog
+    catalog,
+    captureDebug
   );
   const skillAssignments = skillAssignment.assignments;
   const totalFormationGain = teamGroups.reduce(
@@ -3626,8 +3701,14 @@ function compareEvaluatedConservativeSelections(
 
 function conservativeCandidateDebug(
   candidate: EvaluatedConservativeSelection,
-  rank: number
+  rank: number,
+  teamComps: TeamComp[],
+  skillPool: Set<string>,
+  catalog: RecommendationCatalog,
+  m: PairedModel
 ): FormationDebugCandidate {
+  if (!candidate.skillRouting)
+    throw new Error('Detailed candidate trace was not captured');
   return {
     rank,
     exactGuideIds: [...candidate.selection.exactGuideIds],
@@ -3653,17 +3734,14 @@ function conservativeCandidateDebug(
       ...(guide
         ? {
             guideId: guide.comp.id,
-            guideMatchDecision: {
-              rankingOrder: [...guide.decision.rankingOrder],
-              selected: {
-                ...guide.decision.selected,
-                matchedHeroes: [...guide.decision.selected.matchedHeroes],
-              },
-              rejected: guide.decision.rejected.map((candidate) => ({
-                ...candidate,
-                matchedHeroes: [...candidate.matchedHeroes],
-              })),
-            },
+            guideMatchDecision: conservativeGuideMatchDecisionDebug(
+              guide,
+              teamComps,
+              group.heroes,
+              skillPool,
+              catalog,
+              m
+            ),
           }
         : {}),
       prioritizedExactGuide,
@@ -3727,9 +3805,15 @@ function recommendConservativeHybridTeams(
     return incompleteFormationRecommendation();
 
   const m = model(data);
-  const boundedHeroes = [...heroes]
-    .sort()
-    .slice(0, FORMATION_HERO_POOL_CAP);
+  const sortedHeroes = [...heroes].sort();
+  const boundedHeroes = sortedHeroes.slice(0, FORMATION_HERO_POOL_CAP);
+  const excludedHeroes = sortedHeroes
+    .slice(FORMATION_HERO_POOL_CAP)
+    .map((hero, index) => ({
+      hero,
+      sortedPoolRank: FORMATION_HERO_POOL_CAP + index + 1,
+      reason: 'excluded_by_alphabetical_hero_pool_cap' as const,
+    }));
   const skillSet = new Set(skills);
   const candidateGroups: ConservativeTeamGroup[] = [
     ...confidentHeroGroups(boundedHeroes, 3, m),
@@ -3757,7 +3841,10 @@ function recommendConservativeHybridTeams(
       evaluateConservativeSelection(selection, skills, m, catalog)
     )
     .sort(compareEvaluatedConservativeSelections);
-  const winner = evaluated[0];
+  const detailedCandidates = evaluated.slice(0, 2).map((candidate) =>
+    evaluateConservativeSelection(candidate.selection, skills, m, catalog, true)
+  );
+  const winner = detailedCandidates[0] ?? evaluated[0];
   const teamGroups = winner?.teamGroups ?? [];
   const skillAssignments =
     winner?.skillAssignments ?? new Map<string, ConservativeSkillSlots>();
@@ -3832,7 +3919,10 @@ function recommendConservativeHybridTeams(
     policy: 'evidence-only-team-builder',
     heroPoolCount: heroes.length,
     skillPoolCount: skills.length,
+    heroPoolCap: FORMATION_HERO_POOL_CAP,
     boundedHeroCount: boundedHeroes.length,
+    consideredHeroes: [...boundedHeroes],
+    excludedHeroes,
     qualifiedHeroPairs: candidateGroups.filter(
       ({ group }) => group.heroes.length === 2
     ).length,
@@ -3854,11 +3944,16 @@ function recommendConservativeHybridTeams(
       'stable canonical key',
     ],
     beamPruning: selectionSearch.beamPruning,
-    topCandidates: evaluated
-      .slice(0, 8)
-      .map((candidate, index) =>
-        conservativeCandidateDebug(candidate, index + 1)
-      ),
+    topCandidates: detailedCandidates.map((candidate, index) =>
+      conservativeCandidateDebug(
+        candidate,
+        index + 1,
+        teamComps,
+        skillSet,
+        catalog,
+        m
+      )
+    ),
   };
 
   return { options: [{ teams }], incomplete: false, debug };

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -598,6 +598,23 @@ test.describe('Team Builder best default', () => {
     await expect(page.getByTestId('recommendation-success')).toHaveText(
       '已编入 3 支完整队伍'
     );
+    const debugContext = await page.evaluate(() =>
+      JSON.parse(window.sanmouDebug())
+    );
+    expect(debugContext).toMatchObject({
+      schema: 'sanmou-recommendation-debug/v1',
+      page: 'team-formation-suggestion',
+      status: 'ready',
+      optimizer_trace: {
+        policy: 'evidence-only-team-builder',
+      },
+      current_layout: {
+        matches_original_recommendation: true,
+        user_edited: false,
+      },
+    });
+    expect(debugContext.recommended_teams).toHaveLength(3);
+    expect(debugContext.optimizer_trace.winner).toMatchObject({ rank: 1 });
     await expect(page.getByRole('button', { name: '清空编排' })).toHaveCount(0);
     await expect(
       page.getByRole('heading', { name: /^队伍 [123]$/ })

--- a/web/tests/optionAnalysisLabels.spec.js
+++ b/web/tests/optionAnalysisLabels.spec.js
@@ -13,6 +13,39 @@ const {
 // autocomplete, setup form) was intentionally left showing bare names.
 
 test.describe('选项分析 — hero & skill labels', () => {
+  test('sanmouDebug exports not-ready and exact recommendation contexts', async ({ page }) => {
+    const team = heroesWithMeta.slice(0, 4);
+    const candidates = heroesWithMeta.slice(4, 13);
+    await seedGame(
+      page,
+      makeGameState({ roundNumber: 1, heroes: team, skills: anySkills(8) }),
+      {
+        set1: candidates.slice(0, 3),
+        set2: candidates.slice(3, 6),
+        set3: candidates.slice(6, 9),
+      },
+    );
+
+    const before = await page.evaluate(() => JSON.parse(window.sanmouDebug()));
+    expect(before).toMatchObject({
+      page: 'candidate-suggestion',
+      status: 'not-ready',
+    });
+
+    await page.getByRole('button', { name: '获取 AI 推荐' }).click();
+    await expect(page.getByText('选项分析')).toBeVisible({ timeout: 15000 });
+    const after = await page.evaluate(() => JSON.parse(window.sanmouDebug()));
+    expect(after).toMatchObject({
+      schema: 'sanmou-recommendation-debug/v1',
+      page: 'candidate-suggestion',
+      status: 'ready',
+    });
+    expect(after.options).toHaveLength(3);
+    expect(after.decision.ranking).toHaveLength(3);
+    expect(after.options[0].score_calculation.length).toBeGreaterThan(0);
+    expect(after.model).not.toHaveProperty('weights');
+  });
+
   test('successful round-prompt copies record the GA event without prompt data', async ({
     page,
     context,


### PR DESCRIPTION
## Intent

Add a browser-console debug function for both the draft candidate suggestion page and the Team Builder formation suggestion page. The user must be able to run copy(sanmouDebug()) and paste a self-contained, readable JSON context into an agent to understand exactly why the current AI recommendation won over an expected alternative. Include current inputs, model/corpus identity, exact weights and evidence, skill routing, ranking and tie-break policy, Team Builder evidence gates, guide matches, selected score breakdowns, unplaced-item reasons, current edits, and compact winner/runner-up optimiser details; keep it local/read-only and exclude telemetry identifiers, cookies, unrelated storage, the full corpus, and full model maps. Return a useful not-ready context before computation, document usage, and cover both pages with unit and browser tests.

## What Changed

- Expose a local, read-only `sanmouDebug()` console export on draft candidate and Team Builder recommendation pages, including useful not-ready responses.
- Capture model identity, inputs, feature weights and evidence, ranking and routing tie-breaks, Team Builder gates, guide matches, unplaced-item reasons, current edits, and bounded winner/runner-up optimiser traces without exporting full model maps or corpus data.
- Document `copy(sanmouDebug())` usage and add unit and Playwright coverage for both recommendation workflows.

## Risk Assessment

✅ Low: The change is local and read-only, preserves recommendation behavior, bounds exported diagnostics to authoritative search inputs and two finalists, and adds behavior-focused unit and browser coverage.

## Testing

No prior baseline commands were supplied. Focused debug/optimizer unit tests and both page-level Playwright flows completed successfully, followed by end-to-end browser captures covering not-ready states, computed recommendations, Team Builder edits, overflow/unplaced diagnostics, and local read-only behavior. An initial evidence harness attempt used a relative URL outside Playwright's configured runner, was corrected to the explicit local Vite URL, and was fully rerun. No screenshot was captured because the feature is exclusively a browser-console JSON interface with no new rendered UI; the exact returned JSON is provided instead.

<details>
<summary>Evidence: Draft-page sanmouDebug JSON before and after recommendation computation</summary>

```text
{
  "invocation": "copy(sanmouDebug())",
  "before_computation": {
    "schema": "sanmou-recommendation-debug/v1",
    "page": "candidate-suggestion",
    "model": {
      "model_type": "paired-logistic",
      "schema_version": 4,
      "catalog_version": "ed3db0590240",
      "corpus_version": "c8627cf829600718",
      "total_battles": 7684,
      "minimum_support": {
        "H": 5,
        "S": 5,
        "HP": 8,
        "HS": 8,
        "SP": 8
      },
      "score_scale": "display points = raw fitted weight × 10, rounded to one decimal",
      "score_meaning": "Relative roster strength against the learned metagame; not an opponent-specific win probability."
    },
    "input": {
      "season": 16,
      "round": 1,
      "round_type": "hero",
      "current_pool": {
        "heroes": [
          "刘禅",
          "糜夫人",
          "孙坚2",
          "木鹿大王"
        ],
        "skills": [
          "诛凶殄逆",
          "驱兽御象",
          "决堰倾涛",
          "慎思笃行",
          "雄护南疆",
          "南疆烈刃",
          "子午奇谋",
          "素衣约俭"
        ],
        "support_hero": null,
        "support_skills": [],
        "heroes_used_for_scoring": [
          "刘禅",
          "糜夫人",
          "孙坚2",
          "木鹿大王"
        ],
        "skills_used_for_scoring": [
          "诛凶殄逆",
          "驱兽御象",
          "决堰倾涛",
          "慎思笃行",
          "雄护南疆",
          "南疆烈刃",
          "子午奇谋",
          "素衣约俭"
        ]
      },
      "offered_sets": [
        {
          "index": 0,
          "label": "A",
          "items": [
            "陆抗",
            "诸葛瑾",
            "孟获"
          ]
        },
        {
          "index": 1,
          "label": "B",
          "items": [
            "祝融",
            "魏延",
            "卞夫人"
          ]
        },
        {
          "index": 2,
          "label": "C",
          "items": [
            "曹丕",
            "高顺",
            "凌统"
          ]
        }
      ]
    },
    "status": "not-ready",
    "reason": "No recommendation has been calculated for the current offers.",
    "next_step": "Complete all three option sets and click 获取 AI 推荐, then run sanmouDebug() again."
  },
  "after_computation": {
    "schema": "sanmou-recommendation-debug/v1",
    "page": "candidate-suggestion",
    "model": {
      "model_type": "paired-logistic",
      "schema_version": 4,
      "catalog_version": "ed3db0590240",
      "corpus_version": "c8627cf829600718",
      "total_battles": 7684,
      "minimum_support": {
        "H": 5,
        "S": 5,
        "HP": 8,
        "HS": 8,
        "SP": 8
      },
      "score_scale": "display points = raw fitted weight × 10, rounded to one decimal",
      "score_meaning": "Relative roster strength against the learned metagame; not an opponent-specific win probability."
    },
    "input": {
      "season": 16,
      "round": 1,
      "round_type": "hero",
      "current_pool": {
        "heroes": [
          "刘禅",
          "糜夫人",
          "孙坚2",
          "木鹿大王"
        ],
        "skills": [
          "诛凶殄逆",
          "驱兽御象",
          "决堰倾涛",
          "慎思笃行",
          "雄护南疆",
          "南疆烈刃",
          "子午奇谋",
          "素衣约俭"
        ],
        "support_hero": null,
        "support_skills": [],
        "heroes_used_for_scoring": [
          "刘禅",
          "糜夫人",
          "孙坚2",
          "木鹿大王"
        ],
        "skills_used_for_scoring": [
          "诛凶殄逆",
          "驱兽御象",
          "决堰倾涛",
          "慎思笃行",
          "雄护南疆",
          "南疆烈刃",
          "子午奇谋",
          "素衣约俭"
        ]
      },
      "offered_sets": [
        {
          "index": 0,
          "label": "A",
          "items": [
            "陆抗",
            "诸葛瑾",
            "孟获"
          ]
        },
        {
          "index": 1,
          "label": "B",
          "items": [
            "祝融",
            "魏延",
            "卞夫人"
          ]
        },
        {
          "index": 2,
          "label": "C",
          "items": [
            "曹丕",
            "高顺",
            "凌统"
          ]
        }
      ]
    },
    "status": "ready",
    "decision": {
      "recommended_index": 1,
      "recommended_label": "B",
      "ranking_rule": [
        "higher final_score",
        "higher total evidence support when displayed scores tie",
        "lower option index when still tied"
      ],
      "ranking": [
        {
          "rank": 1,
          "option": "B",
          "final_score": 14.4,
          "raw_score": 1.4389219999999998,
          "total_support": 4998,
          "minimum_support_in_active_evidence": 18
        },
        {
          "rank": 2,
          "option": "A",
          "final_score": -1.4,
          "raw_score": -0.140154,
          "total_support": 3941,
          "minimum_support_in_active_evidence": 19
        },
        {
          "rank": 3,
          "option": "C",
          "final_score": -2.4,
          "raw_score": -0.236258,
          "total_support": 2513,
          "minimum_support_in_active_evidence": 8
        }
      ],
      "winner_margin_over_runner_up": 15.8
    },
    "options": [
      {
        "option": "A",
        "index": 0,
        "rank": 2,
        "items": [
          "陆抗",
          "诸葛瑾",
          "孟获"
        ],
        "raw_score": -0.140154,
        "display_score": -1.4,
        "item_scores": [
          {
            "item": "陆抗",
            "score": -0.2,
            "support": 418
          },
          {
            "item": "诸葛瑾",
            "score": -0.6,
            "support": 247
          },
          {
            "item": "孟获",
            "score": -0.6,
            "support": 1444
          }
        ],
        "evidence": {
          "featureCount": 11,
          "totalSupport": 3941,
          "minSupport": 19
        },
        "score_calculation": [
          {
            "feature_id": "HP|孙坚2|孟获",
            "meaning": "武将配合：孙坚2 + 孟获",
            "family": "HP",
            "weight": 0.407702,
            "display_points": 4.1,
            "support": 40,
            "contributes_to_score": true
          },
          {
            "feature_id": "H|陆抗",
            "meaning": "武将个体：陆抗",
            "family": "H",
            "weight": 0.075737,
            "display_points": 0.8,
            "support": 418,
            "contributes_to_score": true
          },
          {
            "feature_id": "HP|刘禅|孟获",
            "meaning": "武将配合：刘禅 + 孟获",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|刘禅|诸葛瑾",
            "meaning": "武将配合：刘禅 + 诸葛瑾",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|刘禅|陆抗",
            "meaning": "武将配合：刘禅 + 陆抗",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|孙坚2|诸葛瑾",
            "meaning": "武将配合：孙坚2 + 诸葛瑾",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|孟获|糜夫人",
            "meaning": "武将配合：孟获 + 糜夫人",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "

... [7721 bytes truncated] ...

"support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|祝融|糜夫人",
            "meaning": "武将配合：祝融 + 糜夫人",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|祝融|魏延",
            "meaning": "武将配合：祝融 + 魏延",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|糜夫人|魏延",
            "meaning": "武将配合：糜夫人 + 魏延",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|孙坚2|祝融",
            "meaning": "武将配合：孙坚2 + 祝融",
            "family": "HP",
            "weight": -0.254835,
            "display_points": -2.5,
            "support": 38,
            "contributes_to_score": true
          },
          {
            "feature_id": "H|魏延",
            "meaning": "武将个体：魏延",
            "family": "H",
            "weight": -0.53869,
            "display_points": -5.4,
            "support": 698,
            "contributes_to_score": true
          }
        ],
        "skill_routing": []
      },
      {
        "option": "C",
        "index": 2,
        "rank": 3,
        "items": [
          "曹丕",
          "高顺",
          "凌统"
        ],
        "raw_score": -0.236258,
        "display_score": -2.4,
        "item_scores": [
          {
            "item": "曹丕",
            "score": 6.4,
            "support": 822
          },
          {
            "item": "高顺",
            "score": -7.8,
            "support": 126
          },
          {
            "item": "凌统",
            "score": -0.9,
            "support": 112
          }
        ],
        "evidence": {
          "featureCount": 9,
          "totalSupport": 2513,
          "minSupport": 8
        },
        "score_calculation": [
          {
            "feature_id": "H|曹丕",
            "meaning": "武将个体：曹丕",
            "family": "H",
            "weight": 0.63514,
            "display_points": 6.4,
            "support": 822,
            "contributes_to_score": true
          },
          {
            "feature_id": "HP|凌统|刘禅",
            "meaning": "武将配合：凌统 + 刘禅",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|凌统|孙坚2",
            "meaning": "武将配合：凌统 + 孙坚2",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|凌统|曹丕",
            "meaning": "武将配合：凌统 + 曹丕",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|凌统|木鹿大王",
            "meaning": "武将配合：凌统 + 木鹿大王",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|凌统|糜夫人",
            "meaning": "武将配合：凌统 + 糜夫人",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|凌统|高顺",
            "meaning": "武将配合：凌统 + 高顺",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|刘禅|曹丕",
            "meaning": "武将配合：刘禅 + 曹丕",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|刘禅|高顺",
            "meaning": "武将配合：刘禅 + 高顺",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|孙坚2|曹丕",
            "meaning": "武将配合：孙坚2 + 曹丕",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|曹丕|木鹿大王",
            "meaning": "武将配合：曹丕 + 木鹿大王",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|曹丕|糜夫人",
            "meaning": "武将配合：曹丕 + 糜夫人",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|曹丕|高顺",
            "meaning": "武将配合：曹丕 + 高顺",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|木鹿大王|高顺",
            "meaning": "武将配合：木鹿大王 + 高顺",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "HP|糜夫人|高顺",
            "meaning": "武将配合：糜夫人 + 高顺",
            "family": "HP",
            "weight": 0,
            "display_points": 0,
            "support": 0,
            "contributes_to_score": false
          },
          {
            "feature_id": "H|凌统",
            "meaning": "武将个体：凌统",
            "family": "H",
            "weight": -0.090897,
            "display_points": -0.9,
            "support": 112,
            "contributes_to_score": true
          },
          {
            "feature_id": "HP|孙坚2|高顺",
            "meaning": "武将配合：孙坚2 + 高顺",
            "family": "HP",
            "weight": -0.154674,
            "display_points": -1.5,
            "support": 8,
            "contributes_to_score": true
          },
          {
            "feature_id": "H|高顺",
            "meaning": "武将个体：高顺",
            "family": "H",
            "weight": -0.625827,
            "display_points": -6.3,
            "support": 126,
            "contributes_to_score": true
          }
        ],
        "skill_routing": []
      }
    ],
    "player_preference_model": {
      "version": "preference-v2:ec7fc07a076cdc0f",
      "probabilities": [
        0.077,
        0.901,
        0.022
      ],
      "top_index": 1,
      "probability_margin": 0.8240000000000001,
      "meaningful_margin": 0.1,
      "explanation_driver": "这是相似阵容与选项中的总体选择倾向。",
      "affects_ai_recommendation": false,
      "note": "This separately labelled model describes historical player choices and never changes the paired-model AI recommendation."
    }
  },
  "verification": {
    "returned_pretty_json": true,
    "fetch_calls": 0,
    "xhr_calls": 0,
    "beacon_calls": 0,
    "unrelated_storage_unchanged": true,
    "cookies_unchanged": true
  }
}
```
</details>
- Evidence: Team Builder sanmouDebug JSON before and after a user formation edit (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0GR8B5KBNBAKKG6EHEJ27GT/team-builder-sanmou-debug.json</code>)
<details>
<summary>Evidence: Team Builder not-ready sanmouDebug JSON</summary>

```text
{
  "invocation": "copy(sanmouDebug())",
  "context": {
    "schema": "sanmou-recommendation-debug/v1",
    "page": "team-formation-suggestion",
    "model": {
      "model_type": "paired-logistic",
      "schema_version": 4,
      "catalog_version": "ed3db0590240",
      "corpus_version": "c8627cf829600718",
      "total_battles": 7684,
      "minimum_support": {
        "H": 5,
        "S": 5,
        "HP": 8,
        "HS": 8,
        "SP": 8
      },
      "score_scale": "display points = raw fitted weight × 10, rounded to one decimal",
      "score_meaning": "Relative roster strength against the learned metagame; not an opponent-specific win probability."
    },
    "input": {
      "season": 16,
      "heroes": [
        "刘禅",
        "糜夫人",
        "孙坚2"
      ],
      "skills": [
        "诛凶殄逆",
        "驱兽御象",
        "决堰倾涛",
        "慎思笃行"
      ],
      "support_items": []
    },
    "status": "not-ready",
    "reason": "Automatic recommendation needs at least 9 heroes and 18 skills; current pool has 3 heroes and 4 skills.",
    "next_step": "Wait for the team formation page to finish loading, then run sanmouDebug() again."
  }
}
```
</details>
- Evidence: Team Builder overflow-pool sanmouDebug JSON with unplaced-item diagnostics (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0GR8B5KBNBAKKG6EHEJ27GT/team-builder-overflow-sanmou-debug.json</code>)
<details>
<summary>Evidence: Compact overflow-pool evidence summary and sample unplaced reasons</summary>

```text
{
  "status": "ready",
  "input_counts": {
    "heroes": 17,
    "skills": 28
  },
  "selected_team_count": 3,
  "unplaced_hero_count": 9,
  "unplaced_skill_count": 12,
  "hero_reasons": [
    "excluded_by_alphabetical_hero_pool_cap",
    "eligible_groups_reached_final_evaluation_but_lost_global_ranking",
    "no_fully_evidence_qualified_pair_or_trio",
    "atomic_hero_evidence_gate_failed"
  ],
  "skill_reasons": [
    "routes_to_selected_heroes_lost_assignment_or_capacity_ranking",
    "atomic_skill_evidence_gate_failed",
    "no_evidence_qualified_hero_skill_route"
  ],
  "sample_unplaced_hero": {
    "name": "袁术",
    "support_item": false,
    "individual_gate": null,
    "qualified_pair_or_trio_count": 0,
    "pool_cap_exclusion": {
      "hero": "袁术",
      "sortedPoolRank": 16,
      "reason": "excluded_by_alphabetical_hero_pool_cap"
    },
    "reason": "excluded_by_alphabetical_hero_pool_cap"
  },
  "sample_unplaced_skill": {
    "name": "百战不殆",
    "support_item": false,
    "individual_gate": {
      "feature_id": "S|百战不殆",
      "meaning": "战法个体：百战不殆",
      "family": "S",
      "weight": 0.112213,
      "display_points": 1.1,
      "support": 1154,
      "required_support": 5,
      "passed": true
    },
    "evidence_qualified_routes": {
      "selected_heroes": [
        "乐进",
        "孟获",
        "曹丕",
        "曹操",
        "皇甫嵩2"
      ],
      "unplaced_heroes": []
    },
    "reason": "routes_to_selected_heroes_lost_assignment_or_capacity_ranking"
  }
}
```
</details>
<details>
<summary>Evidence: Compact end-to-end verification summary for readiness, edits, exclusions, and read-only behavior</summary>

```text
{
  "draft": {
    "not_ready_before_computation": true,
    "ready_after_computation": true,
    "option_count": 3,
    "ranking_count": 3,
    "forbidden_export_keys": []
  },
  "team_builder": {
    "ready": true,
    "recommended_team_count": 3,
    "has_winner": true,
    "has_runner_up": true,
    "original_matches_recommendation": true,
    "edit_reflected": true,
    "forbidden_export_keys": []
  },
  "local_read_only_probe": {
    "fetch_calls": 0,
    "xhr_calls": 0,
    "beacon_calls": 0,
    "unrelated_storage_unchanged": true,
    "cookies_unchanged": true
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3c1d6483bbfeb027ee834153e804d133ec64d0ea","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- 🚨 `web/src/services/recommendationDebug.ts:519` - The required “exactly why” context and “unplaced-item reasons” are incorrect for a reachable manually edited pool above 15 heroes. The optimiser alphabetically limits candidates to 15 heroes in recommendationEngine.ts, but this code evaluates every input hero and can label a hero that never entered the search as `eligible_groups_existed_but_lost_global_ranking`; guide and skill-route diagnostics likewise include excluded heroes as though they were considered. Export the optimiser&#39;s bounded hero identities and exclusion reasons from the authoritative search trace, then derive these diagnostics from that boundary.
- 🚨 `web/src/services/recommendationDebug.ts:487` - The required “compact winner/runner-up optimiser details” are contradicted by exporting every rejected entry in `topCandidates`; recommendationEngine.ts produces up to eight full candidates, each containing complete team, guide-matching, and multi-step skill-routing traces. Limit the serialized context to the winner and immediate runner-up, with only compact summaries or specifically relevant decision details.
- ⚠️ `web/src/services/recommendationEngine.ts:3751` - Every bounded-search selection eagerly constructs full guide and model-routing debug traces before sorting, although only the top eight are retained and the console function may never be called. This adds substantial allocation and main-thread fallback work across potentially hundreds of candidates. Evaluate candidates without tracing, then deterministically regenerate traces only for the winner and runner-up.

🔧 Fix: Bound formation diagnostics and defer finalist trace generation
2 issues (1 error, 1 warning) still open:
- 🚨 `web/src/services/recommendationDebug.ts:537` - The required “exactly why” context and “unplaced-item reasons” remain incorrect for a reachable bounded-search path. With more than 64 qualified groups, `capConservativeSelections` can prune every pair/trio containing a low-gain but evidence-qualified hero before final evaluation; this code only recomputes gate-qualified groups and then reports `eligible_groups_existed_but_lost_global_ranking`, falsely implying the hero reached final ranking. Export per-hero reachability/pruning from the authoritative selection search and distinguish proxy-beam exclusion from losing the final optimiser ranking.
- ⚠️ `web/src/services/recommendationEngine.ts:1155` - Non-finalist evaluations still construct guide-matching trace event objects even when `captureDebug` is false: each object is allocated before `record()` immediately discards it, and debug-only arrays and helper closures are also created for every evaluated selection. Guard event creation at the call sites or install the recorder/debug helpers only for the winner/runner-up regeneration.

🔧 Fix: Distinguish beam-pruned heroes and defer debug allocations
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd web && pnpm exec vitest run src/services/__tests__/recommendationDebug.test.ts src/services/__tests__/recommendationEngine.test.ts --testNamePattern='recommendation browser debug context|preserves current-pool order and records the tie-break for equal HS weights|captures the exact guide-match comparator and rejected candidates|traces augmenting reassignment when a later guide slot has one contested skill|captures bounded beam pruning and exact-guide reservation decisions|reports when every qualified group for a hero is pruned before final evaluation'`
- <code>`cd web &amp;&amp; pnpm exec playwright test tests/optionAnalysisLabels.spec.js tests/buildATeam.spec.js --grep=&#39;sanmouDebug exports not-ready and exact recommendation contexts|defaults to one complete evidence-qualified recommendation without mode controls&#39;` exercised the draft-page selector; the unmatched Team Builder selector was corrected in the next command.</code>
- `cd web && pnpm exec playwright test tests/buildATeam.spec.js --grep='seeds exactly one evidence-only editable three-team formation'`
- <code>`pnpm exec vite --host 127.0.0.1 --port 3000` with headless Chromium: invoked `sanmouDebug()` before and after draft computation, captured the exact returned JSON, and verified that invocation made no fetch, XHR, or beacon calls and did not modify a sentinel cookie or unrelated localStorage value.</code>
- <code>`pnpm exec vite --host 127.0.0.1 --port 3000` with headless Chromium: captured Team Builder ready and not-ready exports, changed Team 1&#39;s formation through the rendered UI, and confirmed the subsequent export reflected the user edit.</code>
- <code>`pnpm exec vite --host 127.0.0.1 --port 3000` with a 17-hero/28-skill browser fixture: captured selected scoring, optimizer details, evidence gates, and concrete unplaced hero/skill reasons from the actual Team Builder page.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
