### PR TITLE
fix(web): reduce formation rescoring during skill swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,13 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
 - `make web` — start the Vite dev server (port 3000).
 - Web unit tests: `cd web && pnpm test` (Vitest). Type-check: `cd web && pnpm typecheck`
   (Go-native `tsc`). E2e: `cd web && pnpm test:e2e` (Playwright). Build: `cd web && pnpm build`.
+  `recommendationEngine.test.ts` deliberately keeps the realistic 15-hero /
+  28-skill formation search below 5,000 ms. Scheduled data workflows run that
+  benchmark on shared CI CPU against the just-rebuilt recommendation artifact,
+  so keep substantial headroom: optimize production hot paths, keep synthetic
+  fixtures bounded, and avoid multiplying full formation searches when a
+  focused fixture proves the behavior. Do not raise or remove the limit merely
+  to hide CPU-heavy code or tests.
 - Local agent: `cd agent && pnpm start`. Token-free checks:
   `pnpm typecheck && pnpm test && pnpm build`. Explicit live model check:
   `pnpm smoke`. Explicit combined LangGraph hero + formation + skill check:

--- a/README.md
+++ b/README.md
@@ -521,12 +521,12 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
 - Web unit tests: `cd web && pnpm test` (Vitest). Type-check: `cd web && pnpm typecheck`
   (Go-native `tsc`). E2e: `cd web && pnpm test:e2e` (Playwright). Build: `cd web && pnpm build`.
   `recommendationEngine.test.ts` deliberately keeps the realistic 15-hero /
