### PR TITLE
fix(web): avoid duplicate guide search scoring

### DIFF
--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -1446,12 +1446,17 @@ const VARIABLE_TEAM_SKILL_CONTEXT_FAMILIES = new Set([
   F_TEAM_SKILL_TRIO,
 ]);
 
-interface GuideMatchingScore {
+interface GuideMatchingScoreMetrics {
   score: number;
   contextContribution: number;
   support: number;
+}
+
+interface GuideMatchingScore extends GuideMatchingScoreMetrics {
   stableKey: string;
 }
+
+type GuideMatchingScoreCache = Map<string, GuideMatchingScoreMetrics>;
 
 interface GuideAlternativeEvaluation {
   feasibleMatching: boolean;
@@ -1489,7 +1494,8 @@ function scoreGuideMatching(
   claimedSlots: KnownSkillSlot[],
   assignments: Map<string, string>,
   m: PairedModel,
-  catalog: RecommendationCatalog
+  catalog: RecommendationCatalog,
+  scoreCache?: GuideMatchingScoreCache
 ): GuideMatchingScore {
   const skillsByHero = new Map<string, string[]>();
   for (const slot of claimedSlots) {
@@ -1497,6 +1503,18 @@ function scoreGuideMatching(
     if (!skill) continue;
     skillsByHero.set(slot.hero, [...(skillsByHero.get(slot.hero) ?? []), skill]);
   }
+  const stableKey = guideMatchingStableKey(claimedSlots, assignments);
+  // Guide IDs remain provenance and stable tie-breaks, but distinct guide
+  // variants can produce the same concrete ordered hero/skill assignment.
+  // Reuse only its numeric metrics and rebuild the identity-specific key.
+  const semanticKey = JSON.stringify(
+    teams.map((heroes) =>
+      heroes.map((name) => [name, skillsByHero.get(name) ?? []])
+    )
+  );
+  const cached = scoreCache?.get(semanticKey);
+  if (cached) return { ...cached, stableKey };
+
   const enabledFamilies = new Set(m.enabled_families);
   let score = 0;
   let contextContribution = 0;
@@ -1526,12 +1544,9 @@ function scoreGuideMatching(
     }
     score += teamScore;
   }
-  return {
-    score,
-    contextContribution,
-    support,
-    stableKey: guideMatchingStableKey(claimedSlots, assignments),
-  };
+  const metrics = { score, contextContribution, support };
+  scoreCache?.set(semanticKey, metrics);
+  return { ...metrics, stableKey };
 }
 
 function compareGuideMatchingStates(
@@ -1584,7 +1599,8 @@ function maximumScoredKnownSlotMatching(
   teams: string[][],
   m: PairedModel,
   catalog: RecommendationCatalog,
-  captureDebug = false
+  captureDebug = false,
+  scoreCache?: GuideMatchingScoreCache
 ): ScoredKnownSlotMatchingResult {
   const normalizedSlots = slots
     .map((slot) => ({
@@ -1644,7 +1660,14 @@ function maximumScoredKnownSlotMatching(
     const completed = {
       assignments,
       claimedSlots,
-      ...scoreGuideMatching(teams, claimedSlots, assignments, m, catalog),
+      ...scoreGuideMatching(
+        teams,
+        claimedSlots,
+        assignments,
+        m,
+        catalog,
+        scoreCache
+      ),
     };
     completedStateCache.set(stableKey, completed);
     return completed;
@@ -1737,7 +1760,8 @@ function maximumScoredKnownSlotMatching(
       claimedSlots,
       baseline.assignments,
       m,
-      catalog
+      catalog,
+      scoreCache
     );
     return {
       ...baseline,
@@ -4237,7 +4261,8 @@ function buildConservativeGuideVariantCandidate(
 function scoreConservativeGuideVariantCandidate(
   candidate: ConservativeGuideVariantCandidate,
   m: PairedModel,
-  catalog: RecommendationCatalog
+  catalog: RecommendationCatalog,
+  scoreCache: GuideMatchingScoreCache
 ): ScoredConservativeGuideVariant {
   return {
     candidate,
@@ -4245,7 +4270,9 @@ function scoreConservativeGuideVariantCandidate(
       candidate.slots,
       candidate.teamGroups.map(({ group }) => group.heroes),
       m,
-      catalog
+      catalog,
+      false,
+      scoreCache
     ),
   };
 }
@@ -4285,17 +4312,26 @@ function selectConservativeGuideVariants(
       1n
     )
     .toString();
-  const scoreGroups = (selected: ConservativeTeamGroup[]) =>
-    scoreConservativeGuideVariantCandidate(
-      buildConservativeGuideVariantCandidate(
-        selected,
-        skillPool,
-        m,
-        catalog
-      ),
+  const scoreCache: GuideMatchingScoreCache = new Map();
+  const candidateCache = new Map<string, ScoredConservativeGuideVariant>();
+  const scoreGroups = (selected: ConservativeTeamGroup[]) => {
+    const candidate = buildConservativeGuideVariantCandidate(
+      selected,
+      skillPool,
       m,
       catalog
     );
+    const cached = candidateCache.get(candidate.key);
+    if (cached) return cached;
+    const scored = scoreConservativeGuideVariantCandidate(
+      candidate,
+      m,
+      catalog,
+      scoreCache
+    );
+    candidateCache.set(candidate.key, scored);
+    return scored;
+  };
   let fallback = scoreGroups(
     teamGroups.map((group, index) => ({
       ...group,
@@ -4394,7 +4430,8 @@ function selectConservativeGuideVariants(
     winner.candidate.teamGroups.map(({ group }) => group.heroes),
     m,
     catalog,
-    captureDebug
+    captureDebug,
+    scoreCache
   );
   if (!captureDebug) {
     return {


### PR DESCRIPTION
## Intent

Fix GitHub Actions run 32636813794 without raising timeouts or weakening bounded guide-search assertions. The realistic 15-hero/28-skill benchmark now passes, but the 514-guide-variant fallback regression still exceeded Vitest's 5-second default on shared CI CPU because identity-distinct guide records repeatedly recompute the same concrete ordered hero/skill score. Cache only semantic numeric guide-assignment metrics and exact candidate evaluations within one search, while preserving every guide ID, provenance, stable tie-break, 512-state beam cap, conflict-aware fallback reservation, debug counts, and recommendation output.

## What Changed
- Cache numeric score, context, and support metrics for semantically equivalent ordered hero/skill assignments within each guide search while preserving identity-specific stable keys.
- Reuse exact scored guide-variant candidates across fallback optimization and bounded beam expansion to eliminate repeated matching work.

## Risk Assessment

✅ Low: The per-search caches are scoped correctly, reuse only semantic numeric metrics or exact identity-bearing candidates, and preserve scoring, provenance, tie-breaks, beam diagnostics, and fallback behavior.

## Testing

After correcting the dependency-install working directory, I ran the default-timeout 514-guide regression, focused guide-ranking and fallback tests, and the real 15-hero/28-skill benchmark successfully. A direct executable API check completed in 1368.6 ms and 1251 ms on repeat, remained deterministic, selected `variant-512` with its provenance, retained the 512-state cap, reserved the conflict-aware fallback, and preserved examined/pruned debug counts; its public formation and captured guide-debug output matched the base revision exactly. The base timeout itself did not reproduce on this faster host, although the comparable base API runs took 1926.4 ms and 1882.4 ms. This is a pure client scoring-engine change with no rendered UI surface, so JSON API evidence was captured instead of a screenshot.

<details>
<summary>Evidence: Target 514-guide-variant recommendation and debug output</summary>

```text
{
  "revision": "target-14e587c1",
  "elapsedMs": 1368.6,
  "repeatedElapsedMs": 1251,
  "deterministic": true,
  "output": {
    "incomplete": false,
    "selectedFormation": {
      "teams": [
        {
          "heroes": [
            {
              "name": "q0",
              "skills": [
                "qf2"
              ],
              "skillScore": 0,
              "slotIndex": 0,
              "skillSlots": [
                "qf2",
                null
              ]
            },
            {
              "name": "q1",
              "skills": [],
              "skillScore": 0,
              "slotIndex": 1,
              "skillSlots": [
                null,
                null
              ]
            },
            {
              "name": "q2",
              "skills": [],
              "skillScore": 0,
              "slotIndex": 2,
              "skillSlots": [
                null,
                null
              ]
            }
          ],
          "strength": 0,
          "evidence": {
            "heroSynergy": [],
            "heroSkill": [],
            "skillSynergy": []
          },
          "formation": "formation-variant-512",
          "knownTeam": {
            "id": "variant-512",
            "ranking": "S",
            "sources": [
              "strong"
            ],
            "matchedHeroSlots": 3,
            "totalHeroSlots": 3,
            "matchedSkillSlots": 1,
            "totalSkillSlots": 6
          }
        },
        {
          "heroes": [
            {
              "name": "q3",
              "skills": [],
              "skillScore": 0,
              "slotIndex": 0,
              "skillSlots": [
                null,
                null
              ]
            },
            {
              "name": "q4",
              "skills": [],
              "skillScore": 0,
              "slotIndex": 1,
              "skillSlots": [
                null,
                null
              ]
            },
            {
              "name": "q5",
              "skills": [],
              "skillScore": 0,
              "slotIndex": 2,
              "skillSlots": [
                null,
                null
              ]
            }
          ],
          "strength": 0,
          "evidence": {
            "heroSynergy": [],
            "heroSkill": [],
            "skillSynergy": []
          }
        },
        {
          "heroes": [
            {
              "name": "q6",
              "skills": [
                "shared-guide-skill",
                "qf0"
              ],
              "skillScore": 10,
              "slotIndex": 0,
              "skillSlots": [
                "shared-guide-skill",
                "qf0"
              ]
            },
            {
              "name": "q7",
              "skills": [],
              "skillScore": 0,
              "slotIndex": 1,
              "skillSlots": [
                null,
                null
              ]
            },
            {
              "name": "q8",
              "skills": [],
              "skillScore": 0,
              "slotIndex": 2,
              "skillSlots": [
                null,
                null
              ]
            }
          ],
          "strength": 10,
          "evidence": {
            "heroSynergy": [],
            "heroSkill": [
              {
                "label": "q6 · shared-guide-skill",
                "gain": 10,
                "support": 16
              }
            ],
            "skillSynergy": []
          },
          "formation": "formation-third-high",
          "knownTeam": {
            "id": "third-high",
            "ranking": "S",
            "sources": [
              "strong"
            ],
            "matchedHeroSlots": 3,
            "totalHeroSlots": 3,
            "matchedSkillSlots": 1,
            "totalSkillSlots": 6
          }
        }
      ]
    },
    "selectedVariantDecision": {
      "rankingOrder": [
        "higher globally attainable guide-slot count across all selected teams",
        "higher matched hero count",
        "higher evidence-qualified skill-slot count",
        "championship source before non-championship source",
        "higher guide ranking score (S=3, A=2, other=1)",
        "higher canonical enabled per-team score for scored feasible variants",
        "higher support across the scored matching",
        "lower stable joint variant key by locale order",
        "beam-pruned variant scores remain unknown"
      ],
      "selected": {
        "guideId": "variant-512",
        "matchedHeroes": [
          "q0",
          "q1",
          "q2"
        ],
        "matchedHeroCount": 3,
        "qualifiedSkillSlotCount": 1,
        "championship": false,
        "ranking": "S",
        "rankingScore": 3,
        "stableId": "variant-512",
        "evaluationStatus": "selected",
        "globalMatchedSlotCount": 2,
        "decisionScore": 1,
        "contextContribution": 0,
        "support": 286,
        "jointVariantKey": "q0|q1|q2=variant-512|q3|q4|q5=|q6|q7|q8=third-high"
      },
      "rejectedCandidateLimit": 4,
      "rejected": [
        {
          "guideId": "variant-000",
          "matchedHeroes": [
            "q0",
            "q1",
            "q2"
          ],
          "matchedHeroCount": 3,
          "qualifiedSkillSlotCount": 1,
          "championship": false,
          "ranking": "S",
          "rankingScore": 3,
          "stableId": "variant-000",
          "evaluationStatus": "feasible",
          "globalMatchedSlotCount": 2,
          "decisionScore": 0,
          "contextContribution": 0,
          "support": 286,
          "jointVariantKey": "q0|q1|q2=variant-000|q3|q4|q5=|q6|q7|q8=third-low"
        },
        {
          "guideId": "variant-510",
          "matchedHeroes": [
            "q0",
            "q1",
            "q2"
          ],
          "matchedHeroCount": 3,
          "qualifiedSkillSlotCount": 1,
          "championship": false,
          "ranking": "S",
          "rankingScore": 3,
          "stableId": "variant-510",
          "evaluationStatus": "feasible",
          "globalMatchedSlotCount": 2,
          "decisionScore": 0,
          "contextContribution": 0,
          "support": 286,
          "jointVariantKey": "q0|q1|q2=variant-510|q3|q4|q5=|q6|q7|q8=third-low"
        },
        {
          "guideId": "variant-513",
          "matchedHeroes": [
            "q0",
            "q1",
            "q2"
          ],
          "matchedHeroCount": 3,
          "qualifiedSkillSlotCount": 1,
          "championship": false,
          "ranking": "S",
          "rankingScore": 3,
          "stableId": "variant-513",
          "evaluationStatus": "beam-pruned-unknown",
          "globalMatchedSlotCount": 2,
          "decisionScore": null,
          "contextContribution": null,
          "support": null,
          "jointVariantKey": "q0|q1|q2=variant-513|q3|q4|q5=|q6|q7|q8=third-high"
        },
        {
          "guideId": "variant-511",
          "matchedHeroes": [
            "q0",
            "q1",
            "q2"
          ],
          "matchedHeroCount": 3,
          "qualifiedSkillSlotCount": 1,
          "championship": false,
          "ranking": "S",
          "rankingScore": 3,
          "stableId": "variant-511",
          "evaluationStatus": "priority-rejected",
          "globalMatchedSlotCount": 1,
          "decisionScore": null,
          "contextContribution": null,
          "support": null,
          "jointVariantKey": "q0|q1|q2=variant-511|q3|q4|q5=|q6|q7|q8=third-high"
        }
      ],
      "omittedRejectedCount": 509
    },
    "thirdHighDecision": {
      "rankingOrder": [
        "higher globally attainable guide-slot count across all selected teams",
        "higher matched hero count",
        "higher evidence-qualified skill-slot count",
        "championship source before non-championship source",
        "higher guide ranking score (S=3, A=2, other=1)",
        "higher canonical enabled per-team score for scored feasible variants",
        "higher support across the scored matching",
        "lower stable joint variant key by locale order",
        "beam-pruned variant scores remain unknown"
      ],
      "selected": {
        "guideId": "third-high",
        "matchedHeroes": [
          "q6",
          "q7",
          "q8"
        ],
        "matchedHeroCount": 3,
        "qualifiedSkillSlotCount": 1,
        "championship": false,
        "ranking": "S",
        "rankingScore": 3,
        "stableId": "third-high",
        "evaluationStatus": "selected",
        "globalMatchedSlotCount": 2,
        "decisionScore": 1,
        "contextContribution": 0,
        "support": 286,
        "jointVariantKey": "q0|q1|q2=variant-512|q3|q4|q5=|q6|q7|q8=third-high"
      },
      "rejectedCandidateLimit": 4,
      "rejected": [
        {
          "guideId": "third-low",
          "matchedHeroes": [
            "q6",
            "q7",
            "q8"
          ],
          "matchedHeroCount": 3,
          "qualifiedSkillSlotCount": 1,
          "championship": false,
          "ranking": "S",
          "rankingScore": 3,
          "stableId": "third-low",
          "evaluationStatus": "feasible",
          "globalMatchedSlotCount": 2,
          "decisionScore": 0,
          "contextContribution": 0,
          "support": 286,
          "jointVariantKey": "q0|q1|q2=variant-000|q3|q4|q5=|q6|q7|q8=third-low"
        }
      ],
      "omittedRejectedCount": 0
    },
    "variantSelection": {
      "objective": "maximize global guide matching cardinality; preserve guide priority and provenance; score retained variants canonically per team; then support and stable key",
      "beamCap": 512,
      "theoreticalCandidateCount": "1028",
      "fullCartesianEvaluated": false,
      "candidateCount": 1024,
      "examinedStateCount": 2050,
      "retainedStateCount": 512,
      "maxRetainedStateCount": 512,
      "prunedStateCount": 514,
      "priorityEligibleCandidateCount": 512,
      "scoredCandidateCount": 512,
      "beamPrunedCandidateCount": "516",
      "fallbackReservationCount": 1,
      "depths": [
        {
          "depth": 1,
          "inputStateCount": 1,
          "optionCount": 514,
          "examinedStateCount": 514,
          "retainedStateCount": 512,
          "prunedStateCount": 2,
          "fallbackReserved": true
        },
        {
          "depth": 2,
          "inputStateCount": 512,
          "optionCount": 1,
          "examinedStateCount": 512,
          "retainedStateCount": 512,
          "prunedStateCount": 0,
          "fallbackReserved": false
        },
        {
          "depth": 3,
          "inputStateCount": 512,
          "optionCount": 2,
          "examinedStateCount": 1024,
          "retainedStateCount": 512,
          "prunedStateCount": 512,
          "fallbackReserved": false
        }
      ],
      "selectedKey": "q0|q1|q2=variant-512|q3|q4|q5=|q6|q7|q8=third-high"
    },
    "maximumCardinality": {
      "objective": "maximize guide matching cardinality; preserve substantive priority without stable IDs; maximize canonical enabled per-team score; then support and stable key",
      "slotCount": 2,
      "uniqueSkillCount": 2,
      "matchedSlotCount": 2,
      "scoredSelection": {
        "objective": "sum canonical enabled feature scores over each actual team independently",
        "beamCap": 512,
        "evaluatedStateCount": 3,
        "examinedStateCount": 5,
        "retainedStateCount": 1,
        "prunedStateCount": 2,
        "maxRetainedStateCount": 1,
        "score": 1,
        "contextContribution": 0,
        "support": 286,
        "stableKey": "conservative|0|variant-512|q0|0=qf2|conservative|2|third-high|q6|0=shared-guide-skill",
        "enabledFamilies": [
          "H",
          "S",
          "HP",
          "HS",
          "SP"
        ]
      },
      "finalAssignments": [
        {
          "slotKey": "conservative|0|variant-512|q0|0",
          "skill": "qf2"
        },
        {
          "slotKey": "conservative|2|third-high|q6|0",
          "skill": "shared-guide-skill"
        }
      ]
    }
  }
}
```
</details>
<details>
<summary>Evidence: Base-to-target executable behavior and timing comparison</summary>

<code>Executable public formation and captured guide-debug output identical: true&#10;Baseline elapsed: 1926.4 ms (repeat 1882.4 ms)&#10;Target elapsed: 1368.6 ms (repeat 1251 ms)&#10;Selected guide: variant-512&#10;Selected provenance: {&#34;id&#34;:&#34;variant-512&#34;,&#34;ranking&#34;:&#34;S&#34;,&#34;sources&#34;:[&#34;strong&#34;],&#34;matchedHeroSlots&#34;:3,&#34;totalHeroSlots&#34;:3,&#34;matchedSkillSlots&#34;:1,&#34;totalSkillSlots&#34;:6}&#10;Matched guide slots: 2&#10;Beam retained/max/cap: 512/512/512&#10;Fallback reservations: 1&#10;Debug examined/pruned: 2050/514</code>

```text
Executable public formation and captured guide-debug output identical: true
Baseline elapsed: 1926.4 ms (repeat 1882.4 ms)
Target elapsed: 1368.6 ms (repeat 1251 ms)
Selected guide: variant-512
Selected provenance: {"id":"variant-512","ranking":"S","sources":["strong"],"matchedHeroSlots":3,"totalHeroSlots":3,"matchedSkillSlots":1,"totalSkillSlots":6}
Matched guide slots: 2
Beam retained/max/cap: 512/512/512
Fallback reservations: 1
Debug examined/pruned: 2050/514
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"14e587c1dc631743a16d37f19fdf58ded75ef2ab","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install --frozen-lockfile` initially ran from the repository root and failed because the package manifest is under `web/`; setup was corrected with `cd web &amp;&amp; pnpm install --frozen-lockfile`.</code>
- <code>`cd web &amp;&amp; /usr/bin/time -p pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t &#34;preserves a conflict-aware cardinality fallback and reports beam-pruned scores as unknown&#34; --reporter=verbose` exercised the 514-variant regression under Vitest&#39;s default timeout.</code>
- <code>Temporarily restored `web/src/services/recommendationEngine.ts` from base `2b696add`, ran the same default-timeout regression, and restored target `14e587c1`; the baseline completed locally in 2.18 seconds, so the shared-CI timeout did not reproduce on this host.</code>
- <code>`cd web &amp;&amp; pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t &#34;(scores equal-priority contested claims before stable slot IDs|selects guide variants jointly before matched-hero priority|reports the actual globally scored guide variant ranking|preserves a conflict-aware cardinality fallback and reports beam-pruned scores as unknown|guide matching chooses the higher complete team score over higher S\\+HS)&#34;` checked score ordering, stable identity handling, fallback reservation, beam diagnostics, and complete-team scoring.</code>
- <code>`cd web &amp;&amp; pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t &#34;realistic 15-hero / 28-skill round-10 pool stays within the interactive budget&#34;` exercised the real generated model and its explicit five-second performance assertion.</code>
- <code>Executed `recommendHybridTeams` directly through Vite&#39;s runtime interface with 514 identity-distinct guide variants, repeated it for determinism, captured the public formation and guide-debug response, then ran the same fixture against the base revision and compared outputs.</code>
- <code>Removed the testing-only `web/node_modules/` directory and restored the target source exactly; no worktree changes remain.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
