### PR TITLE
fix(web): reduce recommendation engine scoring overhead

### DIFF
--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -1506,28 +1506,25 @@ function scoreGuideMatching(
       name,
       skills: skillsByHero.get(name) ?? [],
     }));
-    score += scoreTeam(
-      assigned,
-      m,
-      catalog.relationships,
-      true,
-      enabledFamilies
-    );
+    let teamScore = 0;
     for (const featureId of teamFeatureIds(
       assigned,
       catalog.relationships,
       true,
       enabledFamilies
     )) {
+      const weight = weightOf(m, featureId);
+      teamScore += weight;
       support += supportOf(m, featureId);
       if (
         VARIABLE_TEAM_SKILL_CONTEXT_FAMILIES.has(
           featureId.split('|', 1)[0]
         )
       ) {
-        contextContribution += weightOf(m, featureId);
+        contextContribution += weight;
       }
     }
+    score += teamScore;
   }
   return {
     score,
@@ -1619,6 +1616,7 @@ function maximumScoredKnownSlotMatching(
     };
   }
 
+  const completedStateCache = new Map<string, GuideMatchingState>();
   const completePartialState = (
     partialAssignments: Map<string, string>,
     usedSkills: Set<string>,
@@ -1640,11 +1638,16 @@ function maximumScoredKnownSlotMatching(
     if (compareGuideClaimPriority(claimedSlots, targetClaimPriority) !== 0) {
       return null;
     }
-    return {
+    const stableKey = guideMatchingStableKey(claimedSlots, assignments);
+    const cached = completedStateCache.get(stableKey);
+    if (cached) return cached;
+    const completed = {
       assignments,
       claimedSlots,
       ...scoreGuideMatching(teams, claimedSlots, assignments, m, catalog),
     };
+    completedStateCache.set(stableKey, completed);
+    return completed;
   };
 
   const initialCompletion = completePartialState(
@@ -2303,6 +2306,9 @@ function assignSkills(
 
   // Bounded local improvement: swap two assigned skills when it raises the
   // top-two-weighted objective (the two main teams first, third secondary).
+  // Keep the accepted objective instead of recomputing the unchanged pre-swap
+  // formation for every candidate; each trial then needs only one full score.
+  let currentAssignmentObjective = assignmentObjective();
   for (let pass = 0; pass < 4; pass++) {
     let improved = false;
     for (let a = 0; a < heroes.length; a++) {
@@ -2321,10 +2327,10 @@ function assignSkills(
             }
             // Never assign a hero its own signature skill via a swap.
             if (sb[j] === catalog.default_skill[ha] || sa[i] === catalog.default_skill[hb]) continue;
-            const before = assignmentObjective();
             [sa[i], sb[j]] = [sb[j], sa[i]];
             const after = assignmentObjective();
-            if (after > before + 1e-9) {
+            if (after > currentAssignmentObjective + 1e-9) {
+              currentAssignmentObjective = after;
               improved = true;
             } else {
               [sa[i], sb[j]] = [sb[j], sa[i]]; // revert


### PR DESCRIPTION
## Intent

Fix the red scheduled build from GitHub Actions run 32619440834. The web-battle import and generated-data rebuild succeeded, but three CPU-heavy recommendation-engine tests exceeded CI timing limits. Preserve recommendation behavior and bounded search/cardinality diagnostics; address the root performance overhead rather than weakening or removing assertions, and validate the complete web workspace before opening a PR.

## What Changed

- Score guide matchings from a single generated feature set and cache equivalent completed matching states.
- Reuse the accepted skill-assignment objective during swap search instead of rescoring the unchanged pre-swap formation for every candidate.

## Risk Assessment

✅ Low: The changes are narrowly scoped, preserve scoring and diagnostic behavior, and remove redundant computation through equivalent feature iteration, memoization, and objective reuse.

## Testing

After reproducing the three original failures from GitHub run 32619440834, the focused regressions completed within budget, the complete web unit/e2e/prerender/build surfaces succeeded after one transient e2e infrastructure retry, and a real browser rendered the realistic Team Builder result with bounded beam and cardinality diagnostics intact; static typechecking was left to the outer lint phase because this test phase forbids static analysis.

- Evidence: Rendered realistic round-10 Team Builder recommendation (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0Q3WMAG4HKQBTHNFDFJTQKB/round-10-team-builder.png</code>)
<details>
<summary>Evidence: Concise Team Builder result and bounded-search diagnostics</summary>

`The realistic 15-hero/28-skill browser flow reached ready state in 1917 ms, produced three ranked teams, retained 64 hero-search states at each bounded depth, used a 512-state guide beam, and reported maximum cardinality 9/9 with bounded event and scored-state counters.`

```text
{
  "route": "/team-builder",
  "realisticPool": {
    "heroCount": 15,
    "skillCount": 28
  },
  "status": "ready",
  "readyElapsedMs": 1917,
  "policy": "evidence-only-team-builder",
  "recommendedTeams": [
    {
      "heroes": [
        "曹操",
        "夏侯惇",
        "司马懿"
      ],
      "strength": 48.5,
      "assignedSkillCount": 6
    },
    {
      "heroes": [
        "陆逊",
        "周瑜",
        "孙权"
      ],
      "strength": 32.4,
      "assignedSkillCount": 4
    },
    {
      "heroes": [
        "马超",
        "刘备",
        "诸葛亮"
      ],
      "strength": 33.3,
      "assignedSkillCount": 6
    }
  ],
  "boundedHeroSearch": {
    "poolCount": 15,
    "poolCap": 15,
    "boundedHeroCount": 15,
    "candidateSelectionsEvaluated": 192,
    "depths": [
      {
        "depth": 1,
        "examined": 115,
        "retained": 64,
        "cap": 64
      },
      {
        "depth": 2,
        "examined": 2906,
        "retained": 64,
        "cap": 64
      },
      {
        "depth": 3,
        "examined": 1504,
        "retained": 64,
        "cap": 64
      }
    ]
  },
  "winner": {
    "rank": 1,
    "totalModelGain": 114.2,
    "heroesPlaced": 9,
    "completeTrios": 3,
    "heroSupport": 26698,
    "canonicalKey": "刘备|诸葛亮|马超||司马懿|夏侯惇|曹操||周瑜|孙权|陆逊"
  },
  "guideVariantSearch": {
    "beamCap": 512,
    "theoreticalCandidateCount": "15",
    "fullCartesianEvaluated": true,
    "examinedStateCount": 35,
    "retainedStateCount": 15,
    "prunedStateCount": 0,
    "fallbackReservationCount": 0
  },
  "cardinalityDiagnostics": {
    "slotCount": 9,
    "uniqueSkillCount": 9,
    "matchedSlotCount": 9,
    "eventCount": 9,
    "eventLimit": 24,
    "omittedEventCount": 0,
    "scoredSelection": {
      "beamCap": 512,
      "evaluatedStateCount": 10,
      "examinedStateCount": 20,
      "retainedStateCount": 1,
      "prunedStateCount": 10,
      "score": 8.432384
    }
  }
}
```
</details>
<details>
<summary>Evidence: Full public recommendation debug protocol output</summary>

```text
{
  "schema": "sanmou-recommendation-debug/v1",
  "page": "team-formation-suggestion",
  "model": {
    "model_type": "paired-logistic",
    "schema_version": 6,
    "catalog_version": "ed3db0590240",
    "relationship_version": "39e09a2900e9",
    "corpus_version": "36563473f49bd020",
    "total_battles": 7836,
    "minimum_support": {
      "H": 5,
      "S": 5,
      "HP": 8,
      "HS": 8,
      "SP": 8,
      "THS": 20,
      "TSP": 20,
      "HT": 50,
      "TS3": 50,
      "HC": 12,
      "B": 12
    },
    "selection_prior": {
      "count_unit": "known-season team appearances",
      "expected_count": "season-aware uniform share of draftable or observed transferred catalog items",
      "hero_slots_per_battle": 6,
      "hero_strength": 0.4,
      "log_ratio_clip": 2,
      "skill_slots_per_battle": 12,
      "skill_strength": 0.3,
      "smoothing": 20
    },
    "score_scale": "display points = final model weight × 10, rounded to one decimal",
    "score_meaning": "Atomic hero/skill weights combine paired battle outcomes with season-aware player-selection count; interactions remain outcome-only. This is not an opponent-specific win probability."
  },
  "input": {
    "season": 16,
    "heroes": [
      "刘备",
      "关羽",
      "张飞",
      "诸葛亮",
      "赵云",
      "马超",
      "曹操",
      "司马懿",
      "夏侯惇",
      "孙权",
      "周瑜",
      "陆逊",
      "吕布",
      "张辽",
      "貂蝉"
    ],
    "skills": [
      "乐不思蜀",
      "暗渡阴平",
      "恩威并行",
      "未雨绸缪",
      "诱敌深入",
      "风助火势",
      "瞋目横矛",
      "掠阵破军",
      "及锋而试",
      "调和阴阳",
      "蹈锋饮血",
      "践墨随敌",
      "机变无穷",
      "潜龙在渊",
      "御敌临前",
      "虎步连环",
      "神略制变",
      "惩前毖后",
      "万军辟易",
      "谋而后动",
      "黄天惑心",
      "断戈夺锋",
      "空城计",
      "步步为营",
      "智破千军",
      "挫锐折锋",
      "运智铺谋",
      "十面埋伏"
    ],
    "support_items": []
  },
  "status": "ready",
  "policy": {
    "name": "evidence-only-team-builder",
    "rules": [
      "Every placed hero must independently pass its H evidence gate.",
      "Every hero pair inside a selected pair/trio must independently pass its HP evidence gate.",
      "Every placed skill must independently pass both its S and assigned-hero HS evidence gates.",
      "Positive, zero, and negative supported weights remain eligible and affect ranking.",
      "A usable exact 3/3 guide core is ranked before fully assigned model gain.",
      "Guide data preserves qualified slots but never bypasses an evidence gate."
    ]
  },
  "optimizer_trace": {
    "policy": "evidence-only-team-builder",
    "heroPoolCount": 15,
    "skillPoolCount": 28,
    "heroPoolCap": 15,
    "boundedHeroCount": 15,
    "consideredHeroes": [
      "关羽",
      "刘备",
      "司马懿",
      "吕布",
      "周瑜",
      "夏侯惇",
      "孙权",
      "张辽",
      "张飞",
      "曹操",
      "诸葛亮",
      "貂蝉",
      "赵云",
      "陆逊",
      "马超"
    ],
    "excludedHeroes": [],
    "qualifiedHeroPairs": 51,
    "qualifiedHeroTrios": 64,
    "candidateSelectionsEvaluated": 192,
    "prioritizedExactGuideCoreCount": 0,
    "rankingOrder": [
      "more usable exact 3/3 guide cores",
      "higher fully assigned total model gain",
      "more exact championship teams",
      "higher exact guide ranking score",
      "more heroes placed",
      "more complete trios",
      "higher hero evidence support",
      "stable canonical key"
    ],
    "beamPruning": [
      {
        "depth": 1,
        "preCapCount": 115,
        "retainedCount": 64,
        "nominalCap": 64,
        "effectiveCap": 64,
        "proxyRankingOrder": [
          "more usable exact 3/3 guide cores",
          "higher unassigned hero model gain",
          "more heroes placed",
          "more complete trios",
          "higher hero evidence support",
          "lower stable canonical key by locale order"
        ],
        "nominalCutoff": {
          "exactGuideCount": 0,
          "heroGain": 0.563935,
          "heroesPlaced": 2,
          "completeTrios": 0,
          "heroSupport": 1696,
          "canonicalKey": "赵云|陆逊"
        },
        "retainedCutoff": {
          "exactGuideCount": 0,
          "heroGain": 0.563935,
          "heroesPlaced": 2,
          "completeTrios": 0,
          "heroSupport": 1696,
          "canonicalKey": "赵云|陆逊"
        },
        "exactGuideReservations": [],
        "retainedOnlyByReservationCount": 0
      },
      {
        "depth": 2,
        "preCapCount": 2906,
        "retainedCount": 64,
        "nominalCap": 64,
        "effectiveCap": 64,
        "proxyRankingOrder": [
          "more usable exact 3/3 guide cores",
          "higher unassigned hero model gain",
          "more heroes placed",
          "more complete trios",
          "higher hero evidence support",
          "lower stable canonical key by locale order"
        ],
        "nominalCutoff": {
          "exactGuideCount": 0,
          "heroGain": 2.770271,
          "heroesPlaced": 6,
          "completeTrios": 2,
          "heroSupport": 17746,
          "canonicalKey": "关羽|诸葛亮|马超||司马懿|夏侯惇|张辽"
        },
        "retainedCutoff": {
          "exactGuideCount": 0,
          "heroGain": 2.770271,
          "heroesPlaced": 6,
          "completeTrios": 2,
          "heroSupport": 17746,
          "canonicalKey": "关羽|诸葛亮|马超||司马懿|夏侯惇|张辽"
        },
        "exactGuideReservations": [],
        "retainedOnlyByReservationCount": 0
      },
      {
        "depth": 3,
        "preCapCount": 1504,
        "retainedCount": 64,
        "nominalCap": 64,
        "effectiveCap": 64,
        "proxyRankingOrder": [
          "more usable exact 3/3 guide cores",
          "higher unassigned hero model gain",
          "more heroes placed",
          "more complete trios",
          "higher hero evidence support",
          "lower stable canonical key by locale order"
        ],
        "nominalCutoff": {
          "exactGuideCount": 0,
          "heroGain": 4.262015,
          "heroesPlaced": 9,
          "completeTrios": 3,
          "heroSupport": 25687,
          "canonicalKey": "刘备|诸葛亮|赵云||司马懿|夏侯惇|曹操||张飞|貂蝉|马超"
        },
        "retainedCutoff": {
          "exactGuideCount": 0,
          "heroGain": 4.262015,
          "heroesPlaced": 9,
          "completeTrios": 3,
          "heroSupport": 25687,
          "canonicalKey": "刘备|诸葛亮|赵云||司马懿|夏侯惇|曹操||张飞|貂蝉|马超"
        },
        "exactGuideReservations": [],
        "retainedOnlyByReservationCount": 0
      }
    ],
    "heroSelectionReachability": [
      {
        "hero": "关羽",
        "qualifiedGroupCount": 32,
        "reachedFinalEvaluation": true,
        "depths": [
          {
            "depth": 1,
            "generatedContainingSelectionCount": 32,
            "retainedContainingSelectionCount": 14,
            "reservedContainingSelectionCount": 0,
            "entirelyProxyPruned": false
          },
          {
            "depth": 2,
            "generatedContainingSelectionCount": 1327,
            "retainedContainingSelectionCount": 22,
            "reservedContainingSelectionCount": 0,
            "entirelyProxyPruned": false
          },
          {
            "depth": 3,
            "generatedContainingSelectionCount": 863,
            "retainedContainingSelectionCount": 32,
            "reservedContainingSelectionCount": 0,
            "entirelyProxyPruned": false
          }
        ]
      },
      {
        "hero": "刘备",
        "qualifiedGroupCount": 21,
        "reachedFinalEvaluation": true,
        "depths": [
          {
            "depth": 1,
            "generatedContainingSelectionCount": 21,
            "retainedContainingSelectionCount": 13,
            "reservedContainingSelectionCount": 0,
       

... [369607 bytes truncated] ...

      "count_adjustment": 0.159362,
            "expected_count": 550.258538,
            "final_weight": 0.059783,
            "outcome_weight": -0.099579,
            "usage_ratio": 1.726461
          }
        },
        "evidence_qualified_routes": {
          "selected_heroes": [
            "司马懿",
            "诸葛亮",
            "陆逊"
          ],
          "unplaced_heroes": []
        },
        "reason": "routes_to_selected_heroes_lost_assignment_or_capacity_ranking"
      },
      {
        "name": "虎步连环",
        "support_item": false,
        "individual_gate": {
          "feature_id": "S|虎步连环",
          "meaning": "战法个体：虎步连环",
          "family": "S",
          "weight": -0.643378,
          "display_points": -6.4,
          "support": 93,
          "required_support": 5,
          "passed": true,
          "atomic_components": {
            "appearance_count": 94,
            "count_adjustment": -0.482967,
            "expected_count": 550.258538,
            "final_weight": -0.643378,
            "outcome_weight": -0.160411,
            "usage_ratio": 0.170829
          }
        },
        "evidence_qualified_routes": {
          "selected_heroes": [
            "马超"
          ],
          "unplaced_heroes": []
        },
        "reason": "routes_to_selected_heroes_lost_assignment_or_capacity_ranking"
      },
      {
        "name": "神略制变",
        "support_item": false,
        "individual_gate": {
          "feature_id": "S|神略制变",
          "meaning": "战法个体：神略制变",
          "family": "S",
          "weight": 0.094242,
          "display_points": 0.9,
          "support": 855,
          "required_support": 5,
          "passed": true,
          "atomic_components": {
            "appearance_count": 883,
            "count_adjustment": 0.121781,
            "expected_count": 581.715681,
            "final_weight": 0.094242,
            "outcome_weight": -0.02754,
            "usage_ratio": 1.517924
          }
        },
        "evidence_qualified_routes": {
          "selected_heroes": [
            "刘备",
            "司马懿",
            "曹操",
            "诸葛亮",
            "陆逊"
          ],
          "unplaced_heroes": []
        },
        "reason": "routes_to_selected_heroes_lost_assignment_or_capacity_ranking"
      },
      {
        "name": "万军辟易",
        "support_item": false,
        "individual_gate": {
          "feature_id": "S|万军辟易",
          "meaning": "战法个体：万军辟易",
          "family": "S",
          "weight": -0.408805,
          "display_points": -4.1,
          "support": 150,
          "required_support": 5,
          "passed": true,
          "atomic_components": {
            "appearance_count": 152,
            "count_adjustment": -0.375687,
            "expected_count": 581.715681,
            "final_weight": -0.408805,
            "outcome_weight": -0.033118,
            "usage_ratio": 0.261296
          }
        },
        "evidence_qualified_routes": {
          "selected_heroes": [
            "马超"
          ],
          "unplaced_heroes": [
            "吕布",
            "张辽"
          ]
        },
        "reason": "routes_to_selected_heroes_lost_assignment_or_capacity_ranking"
      },
      {
        "name": "断戈夺锋",
        "support_item": false,
        "individual_gate": {
          "feature_id": "S|断戈夺锋",
          "meaning": "战法个体：断戈夺锋",
          "family": "S",
          "weight": -0.286154,
          "display_points": -2.9,
          "support": 317,
          "required_support": 5,
          "passed": true,
          "atomic_components": {
            "appearance_count": 323,
            "count_adjustment": -0.180521,
            "expected_count": 606.07389,
            "final_weight": -0.286154,
            "outcome_weight": -0.105633,
            "usage_ratio": 0.532938
          }
        },
        "evidence_qualified_routes": {
          "selected_heroes": [],
          "unplaced_heroes": [
            "关羽",
            "张辽",
            "张飞"
          ]
        },
        "reason": "evidence_qualified_routes_exist_only_to_unplaced_heroes"
      },
      {
        "name": "空城计",
        "support_item": false,
        "individual_gate": {
          "feature_id": "S|空城计",
          "meaning": "战法个体：空城计",
          "family": "S",
          "weight": -0.103125,
          "display_points": -1,
          "support": 477,
          "required_support": 5,
          "passed": true,
          "atomic_components": {
            "appearance_count": 480,
            "count_adjustment": -0.067458,
            "expected_count": 606.07389,
            "final_weight": -0.103125,
            "outcome_weight": -0.035667,
            "usage_ratio": 0.791983
          }
        },
        "evidence_qualified_routes": {
          "selected_heroes": [
            "刘备",
            "曹操",
            "诸葛亮"
          ],
          "unplaced_heroes": [
            "貂蝉"
          ]
        },
        "reason": "routes_to_selected_heroes_lost_assignment_or_capacity_ranking"
      },
      {
        "name": "智破千军",
        "support_item": false,
        "individual_gate": {
          "feature_id": "S|智破千军",
          "meaning": "战法个体：智破千军",
          "family": "S",
          "weight": -0.341511,
          "display_points": -3.4,
          "support": 240,
          "required_support": 5,
          "passed": true,
          "atomic_components": {
            "appearance_count": 242,
            "count_adjustment": -0.261337,
            "expected_count": 606.07389,
            "final_weight": -0.341511,
            "outcome_weight": -0.080174,
            "usage_ratio": 0.399291
          }
        },
        "evidence_qualified_routes": {
          "selected_heroes": [
            "司马懿",
            "诸葛亮",
            "陆逊"
          ],
          "unplaced_heroes": []
        },
        "reason": "routes_to_selected_heroes_lost_assignment_or_capacity_ranking"
      }
    ]
  },
  "current_layout": {
    "matches_original_recommendation": true,
    "user_edited": false,
    "layout": [
      {
        "formation": "方圆阵",
        "heroes": [
          {
            "hero": "曹操",
            "row": "前排",
            "skills": [
              "挫锐折锋",
              "践墨随敌"
            ]
          },
          {
            "hero": "夏侯惇",
            "row": "前排",
            "skills": [
              "蹈锋饮血",
              "步步为营"
            ]
          },
          {
            "hero": "司马懿",
            "row": "前排",
            "skills": [
              "运智铺谋",
              "谋而后动"
            ]
          }
        ]
      },
      {
        "formation": "雁形阵",
        "heroes": [
          {
            "hero": "陆逊",
            "row": "前排",
            "skills": [
              "未雨绸缪",
              "黄天惑心"
            ]
          },
          {
            "hero": "周瑜",
            "row": "前排",
            "skills": [
              null,
              null
            ]
          },
          {
            "hero": "孙权",
            "row": "前排",
            "skills": [
              "风助火势",
              "御敌临前"
            ]
          }
        ]
      },
      {
        "formation": "偃月阵",
        "heroes": [
          {
            "hero": "马超",
            "row": "前排",
            "skills": [
              "十面埋伏",
              "及锋而试"
            ]
          },
          {
            "hero": "刘备",
            "row": "前排",
            "skills": [
              "瞋目横矛",
              "恩威并行"
            ]
          },
          {
            "hero": "诸葛亮",
            "row": "前排",
            "skills": [
              "机变无穷",
              "惩前毖后"
            ]
          }
        ]
      }
    ]
  }
}
```
</details>
<details>
<summary>Evidence: Focused timing and diagnostic regression transcript</summary>

Source: Focused timing and diagnostic regression transcript (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0Q3WMAG4HKQBTHNFDFJTQKB/targeted-recommendation-regressions.log</code>)

```text
The realistic 15/28 recommendation completed in 1377.8 ms; the conflict-aware fallback and feasible-beam-pruned diagnostic scenarios completed in 1841 ms and 1730 ms respectively.
```
</details>
<details>
<summary>Evidence: Original GitHub Actions failure excerpt</summary>

```text
update	UNKNOWN STEP	2026-08-23T05:07:03.4959238Z  ^[[31m❯^[[39m src/services/__tests__/recommendationEngine.test.ts ^[[2m(^[[22m^[[2m77 tests^[[22m^[[2m | ^[[22m^[[31m3 failed^[[39m^[[2m)^[[22m^[[33m 82839^[[2mms^[[22m^[[39m
update	UNKNOWN STEP	2026-08-23T05:07:03.5063553Z ^[[41m^[[1m FAIL ^[[22m^[[49m src/services/__tests__/recommendationEngine.test.ts^[[2m > ^[[22mrecommendTeams — global formation optimization^[[2m > ^[[22mrealistic 15-hero / 28-skill round-10 pool stays within the interactive budget
update	UNKNOWN STEP	2026-08-23T05:07:03.5075518Z ^[[41m^[[1m FAIL ^[[22m^[[49m src/services/__tests__/recommendationEngine.test.ts^[[2m > ^[[22mrecommendHybridTeams — evidence-only partial placement^[[2m > ^[[22mpreserves a conflict-aware cardinality fallback and reports beam-pruned scores as unknown
update	UNKNOWN STEP	2026-08-23T05:07:03.5077556Z ^[[31m^[[1mError^[[22m: Test timed out in 5000ms.
update	UNKNOWN STEP	2026-08-23T05:07:03.5084679Z ^[[41m^[[1m FAIL ^[[22m^[[49m src/services/__tests__/recommendationEngine.test.ts^[[2m > ^[[22mrecommendHybridTeams — evidence-only partial placement^[[2m > ^[[22mreports feasible alternatives pruned by the guide scoring beam
update	UNKNOWN STEP	2026-08-23T05:07:03.5085723Z ^[[31m^[[1mError^[[22m: Test timed out in 5000ms.
update	UNKNOWN STEP	2026-08-23T05:07:03.5090606Z ^[[2m      Tests ^[[22m ^[[1m^[[31m3 failed^[[39m^[[22m^[[2m | ^[[22m^[[1m^[[32m462 passed^[[39m^[[22m^[[90m (465)^[[39m
update	UNKNOWN STEP	2026-08-23T05:07:03.5135820Z ##[error]AssertionError: expected 6060.886072000001 to be less than 5000
update	UNKNOWN STEP	2026-08-23T05:07:03.5145892Z ##[error]Error: Test timed out in 5000ms.
update	UNKNOWN STEP	2026-08-23T05:07:03.5149327Z ##[error]Error: Test timed out in 5000ms.
```
</details>
- Evidence: Successful full web e2e and production-prerender rerun (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0Q3WMAG4HKQBTHNFDFJTQKB/web-e2e-retry.log</code>)
<details>
<summary>Evidence: Production build transcript</summary>

```text
$ node scripts/build.mjs
vite v8.1.4 building client environment for production...
[2Ktransforming...✓ 1008 modules transformed.
rendering chunks...
computing gzip size...
build/index.html                                   2.10 kB │ gzip:   1.02 kB
build/assets/teamFormation.worker-Bn9p2KEJ.js    954.63 kB
build/assets/dividerClasses-B_XG_Uci.js            0.30 kB │ gzip:   0.22 kB
build/assets/NotFound-Bl0fT3Eg.js                  0.45 kB │ gzip:   0.35 kB
build/assets/rolldown-runtime-Bh1tDfsg.js          0.56 kB │ gzip:   0.36 kB
build/assets/uploaderName-Bi30XoB9.js              0.61 kB │ gzip:   0.46 kB
build/assets/Close-PwoWf14z.js                     3.55 kB │ gzip:   1.47 kB
build/assets/Divider-CzfUvtR_.js                   3.75 kB │ gzip:   1.31 kB
build/assets/ExpandMore-nd_TA9z_.js                3.76 kB │ gzip:   1.54 kB
build/assets/web-vitals-EF2FPrUq.js                4.34 kB │ gzip:   1.70 kB
build/assets/Contributors-C6-v7-s2.js              5.08 kB │ gzip:   2.40 kB
build/assets/js.cookie-DjAdeYV9.js                 6.45 kB │ gzip:   2.69 kB
build/assets/TableRow-Bbkd_lNI.js                  6.57 kB │ gzip:   2.16 kB
build/assets/List-CeTunz3J.js                      7.54 kB │ gzip:   2.93 kB
build/assets/ToggleButtonGroup-CT2UW0hS.js        12.38 kB │ gzip:   3.69 kB
build/assets/YanwuGuide-BbQqJhzt.js               15.03 kB │ gzip:   5.24 kB
build/assets/Analytics-8H9Ns9vZ.js                22.50 kB │ gzip:   6.94 kB
build/assets/Contribute-C2LHlTdZ.js               27.35 kB │ gzip:  11.80 kB
build/assets/rankings-BYPXKuNL.js                 71.89 kB │ gzip:  22.58 kB
build/assets/Button-98-K7q0A.js                  112.07 kB │ gzip:  37.98 kB
build/assets/TeamBuilder-C8MzKvtm.js             140.34 kB │ gzip:  46.55 kB
build/assets/usePinyin-a-blJdu4.js               337.22 kB │ gzip: 159.20 kB
build/assets/index-CeS1Ff-3.js                   377.58 kB │ gzip: 120.85 kB
build/assets/data-Q0XWPryh.js                  1,003.80 kB │ gzip: 205.93 kB

✓ built in 190ms
[plugin builtin:vite-reporter] 
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
vite v8.1.4 building ssr environment for production...
[2Ktransforming...✓ 71 modules transformed.
rendering chunks...
computing gzip size...
.ssr-build/entry-server.mjs  1,533.72 kB │ gzip: 317.87 kB

✓ built in 47ms
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c0142db2ad754d9987cd4e5b44a22a157ee25a8e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`gh run view 32619440834 --log-failed` to confirm the baseline failure: the realistic formation benchmark exceeded 5 seconds and both guide-beam diagnostic tests timed out.</code>
- `cd web && pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t 'realistic 15-hero / 28-skill|preserves a conflict-aware cardinality fallback|reports feasible alternatives pruned' --reporter=verbose`
- `cd web && pnpm test`
- <code>`cd web &amp;&amp; pnpm test:e2e` — the first attempt encountered a transient browser `ERR_NETWORK_IO_SUSPENDED` and related timeout cascade; a complete rerun passed, including production prerender checks.</code>
- <code>`cd web &amp;&amp; pnpm exec playwright test tests/battleContribution.spec.js:298 tests/buildATeam.spec.js:318 tests/buildATeam.spec.js:476 tests/optionAnalysisLabels.spec.js:103 tests/playerPreferenceFlow.spec.js:98 tests/supportHeroSkills.spec.js:200 --workers=1` to verify every initially affected e2e scenario independently.</code>
- <code>`cd web &amp;&amp; pnpm start --host 127.0.0.1` plus a headless Chromium check that seeded the realistic 15-hero/28-skill pool, opened `/team-builder`, waited for recommendation completion, captured the rendered formation, and exported `window.sanmouDebug()` diagnostics.</code>
- `cd web && pnpm build`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