-  28-skill formation search below 5,000 ms. Scheduled data workflows run that
-  benchmark on shared CI CPU against the just-rebuilt recommendation artifact,
-  so keep substantial headroom: optimize production hot paths, keep synthetic
-  fixtures bounded, and avoid multiplying full formation searches when a
-  focused fixture proves the behavior. Do not raise or remove the limit merely
-  to hide CPU-heavy code or tests.
+  28-skill formation search below 5,000 ms. The scheduled web-battle workflow
+  runs that benchmark on shared CI CPU against the just-rebuilt recommendation
+  artifact, so keep substantial headroom: optimize production hot paths, keep
+  synthetic fixtures bounded, and avoid multiplying full formation searches
+  when a focused fixture proves the behavior. Do not raise or remove the limit
+  merely to hide CPU-heavy code or tests.
 - Local agent: `cd agent && pnpm start`. Token-free checks:
   `pnpm typecheck && pnpm test && pnpm build`. Explicit live model check:
   `pnpm smoke`. Explicit combined LangGraph hero + formation + skill check:

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -2312,7 +2312,7 @@ function assignSkills(
   // Bounded local improvement: swap two assigned skills when it raises the
   // top-two-weighted objective (the two main teams first, third secondary).
   // Keep accepted team scores and recompute only the one or two teams touched
-  // by each trial; the third team's unchanged score is reused.
+  // by each trial; all untouched team scores are reused.
   let currentTeamScores = trios.map((_, index) => scoreAssignedTeam(index));
   let currentAssignmentObjective = assignmentObjective(currentTeamScores);
   for (let pass = 0; pass < 4; pass++) {

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -2289,26 +2289,32 @@ function assignSkills(
   // possible, then the third), so the assignment step never routes skills away
   // from the best two teams merely to improve the third. Which heroes team up
   // (and hence camp structure) is fixed by the partition.
-  const assignmentObjective = (): number => {
-    const scores = trios
-      .map((trio) =>
-        scoreTeam(
-          trio.map((name) => ({ name, skills: assign.get(name) ?? [] })),
-          m,
-          catalog.relationships,
-          true,
-          ASSIGNMENT_PROXY_FAMILIES
-        )
-      )
-      .sort((a, b) => b - a);
+  const teamIndexByHero = new Map<string, number>();
+  trios.forEach((trio, teamIndex) => {
+    for (const hero of trio) teamIndexByHero.set(hero, teamIndex);
+  });
+  const scoreAssignedTeam = (teamIndex: number): number =>
+    scoreTeam(
+      trios[teamIndex].map((name) => ({
+        name,
+        skills: assign.get(name) ?? [],
+      })),
+      m,
+      catalog.relationships,
+      true,
+      ASSIGNMENT_PROXY_FAMILIES
+    );
+  const assignmentObjective = (teamScores: number[]): number => {
+    const scores = [...teamScores].sort((a, b) => b - a);
     return scores[0] + scores[1] + 0.25 * scores[2];
   };
 
   // Bounded local improvement: swap two assigned skills when it raises the
   // top-two-weighted objective (the two main teams first, third secondary).
-  // Keep the accepted objective instead of recomputing the unchanged pre-swap
-  // formation for every candidate; each trial then needs only one full score.
-  let currentAssignmentObjective = assignmentObjective();
+  // Keep accepted team scores and recompute only the one or two teams touched
+  // by each trial; the third team's unchanged score is reused.
+  let currentTeamScores = trios.map((_, index) => scoreAssignedTeam(index));
+  let currentAssignmentObjective = assignmentObjective(currentTeamScores);
   for (let pass = 0; pass < 4; pass++) {
     let improved = false;
     for (let a = 0; a < heroes.length; a++) {
@@ -2317,6 +2323,8 @@ function assignSkills(
         const hb = heroes[b];
         const sa = assign.get(ha)!;
         const sb = assign.get(hb)!;
+        const firstTeamIndex = teamIndexByHero.get(ha)!;
+        const secondTeamIndex = teamIndexByHero.get(hb)!;
         for (let i = 0; i < sa.length; i++) {
           for (let j = 0; j < sb.length; j++) {
             if (
@@ -2328,8 +2336,14 @@ function assignSkills(
             // Never assign a hero its own signature skill via a swap.
             if (sb[j] === catalog.default_skill[ha] || sa[i] === catalog.default_skill[hb]) continue;
             [sa[i], sb[j]] = [sb[j], sa[i]];
-            const after = assignmentObjective();
+            const trialTeamScores = [...currentTeamScores];
+            trialTeamScores[firstTeamIndex] = scoreAssignedTeam(firstTeamIndex);
+            if (secondTeamIndex !== firstTeamIndex) {
+              trialTeamScores[secondTeamIndex] = scoreAssignedTeam(secondTeamIndex);
+            }
+            const after = assignmentObjective(trialTeamScores);
             if (after > currentAssignmentObjective + 1e-9) {
+              currentTeamScores = trialTeamScores;
               currentAssignmentObjective = after;
               improved = true;
             } else {


### PR DESCRIPTION
## Intent

Fix the follow-up failure in GitHub Actions run 32635723666 after PR 104 merged. The scheduled web-battle workflow tests a just-rebuilt recommendation artifact and its realistic 15-hero/28-skill benchmark still exceeded the fixed 5,000 ms budget by 7 ms on shared CI CPU. Preserve recommendation output, bounded search, and the 5-second assertion; create material headroom by rescoring only teams affected by each candidate skill swap. Also update the root README so future AI agents know the benchmark runs against regenerated data on constrained CI, keep test fixtures bounded, avoid unnecessary full formation searches, and do not mask CPU-heavy code by raising the timeout.

## What Changed

- Cache assigned-team scores during bounded skill-swap optimization and rescore only the one or two teams affected by each candidate swap.
- Document the regenerated-artifact formation benchmark, its shared-CI constraints, and guidance for maintaining headroom without raising the 5-second limit.

## Risk Assessment

✅ Low: The change is a localized, mathematically equivalent score-cache optimization that rescans only swap-affected teams while preserving bounded search, recommendation behavior, and the existing 5-second benchmark.

## Testing

After correcting the dependency setup directory, I regenerated the 7,836-battle artifact byte-for-byte, exercised focused routing and realistic 15-hero/28-skill benchmarks, and compared base with target through the executable recommendation interface: output and bounds were identical while runtime fell from 1436.3 ms to 976.9 ms, leaving 4023.1 ms below the unchanged limit; transient caches and dependencies were removed afterward.

<details>
<summary>Evidence: Base-versus-target performance and behavior comparison</summary>

`Output preserved: true; bounded search preserved: true; 287 partitions within the 1,920 cap; runtime 1436.3 ms → 976.9 ms (32.0% faster); target headroom below 5,000 ms: 4023.1 ms.`

```text
{
  "artifact_corpus_version": "36563473f49bd020",
  "realistic_input": {
    "heroes": 15,
    "skills": 28
  },
  "output_preserved": true,
  "recommendation_sha256": "807a61b222a76052222c39a00b544b41a973a904065b529005d010195f618df2",
  "bounded_search_preserved": true,
  "bounded_search": {
    "partition_count": 287,
    "partition_cap": 1920,
    "covered_all_input_heroes": true,
    "deterministic": true
  },
  "all_target_options_legal": true,
  "five_second_assertion_preserved": true,
  "pre_fix_elapsed_ms": 1436.3,
  "optimized_elapsed_ms": 976.9,
  "saved_ms": 459.4,
  "speedup_percent": 32.0,
  "optimized_headroom_below_5000_ms": 4023.1
}
```
</details>
<details>
<summary>Evidence: Focused benchmark transcript against the regenerated artifact</summary>

```text

 RUN  v4.1.10 /Users/lma2/.no-mistakes/worktrees/cddaca7d92a1/01M0Q5K56372EYNWT1XRRED5ZP/web

stdout | src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > realistic 15-hero / 28-skill round-10 pool stays within the interactive budget
recommendTeams 15 heroes / 28 skills: 1011.6 ms

 ↓ src/services/__tests__/recommendationEngine.test.ts > bounded guide-variant traversal > bounds each Cartesian expansion incrementally and deterministically
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHeroSet — marginal roster-strength ranking > recommends the set with the greatest marginal improvement over the pool
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHeroSet — marginal roster-strength ranking > defers exact-team-only context for offered sets
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHeroSet — marginal roster-strength ranking > does not require an opponent argument (relative strength only)
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHeroSet — marginal roster-strength ranking > produces deterministic output across calls
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHeroSet — marginal roster-strength ranking > reports evidence only for marginal features, not the existing pool
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHeroSet — marginal roster-strength ranking > surfaces negative combo evidence separately from atomic tradeoffs
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendSkillSet — best hero-routing > routes a skill to the current hero maximising its hero-skill weight
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendSkillSet — best hero-routing > preserves current-pool order and records the tie-break for equal HS weights
 ↓ src/services/__tests__/recommendationEngine.test.ts > currentRosterScore — current pool display score > hero-only pool: sums hero presence + hero-pair weights (display units)
 ↓ src/services/__tests__/recommendationEngine.test.ts > currentRosterScore — current pool display score > owned skills add standalone S plus best HS routing onto a current hero
 ↓ src/services/__tests__/recommendationEngine.test.ts > currentRosterScore — current pool display score > includes support hero + support skills when passed in the pool
 ↓ src/services/__tests__/recommendationEngine.test.ts > currentRosterScore — current pool display score > is pure and deterministic across calls
 ↓ src/services/__tests__/recommendationEngine.test.ts > currentRosterScore — current pool display score > empty pool scores zero
 ↓ src/services/__tests__/recommendationEngine.test.ts > currentRosterScore — current pool display score > option analysis no longer carries current_score / projected_score
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendSingleHero / recommendTwoSkills — support picks > single-hero result exposes finalScore + details fields
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendSingleHero / recommendTwoSkills — support picks > two-skills returns exactly two skills chosen as a joint pair
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendSingleHero / recommendTwoSkills — support picks > empty pools fall back gracefully
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTwoSkills — joint pair selection with same-hero synergy > a strong same-hero skill-pair synergy pulls a pair together that a per-skill ranking would split
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTwoSkills — joint pair selection with same-hero synergy > without a same-hero synergy the highest joint presence pair wins
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTwoSkills — joint pair selection with same-hero synergy > is deterministic
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > scores and labels context only inside each concrete formation team
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > returns incomplete for pools smaller than 9 heroes / 18 skills
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > is incomplete when skills contain duplicates that leave fewer than 18 unique
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > assigns exactly 9 unique heroes and 18 unique skills, 2 per hero, no signature skill
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > splits 9 heroes into three disjoint 3-hero teams with unique 18 skills
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > hero-skill and skill-pair affinity influences the skill assignment
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > positive SP potential keeps an individually weak decisive pair in the 28→18 shortlist
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > skill routing strengthens the top two teams before spending value on the third
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > hero-pair affinity changes which heroes team up (selection follows the model)
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > exposes at most three options, option one is the recommended winner
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > options use distinct canonical hero partitions in deterministic order
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > all options derive from the already-evaluated capped partition set (no extra enumeration)
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > ranks by the two strongest teams (top-two sum), third team secondary
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > within the tolerance band prefers same-camp teams
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > camp preference never overrides a real strength gap larger than the band
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > considers the full 15-hero pool before the bounded partition prune
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > fully evaluates a hero whose decisive HS value is invisible to hero-only pruning
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > deterministically caps out-of-contract 16+ hero pools before enumeration
 ✓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > realistic 15-hero / 28-skill round-10 pool stays within the interactive budget 1075ms
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > presentation rankings do not affect recommendation scoring
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > bounds the fully-evaluated partition set and keeps a deterministic strength/camp mix
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > tolerates missing and partial camp metadata
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > surfaces only positive, grouped evidence (no deductions) per team
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendTeams — global formation optimization > does not surface a positive contribution that displays as 加分 +0.0
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > preserves canonical slots for a confident two-hero guide core
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > captures the exact guide-match comparator and rejected candidates
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > reserves qualified guide skills for a partial core before a stronger model pair
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > does not reserve a partial-guide skill that fails S or HS support
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > an absent guide hero neither appears nor reserves an otherwise qualified owned skill
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > gives an exact guide core priority over a partial core for a shared skill
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > traces augmenting reassignment when a later guide slot has one contested skill
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > shows all three canonical slots when the complete guide trio is confident
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > places positive, zero, and negative features at the fitted support floors
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > uses negative fitted weights for ranking without blocking a supported guide pair
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > leaves a hero pair below the fitted support floor out even when its weight is large
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > requires both S and HS support and uses model gain among guide alternatives
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > scores equal-priority contested claims before stable slot IDs
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > selects guide variants jointly before matched-hero priority
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > reports the actual globally scored guide variant ranking
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > preserves a conflict-aware cardinality fallback and reports beam-pruned scores as unknown
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > reports feasible alternatives pruned by the guide scoring beam
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > ranks all rejected alternatives canonically before debug truncation
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > guide matching chooses the higher complete team score over higher S+HS
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > prioritizes a usable exact guide core ahead of a stronger model-only trio
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > captures bounded beam pruning and exact-guide reservation decisions
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > reports when every qualified group for a hero is pruned before final evaluation
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > ranks total formation gain ahead of the number of complete trios
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > keeps the current supported exact 孟获/祝融/木鹿大王 guide core together
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > real model-only fallback never places a relationship below the evidence gate
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > searches qualified trios beyond the former 320-candidate cutoff
 ↓ src/services/__tests__/recommendationEngine.test.ts > recommendHybridTeams — evidence-only partial placement > cooperative fallback returns the same deterministic result
 ↓ src/services/__tests__/recommendationEngine.test.ts > integration with the real generated artifact > artifact has the expected schema/shape
 ↓ src/services/__tests__/recommendationEngine.test.ts > integration with the real generated artifact > contextual families do not become standalone analytics strength
 ↓ src/services/__tests__/recommendationEngine.test.ts > integration with the real generated artifact > getAnalytics returns rankings + model quality
 ↓ src/services/__tests__/recommendationEngine.test.ts > integration with the real generated artifact > getAnalytics ranks heroes and skills by 强度加成 (strength) descending
 ↓ src/services/__tests__/recommendationEngine.test.ts > integration with the real generated artifact > recommendHeroSet on the real artifact ranks all three offered sets

 Test Files  1 passed (1)
      Tests  1 passed | 76 skipped (77)
   Start at  21:23:44
   Duration  1.97s (transform 196ms, setup 57ms, import 242ms, tests 1.08s, environment 479ms)
```
</details>
<details>
<summary>Evidence: Optimized target recommendation result with complete teams, skills, strengths, search bounds, and timing</summary>

```text
{
  "scenario": "optimized-target-after-base",
  "artifact": {
    "corpus_version": "36563473f49bd020",
    "total_battles": 7836,
    "model_features": 10454
  },
  "input": {
    "heroes": 15,
    "skills": 28
  },
  "bounded_search": {
    "partition_count": 287,
    "partition_cap": 1920,
    "covered_all_input_heroes": true,
    "deterministic": true
  },
  "recommendation": {
    "incomplete": false,
    "option_count": 3,
    "all_options_legal": true,
    "total_assigned_hero_slots": 27,
    "total_assigned_skill_slots": 54,
    "sha256": "807a61b222a76052222c39a00b544b41a973a904065b529005d010195f618df2",
    "options": [
      {
        "teams": [
          {
            "strength": 46.5,
            "heroes": [
              {
                "name": "司马懿",
                "skills": [
                  "未雨绸缪",
                  "潜龙在渊"
                ]
              },
              {
                "name": "曹操",
                "skills": [
                  "御敌临前",
                  "调和阴阳"
                ]
              },
              {
                "name": "夏侯惇",
                "skills": [
                  "挫锐折锋",
                  "步步为营"
                ]
              }
            ]
          },
          {
            "strength": 39.3,
            "heroes": [
              {
                "name": "陆逊",
                "skills": [
                  "惩前毖后",
                  "黄天惑心"
                ]
              },
              {
                "name": "貂蝉",
                "skills": [
                  "践墨随敌",
                  "蹈锋饮血"
                ]
              },
              {
                "name": "孙权",
                "skills": [
                  "谋而后动",
                  "风助火势"
                ]
              }
            ]
          },
          {
            "strength": 29.9,
            "heroes": [
              {
                "name": "诸葛亮",
                "skills": [
                  "机变无穷",
                  "运智铺谋"
                ]
              },
              {
                "name": "马超",
                "skills": [
                  "十面埋伏",
                  "及锋而试"
                ]
              },
              {
                "name": "刘备",
                "skills": [
                  "恩威并行",
                  "瞋目横矛"
                ]
              }
            ]
          }
        ]
      },
      {
        "teams": [
          {
            "strength": 47,
            "heroes": [
              {
                "name": "司马懿",
                "skills": [
                  "惩前毖后",
                  "未雨绸缪"
                ]
              },
              {
                "name": "曹操",
                "skills": [
                  "调和阴阳",
                  "运智铺谋"
                ]
              },
              {
                "name": "夏侯惇",
                "skills": [
                  "挫锐折锋",
                  "步步为营"
                ]
              }
            ]
          },
          {
            "strength": 39.5,
            "heroes": [
              {
                "name": "陆逊",
                "skills": [
                  "御敌临前",
                  "黄天惑心"
                ]
              },
              {
                "name": "貂蝉",
                "skills": [
                  "践墨随敌",
                  "蹈锋饮血"
                ]
              },
              {
                "name": "孙权",
                "skills": [
                  "谋而后动",
                  "风助火势"
                ]
              }
            ]
          },
          {
            "strength": 24.1,
            "heroes": [
              {
                "name": "马超",
                "skills": [
                  "及锋而试",
                  "神略制变"
                ]
              },
              {
                "name": "张飞",
                "skills": [
                  "潜龙在渊",
                  "瞋目横矛"
                ]
              },
              {
                "name": "关羽",
                "skills": [
                  "十面埋伏",
                  "机变无穷"
                ]
              }
            ]
          }
        ]
      },
      {
        "teams": [
          {
            "strength": 48,
            "heroes": [
              {
                "name": "司马懿",
                "skills": [
                  "惩前毖后",
                  "未雨绸缪"
                ]
              },
              {
                "name": "曹操",
                "skills": [
                  "调和阴阳",
                  "谋而后动"
                ]
              },
              {
                "name": "夏侯惇",
                "skills": [
                  "挫锐折锋",
                  "步步为营"
                ]
              }
            ]
          },
          {
            "strength": 39.9,
            "heroes": [
              {
                "name": "陆逊",
                "skills": [
                  "御敌临前",
                  "黄天惑心"
                ]
              },
              {
                "name": "貂蝉",
                "skills": [
                  "践墨随敌",
                  "蹈锋饮血"
                ]
              },
              {
                "name": "孙权",
                "skills": [
                  "运智铺谋",
                  "风助火势"
                ]
              }
            ]
          },
          {
            "strength": 26,
            "heroes": [
              {
                "name": "马超",
                "skills": [
                  "十面埋伏",
                  "及锋而试"
                ]
              },
              {
                "name": "刘备",
                "skills": [
                  "恩威并行",
                  "瞋目横矛"
                ]
              },
              {
                "name": "张飞",
                "skills": [
                  "机变无穷",
                  "潜龙在渊"
                ]
              }
            ]
          }
        ]
      }
    ]
  },
  "elapsed_ms": 976.9,
  "under_5000_ms": true
}
```
</details>
<details>
<summary>Evidence: Pre-fix recommendation result used for output-equivalence comparison</summary>

```text
{
  "scenario": "pre-fix-base",
  "artifact": {
    "corpus_version": "36563473f49bd020",
    "total_battles": 7836,
    "model_features": 10454
  },
  "input": {
    "heroes": 15,
    "skills": 28
  },
  "bounded_search": {
    "partition_count": 287,
    "partition_cap": 1920,
    "covered_all_input_heroes": true,
    "deterministic": true
  },
  "recommendation": {
    "incomplete": false,
    "option_count": 3,
    "all_options_legal": true,
    "total_assigned_hero_slots": 27,
    "total_assigned_skill_slots": 54,
    "sha256": "807a61b222a76052222c39a00b544b41a973a904065b529005d010195f618df2",
    "options": [
      {
        "teams": [
          {
            "strength": 46.5,
            "heroes": [
              {
                "name": "司马懿",
                "skills": [
                  "未雨绸缪",
                  "潜龙在渊"
                ]
              },
              {
                "name": "曹操",
                "skills": [
                  "御敌临前",
                  "调和阴阳"
                ]
              },
              {
                "name": "夏侯惇",
                "skills": [
                  "挫锐折锋",
                  "步步为营"
                ]
              }
            ]
          },
          {
            "strength": 39.3,
            "heroes": [
              {
                "name": "陆逊",
                "skills": [
                  "惩前毖后",
                  "黄天惑心"
                ]
              },
              {
                "name": "貂蝉",
                "skills": [
                  "践墨随敌",
                  "蹈锋饮血"
                ]
              },
              {
                "name": "孙权",
                "skills": [
                  "谋而后动",
                  "风助火势"
                ]
              }
            ]
          },
          {
            "strength": 29.9,
            "heroes": [
              {
                "name": "诸葛亮",
                "skills": [
                  "机变无穷",
                  "运智铺谋"
                ]
              },
              {
                "name": "马超",
                "skills": [
                  "十面埋伏",
                  "及锋而试"
                ]
              },
              {
                "name": "刘备",
                "skills": [
                  "恩威并行",
                  "瞋目横矛"
                ]
              }
            ]
          }
        ]
      },
      {
        "teams": [
          {
            "strength": 47,
            "heroes": [
              {
                "name": "司马懿",
                "skills": [
                  "惩前毖后",
                  "未雨绸缪"
                ]
              },
              {
                "name": "曹操",
                "skills": [
                  "调和阴阳",
                  "运智铺谋"
                ]
              },
              {
                "name": "夏侯惇",
                "skills": [
                  "挫锐折锋",
                  "步步为营"
                ]
              }
            ]
          },
          {
            "strength": 39.5,
            "heroes": [
              {
                "name": "陆逊",
                "skills": [
                  "御敌临前",
                  "黄天惑心"
                ]
              },
              {
                "name": "貂蝉",
                "skills": [
                  "践墨随敌",
                  "蹈锋饮血"
                ]
              },
              {
                "name": "孙权",
                "skills": [
                  "谋而后动",
                  "风助火势"
                ]
              }
            ]
          },
          {
            "strength": 24.1,
            "heroes": [
              {
                "name": "马超",
                "skills": [
                  "及锋而试",
                  "神略制变"
                ]
              },
              {
                "name": "张飞",
                "skills": [
                  "潜龙在渊",
                  "瞋目横矛"
                ]
              },
              {
                "name": "关羽",
                "skills": [
                  "十面埋伏",
                  "机变无穷"
                ]
              }
            ]
          }
        ]
      },
      {
        "teams": [
          {
            "strength": 48,
            "heroes": [
              {
                "name": "司马懿",
                "skills": [
                  "惩前毖后",
                  "未雨绸缪"
                ]
              },
              {
                "name": "曹操",
                "skills": [
                  "调和阴阳",
                  "谋而后动"
                ]
              },
              {
                "name": "夏侯惇",
                "skills": [
                  "挫锐折锋",
                  "步步为营"
                ]
              }
            ]
          },
          {
            "strength": 39.9,
            "heroes": [
              {
                "name": "陆逊",
                "skills": [
                  "御敌临前",
                  "黄天惑心"
                ]
              },
              {
                "name": "貂蝉",
                "skills": [
                  "践墨随敌",
                  "蹈锋饮血"
                ]
              },
              {
                "name": "孙权",
                "skills": [
                  "运智铺谋",
                  "风助火势"
                ]
              }
            ]
          },
          {
            "strength": 26,
            "heroes": [
              {
                "name": "马超",
                "skills": [
                  "十面埋伏",
                  "及锋而试"
                ]
              },
              {
                "name": "刘备",
                "skills": [
                  "恩威并行",
                  "瞋目横矛"
                ]
              },
              {
                "name": "张飞",
                "skills": [
                  "机变无穷",
                  "潜龙在渊"
                ]
              }
            ]
          }
        ]
      }
    ]
  },
  "elapsed_ms": 1436.3,
  "under_5000_ms": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5a48d98c18a252116cfc6bd154e307214cbf77dc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; pnpm install --frozen-lockfile` (rerun from the correct workspace after the initial root-level setup invocation found no package manifest)</code>
- `make build-recommendation`
- <code>`git diff --exit-code -- web/src/recommendation_data.json` to confirm the regenerated artifact was byte-identical</code>
- `cd web && pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t 'realistic 15-hero / 28-skill round-10 pool stays within the interactive budget' --reporter=verbose`
- `cd web && pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t 'skill routing strengthens the top two teams before spending value on the third' --reporter=verbose`
- <code>`FORMATION_SCENARIO=pre-fix-base node .../formation-e2e-evidence.mjs` with `recommendationEngine.ts` temporarily loaded from base commit `1567c939`, then restored</code>
- <code>`FORMATION_SCENARIO=optimized-target-after-base node .../formation-e2e-evidence.mjs` against target commit `a7969a5a`</code>
- `Compared the executable base and target results by recommendation SHA-256, bounded partition metadata, legality, elapsed time, and five-second headroom`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
