### PR TITLE
feat(data): add evaluation-only MECH signal stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test:
 
 # Tests for the offline data builders (data/). Fast (no PaddleOCR).
 test-data:
-	uv run pytest data/test_yanwu_corpus.py data/test_manage_mech_catalog.py data/test_build_recommendation_data.py data/test_recommendation_evaluation.py data/test_import_web_battles.py data/test_import_yanwu_workbook.py data/test_build_telemetry_data.py data/test_telemetry_incremental_state.py data/test_telemetry_observation_report.py data/test_telemetry_retention.py -v
+	uv run pytest data/test_yanwu_corpus.py data/test_manage_mech_catalog.py data/test_mech_evaluation.py data/test_build_recommendation_data.py data/test_recommendation_evaluation.py data/test_import_web_battles.py data/test_import_yanwu_workbook.py data/test_build_telemetry_data.py data/test_telemetry_incremental_state.py data/test_telemetry_observation_report.py data/test_telemetry_retention.py -v
 
 test-telemetry:
 	uv run pytest data/test_build_telemetry_data.py data/test_telemetry_incremental_state.py data/test_telemetry_observation_report.py data/test_telemetry_retention.py -v

--- a/README.md
+++ b/README.md
@@ -207,8 +207,13 @@ Training/development groups tune logistic regularization `C`, family-specific
 support floors, the `SP` within-hero skill-pair ablation, and the hero/skill
 selection-count prior strengths, smoothing, and log-ratio bound. A bounded
 staged ablation then compares (1) the pre-context production baseline, (2)
-`THS`/`TSP`, (3) `HC`/`B`, (4) `HT`, and (5) `TS3`. Optional high-order stages
-must improve both development log loss and Brier score; TS3 also requires every
+`THS`/`TSP`, (3) `HC`/`B`, (4) evaluation-only reviewed mechanics (`M`), (5)
+`HT`, and (6) `TS3`. The M stage matches exact `provides` →
+`benefits_from`/`requires`/`consumes` mechanic IDs inside one concrete team,
+compares explicit-only and all-reviewed certainty, requires training-only battle
+support plus at least two distinct ordered provider/consumer skill-name pairs,
+and applies bounded post-fit shrinkage. Optional M/high-order stages must
+improve both development log loss and Brier score; TS3 also requires every
 constituent `TSP` pair to clear the selected team-context floor. Season-recency
 weighting and season-trend variants were removed rather than replaced with
 another temporal assumption. Selected and current production configurations are
@@ -236,7 +241,11 @@ for review: they are never fed back into the builder, and no production weight
 or support-threshold change happens automatically. The reviewed PR-1 decision
 is documented in [`data/evaluation/TEAM_CONTEXT_EVALUATION.md`](data/evaluation/TEAM_CONTEXT_EVALUATION.md):
 production enables `THS`, `TSP`, `HC`, `B`, and support-50 `HT`; `TS3` is
-implemented but disabled because its development Brier score regressed.
+implemented but disabled because its development Brier score regressed. The
+reviewed PR-A mechanics decision is documented in
+[`data/evaluation/MECH_EVALUATION.md`](data/evaluation/MECH_EVALUATION.md): M
+cleared its development calibration gate but remains evaluation-only pending a
+separate reviewed production PR.
 
 ## Reviewed MECH catalog
 

--- a/README.md
+++ b/README.md
@@ -207,14 +207,11 @@ Training/development groups tune logistic regularization `C`, family-specific
 support floors, the `SP` within-hero skill-pair ablation, and the hero/skill
 selection-count prior strengths, smoothing, and log-ratio bound. A bounded
 staged ablation then compares (1) the pre-context production baseline, (2)
-`THS`/`TSP`, (3) `HC`/`B`, (4) evaluation-only reviewed mechanics (`M`), (5)
-`HT`, and (6) `TS3`. The M stage matches exact `provides` →
-`benefits_from`/`requires`/`consumes` mechanic IDs inside one concrete team,
-compares explicit-only and all-reviewed certainty, requires training-only battle
-support plus at least two distinct ordered provider/consumer skill-name pairs,
-and applies bounded post-fit shrinkage. Optional M/high-order stages must
-improve both development log loss and Brier score; TS3 also requires every
-constituent `TSP` pair to clear the selected team-context floor. Season-recency
+`THS`/`TSP`, (3) `HC`/`B`, (4) [evaluation-only reviewed mechanics
+(`M`)](data/evaluation/MECH_EVALUATION.md#feature-contract), (5) `HT`, and (6)
+`TS3`. Optional M/high-order stages must improve both development log loss and
+Brier score; TS3 also requires every constituent `TSP` pair to clear the
+selected team-context floor. Season-recency
 weighting and season-trend variants were removed rather than replaced with
 another temporal assumption. Selected and current production configurations are
 refit on training plus development, then scored once on the locked test. The
@@ -276,9 +273,9 @@ on duplicate JSON object keys, stale mechanics or skill hashes, incomplete or
 mismatched skill coverage, and unknown, duplicate, or invalid relationships.
 Structurally valid unresolved items remain valid and are reported for human
 review; they alone do not make `status` nonzero. The checked-in catalog has no
-unresolved items. The recommendation builder and web app do not read this
-catalog. Maintaining it therefore does not change recommendation schemas,
-weights, or scoring, and does not regenerate
+unresolved items. The production recommendation builder and web app do not read
+this catalog. Maintaining it therefore does not change production recommendation schemas,
+weights, or browser scoring, and does not regenerate
 `web/src/recommendation_data.json`.
 
 ## Community battle uploads
@@ -404,11 +401,12 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
   stable-hash backtest. Manual and web observations share a fail-closed
   maximum-two semantic duplicate policy.
 - `data/evaluate_recommendation_model.py`,
-  `data/recommendation_evaluation.py`, and
+  `data/recommendation_evaluation.py`, `data/mech_evaluation.py`, and
   `data/evaluation/locked-pre-yanwu-test.json` — the deterministic full
-  grouped-holdout experiment harness, its checked-in locked-test identities,
-  and shared stable-hash split, session grouping, near-duplicate, metric, and
-  cluster-bootstrap helpers. Its ignored JSON report is evaluation-only.
+  grouped-holdout experiment harness, strict evaluation-only MECH catalog
+  adapter, checked-in locked-test identities, and shared stable-hash split,
+  session grouping, near-duplicate, metric, and cluster-bootstrap helpers. Its
+  ignored JSON report is evaluation-only.
 - `data/import_web_battles.py` — validates a bounded
   `web_battle_submissions` D1 export, advances the aggregate checkpoint over
   accepted and rejected rows, writes accepted reports plus contributor/time/

--- a/data/build_recommendation_data.py
+++ b/data/build_recommendation_data.py
@@ -351,6 +351,7 @@ class MechanicSkillInstance:
     carrier: str
     skill_name: str
     origin: str
+    slot_index: int
 
 
 @dataclass(frozen=True, order=True)
@@ -363,6 +364,8 @@ class MechanicWitness:
     consumer_carrier: str
     provider_origin: str
     consumer_origin: str
+    provider_slot_index: int
+    consumer_slot_index: int
 
 
 def validate_battle(
@@ -978,11 +981,26 @@ def active_mechanic_skill_instances(
             raise ValueError(
                 f"MECH extraction requires a canonical default skill for {carrier!r}"
             )
-        skill_names = [(signature, "signature"), *(
-            (skill, "equipped")
-            for skill in _non_default_skills(hero_data, default_skill)
-        )]
-        for skill_name, origin in skill_names:
+        skills = hero_data.get("skills")
+        if (
+            not isinstance(skills, list)
+            or len(skills) != SKILLS_PER_HERO
+            or any(not isinstance(skill, str) or not skill for skill in skills)
+        ):
+            raise ValueError(
+                f"MECH extraction requires validated skill slots for {carrier!r}"
+            )
+        skill_slots = [
+            (signature, "signature", DEFAULT_SKILL_INDEX),
+            *(
+                (skill, "equipped", slot_index)
+                for slot_index, skill in enumerate(
+                    skills[DEFAULT_SKILL_INDEX + 1:],
+                    start=DEFAULT_SKILL_INDEX + 1,
+                )
+            ),
+        ]
+        for skill_name, origin, slot_index in skill_slots:
             if skill_name not in mechanics.skill_relationships:
                 raise ValueError(
                     f"MECH contract is missing active skill {skill_name!r}"
@@ -992,6 +1010,7 @@ def active_mechanic_skill_instances(
                     carrier=carrier,
                     skill_name=skill_name,
                     origin=origin,
+                    slot_index=slot_index,
                 )
             )
     return tuple(instances)
@@ -1061,7 +1080,13 @@ def mechanic_feature_witnesses(
             if not provider_targets:
                 continue
             for consumer in instances:
-                if consumer == provider:
+                if (
+                    consumer.carrier,
+                    consumer.slot_index,
+                ) == (
+                    provider.carrier,
+                    provider.slot_index,
+                ):
                     continue
                 for consumer_relation in mechanics.skill_relationships[
                     consumer.skill_name
@@ -1088,6 +1113,8 @@ def mechanic_feature_witnesses(
                         consumer_carrier=consumer.carrier,
                         provider_origin=provider.origin,
                         consumer_origin=consumer.origin,
+                        provider_slot_index=provider.slot_index,
+                        consumer_slot_index=consumer.slot_index,
                     )
                     if ENEMY_TEAM_TARGET in overlap:
                         witnesses[

--- a/data/build_recommendation_data.py
+++ b/data/build_recommendation_data.py
@@ -57,7 +57,7 @@ from itertools import combinations
 from datetime import datetime, timezone
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Sequence
 
 import numpy as np
 from sklearn.linear_model import LogisticRegression
@@ -82,6 +82,7 @@ try:
         load_normalized_corpus,
         normalized_cache_path,
     )
+    from mech_evaluation import MechanicsContract
 except ModuleNotFoundError:  # Support ``import data.build_recommendation_data``.
     from .recommendation_evaluation import (
         EVALUATION_PROTOCOL_VERSION,
@@ -102,6 +103,7 @@ except ModuleNotFoundError:  # Support ``import data.build_recommendation_data``
         load_normalized_corpus,
         normalized_cache_path,
     )
+    from .mech_evaluation import MechanicsContract
 
 # --------------------------------------------------------------------------- #
 # Constants / schema metadata
@@ -136,18 +138,21 @@ F_HERO_TRIO = "HT"       # exact unordered concrete hero trio
 F_TEAM_SKILL_TRIO = "TS3"  # unordered tactic triple in one concrete team
 F_HERO_CAMP = "HC"       # exclusive same-camp composition (2 or 3)
 F_BOND = "B"             # activated validated named bond
+F_MECHANIC = "M"         # evaluation-only reviewed mechanic interaction
 
 ATOMIC_FAMILIES = frozenset((F_HERO, F_SKILL))
 PAIR_FAMILIES = frozenset((F_HERO_PAIR, F_HERO_SKILL, F_SKILL_PAIR))
 TEAM_CONTEXT_FAMILIES = frozenset((F_TEAM_HERO_SKILL, F_TEAM_SKILL_PAIR))
 RELATIONSHIP_FAMILIES = frozenset((F_HERO_CAMP, F_BOND))
 HIGH_ORDER_FAMILIES = frozenset((F_HERO_TRIO, F_TEAM_SKILL_TRIO))
+MECHANIC_FAMILIES = frozenset((F_MECHANIC,))
 ALL_FEATURE_FAMILIES = frozenset(
     ATOMIC_FAMILIES
     | PAIR_FAMILIES
     | TEAM_CONTEXT_FAMILIES
     | RELATIONSHIP_FAMILIES
     | HIGH_ORDER_FAMILIES
+    | MECHANIC_FAMILIES
 )
 
 # Family-specific support floors. Production choices are explicit and reviewed;
@@ -158,8 +163,16 @@ MIN_SUPPORT_PAIR = 8
 MIN_SUPPORT_TEAM_CONTEXT = 20
 MIN_SUPPORT_RELATIONSHIP = 12
 MIN_SUPPORT_HIGH_ORDER = 50
+# Evaluation-only defaults. M is never production-enabled, and these values are
+# not serialized into the runtime artifact.
+MIN_SUPPORT_MECHANIC = 12
+MIN_MECHANIC_PAIR_DIVERSITY = 2
 TEAM_CONTEXT_SHRINKAGE = 0.5
 HIGH_ORDER_SHRINKAGE = 0.35
+MECHANIC_SHRINKAGE = 0.5
+MECH_CERTAINTY_MODES = frozenset(("explicit_only", "all_reviewed"))
+MECH_CONSUMER_RELATIONS = frozenset(("benefits_from", "requires", "consumes"))
+ENEMY_TEAM_TARGET = "ENEMY_TEAM"
 
 # The identity-only context families enabled by the reviewed development
 # ablation. HT cleared the conservative residual-calibration gate at support 50;
@@ -329,6 +342,27 @@ class _CatalogContext:
     names: CatalogNames
     seasons: _CatalogSeasons
     relationships: CatalogRelationships
+
+
+@dataclass(frozen=True)
+class MechanicSkillInstance:
+    """One canonical signature or equipped tactic on one concrete team."""
+
+    carrier: str
+    skill_name: str
+    origin: str
+
+
+@dataclass(frozen=True, order=True)
+class MechanicWitness:
+    """One provider/consumer witness for a binary M feature."""
+
+    provider_skill: str
+    consumer_skill: str
+    provider_carrier: str
+    consumer_carrier: str
+    provider_origin: str
+    consumer_origin: str
 
 
 def validate_battle(
@@ -907,19 +941,191 @@ def bond_id(name: str) -> str:
     return f"{F_BOND}|{name}"
 
 
+def mechanic_id(
+    mechanic: str,
+    consumer_relation: str,
+    target_side: str,
+) -> str:
+    if consumer_relation not in MECH_CONSUMER_RELATIONS:
+        raise ValueError(f"unsupported MECH consumer relation {consumer_relation!r}")
+    if target_side not in ("enemy", "friendly"):
+        raise ValueError(f"unsupported MECH target side {target_side!r}")
+    return f"{F_MECHANIC}|{mechanic}|{consumer_relation}|{target_side}"
+
+
+def active_mechanic_skill_instances(
+    team: list[dict[str, Any]],
+    default_skill: Mapping[str, str],
+    mechanics: MechanicsContract,
+    *,
+    concrete_team: bool = True,
+) -> tuple[MechanicSkillInstance, ...]:
+    """Build canonical active skill instances for one exact three-hero team."""
+    heroes = [str(hero.get("name", "")) for hero in team if hero.get("name")]
+    if (
+        not concrete_team
+        or len(team) != TEAM_SIZE
+        or len(heroes) != TEAM_SIZE
+        or len(set(heroes)) != TEAM_SIZE
+    ):
+        return ()
+
+    instances: list[MechanicSkillInstance] = []
+    for hero_data in team:
+        carrier = str(hero_data.get("name", ""))
+        signature = default_skill.get(carrier)
+        if not isinstance(signature, str) or not signature:
+            raise ValueError(
+                f"MECH extraction requires a canonical default skill for {carrier!r}"
+            )
+        skill_names = [(signature, "signature"), *(
+            (skill, "equipped")
+            for skill in _non_default_skills(hero_data, default_skill)
+        )]
+        for skill_name, origin in skill_names:
+            if skill_name not in mechanics.skill_relationships:
+                raise ValueError(
+                    f"MECH contract is missing active skill {skill_name!r}"
+                )
+            instances.append(
+                MechanicSkillInstance(
+                    carrier=carrier,
+                    skill_name=skill_name,
+                    origin=origin,
+                )
+            )
+    return tuple(instances)
+
+
+def _mechanic_targets(
+    subject: str,
+    carrier: str,
+    friendly_heroes: frozenset[str],
+) -> frozenset[str]:
+    if subject == "self":
+        return frozenset((carrier,))
+    if subject == "ally":
+        return friendly_heroes - frozenset((carrier,))
+    if subject == "team":
+        return friendly_heroes
+    if subject == "enemy":
+        return frozenset((ENEMY_TEAM_TARGET,))
+    if subject == "any":
+        return friendly_heroes | frozenset((ENEMY_TEAM_TARGET,))
+    if subject == "unknown":
+        return frozenset()
+    raise ValueError(f"unsupported MECH subject {subject!r}")
+
+
+def mechanic_feature_witnesses(
+    team: list[dict[str, Any]],
+    default_skill: Mapping[str, str],
+    mechanics: MechanicsContract,
+    *,
+    concrete_team: bool = True,
+    certainty_mode: str = "explicit_only",
+) -> dict[str, tuple[MechanicWitness, ...]]:
+    """Return deterministic distinct-instance witnesses for binary M features."""
+    if certainty_mode not in MECH_CERTAINTY_MODES:
+        raise ValueError(f"unsupported MECH certainty mode {certainty_mode!r}")
+    instances = active_mechanic_skill_instances(
+        team,
+        default_skill,
+        mechanics,
+        concrete_team=concrete_team,
+    )
+    if not instances:
+        return {}
+
+    friendly_heroes = frozenset(instance.carrier for instance in instances)
+
+    def certainty_allowed(certainty: str) -> bool:
+        return certainty == "explicit" or (
+            certainty_mode == "all_reviewed" and certainty == "inferred"
+        )
+
+    witnesses: dict[str, set[MechanicWitness]] = defaultdict(set)
+    for provider in instances:
+        provider_relations = mechanics.skill_relationships[provider.skill_name]
+        for provider_relation in provider_relations:
+            if (
+                provider_relation.relation != "provides"
+                or not certainty_allowed(provider_relation.certainty)
+            ):
+                continue
+            provider_targets = _mechanic_targets(
+                provider_relation.subject,
+                provider.carrier,
+                friendly_heroes,
+            )
+            if not provider_targets:
+                continue
+            for consumer in instances:
+                if consumer == provider:
+                    continue
+                for consumer_relation in mechanics.skill_relationships[
+                    consumer.skill_name
+                ]:
+                    if (
+                        consumer_relation.relation not in MECH_CONSUMER_RELATIONS
+                        or consumer_relation.mechanic != provider_relation.mechanic
+                        or not certainty_allowed(consumer_relation.certainty)
+                    ):
+                        continue
+                    overlap = provider_targets.intersection(
+                        _mechanic_targets(
+                            consumer_relation.subject,
+                            consumer.carrier,
+                            friendly_heroes,
+                        )
+                    )
+                    if not overlap:
+                        continue
+                    witness = MechanicWitness(
+                        provider_skill=provider.skill_name,
+                        consumer_skill=consumer.skill_name,
+                        provider_carrier=provider.carrier,
+                        consumer_carrier=consumer.carrier,
+                        provider_origin=provider.origin,
+                        consumer_origin=consumer.origin,
+                    )
+                    if ENEMY_TEAM_TARGET in overlap:
+                        witnesses[
+                            mechanic_id(
+                                provider_relation.mechanic,
+                                consumer_relation.relation,
+                                "enemy",
+                            )
+                        ].add(witness)
+                    if overlap - frozenset((ENEMY_TEAM_TARGET,)):
+                        witnesses[
+                            mechanic_id(
+                                provider_relation.mechanic,
+                                consumer_relation.relation,
+                                "friendly",
+                            )
+                        ].add(witness)
+    return {
+        feature_id: tuple(sorted(feature_witnesses))
+        for feature_id, feature_witnesses in sorted(witnesses.items())
+    }
+
+
 def team_features(
     team: list[dict[str, Any]],
     default_skill: Mapping[str, str],
     relationships: CatalogRelationships | None = None,
     *,
     concrete_team: bool = True,
+    mechanics: MechanicsContract | None = None,
+    mech_certainty_mode: str = "explicit_only",
 ) -> dict[str, int]:
-    """Return presence-encoded identity features for one roster.
+    """Return presence-encoded features for one roster.
 
-    H/S/HP/HS/SP retain their historical pool-safe semantics. Team-context
-    families fire only when the caller identifies an exact concrete three-hero
-    team; an incomplete or unpartitioned pool therefore cannot manufacture
-    cross-team THS/TSP/HT/TS3/HC/B relationships.
+    H/S/HP/HS/SP retain their historical pool-safe semantics. Team-context and
+    evaluation-only M families fire only for one exact concrete three-hero team;
+    an incomplete or unpartitioned pool cannot manufacture cross-team context.
+    Canonical signatures participate only in M extraction.
     """
     feats: dict[str, int] = {}
 
@@ -958,6 +1164,15 @@ def team_features(
     for skill_a, skill_b, skill_c in combinations(sorted_skills, 3):
         feats[ts3_id(skill_a, skill_b, skill_c)] = 1
 
+    if mechanics is not None:
+        for feature_id in mechanic_feature_witnesses(
+            team,
+            default_skill,
+            mechanics,
+            certainty_mode=mech_certainty_mode,
+        ):
+            feats[feature_id] = 1
+
     if relationships is None:
         return feats
 
@@ -980,10 +1195,25 @@ def paired_difference(
     b: Battle,
     default_skill: Mapping[str, str],
     relationships: CatalogRelationships | None = None,
+    *,
+    mechanics: MechanicsContract | None = None,
+    mech_certainty_mode: str = "explicit_only",
 ) -> dict[str, int]:
     """team1 features minus team2 features for a battle (values in {-1,0,1})."""
-    f1 = team_features(b.team1, default_skill, relationships)
-    f2 = team_features(b.team2, default_skill, relationships)
+    f1 = team_features(
+        b.team1,
+        default_skill,
+        relationships,
+        mechanics=mechanics,
+        mech_certainty_mode=mech_certainty_mode,
+    )
+    f2 = team_features(
+        b.team2,
+        default_skill,
+        relationships,
+        mechanics=mechanics,
+        mech_certainty_mode=mech_certainty_mode,
+    )
     diff: dict[str, int] = {}
     for key in set(f1) | set(f2):
         val = f1.get(key, 0) - f2.get(key, 0)
@@ -996,6 +1226,9 @@ def compute_support(
     battles: list[Battle],
     default_skill: Mapping[str, str],
     relationships: CatalogRelationships | None = None,
+    *,
+    mechanics: MechanicsContract | None = None,
+    mech_certainty_mode: str = "explicit_only",
 ) -> dict[str, int]:
     """How many battles each feature appears in (on either team).
 
@@ -1004,12 +1237,59 @@ def compute_support(
     """
     support: dict[str, int] = defaultdict(int)
     for b in battles:
-        seen = set(team_features(b.team1, default_skill, relationships)) | set(
-            team_features(b.team2, default_skill, relationships)
+        seen = set(
+            team_features(
+                b.team1,
+                default_skill,
+                relationships,
+                mechanics=mechanics,
+                mech_certainty_mode=mech_certainty_mode,
+            )
+        ) | set(
+            team_features(
+                b.team2,
+                default_skill,
+                relationships,
+                mechanics=mechanics,
+                mech_certainty_mode=mech_certainty_mode,
+            )
         )
         for key in seen:
             support[key] += 1
     return dict(support)
+
+
+def compute_mechanic_witness_pair_counts(
+    battles: Sequence[Battle],
+    default_skill: Mapping[str, str],
+    mechanics: MechanicsContract,
+    *,
+    certainty_mode: str = "explicit_only",
+) -> dict[str, dict[tuple[str, str], int]]:
+    """Count ordered skill-name witness pairs at most once per battle."""
+    counts: dict[str, Counter[tuple[str, str]]] = defaultdict(Counter)
+    for battle in battles:
+        seen: set[tuple[str, tuple[str, str]]] = set()
+        for team in (battle.team1, battle.team2):
+            for feature_id, witnesses in mechanic_feature_witnesses(
+                team,
+                default_skill,
+                mechanics,
+                certainty_mode=certainty_mode,
+            ).items():
+                for witness in witnesses:
+                    seen.add(
+                        (
+                            feature_id,
+                            (witness.provider_skill, witness.consumer_skill),
+                        )
+                    )
+        for feature_id, pair in seen:
+            counts[feature_id][pair] += 1
+    return {
+        feature_id: dict(sorted(pair_counts.items()))
+        for feature_id, pair_counts in sorted(counts.items())
+    }
 
 
 def _min_support_for(
@@ -1020,6 +1300,7 @@ def _min_support_for(
     min_support_team_context: int = MIN_SUPPORT_TEAM_CONTEXT,
     min_support_relationship: int = MIN_SUPPORT_RELATIONSHIP,
     min_support_high_order: int = MIN_SUPPORT_HIGH_ORDER,
+    min_support_mechanic: int = MIN_SUPPORT_MECHANIC,
 ) -> int:
     family = feature_id.split("|", 1)[0]
     if family in ATOMIC_FAMILIES:
@@ -1032,6 +1313,8 @@ def _min_support_for(
         return min_support_relationship
     if family in HIGH_ORDER_FAMILIES:
         return min_support_high_order
+    if family in MECHANIC_FAMILIES:
+        return min_support_mechanic
     raise ValueError(f"unknown recommendation feature family {family!r}")
 
 
@@ -1043,6 +1326,9 @@ def select_features(
     min_support_team_context: int = MIN_SUPPORT_TEAM_CONTEXT,
     min_support_relationship: int = MIN_SUPPORT_RELATIONSHIP,
     min_support_high_order: int = MIN_SUPPORT_HIGH_ORDER,
+    min_support_mechanic: int = MIN_SUPPORT_MECHANIC,
+    min_mechanic_pair_diversity: int = MIN_MECHANIC_PAIR_DIVERSITY,
+    mechanic_pair_diversity: Mapping[str, int] | None = None,
     enabled_families: Iterable[str] | None = None,
     excluded_families: Iterable[str] = (),
 ) -> list[str]:
@@ -1059,6 +1345,8 @@ def select_features(
         min_support_team_context,
         min_support_relationship,
         min_support_high_order,
+        min_support_mechanic,
+        min_mechanic_pair_diversity,
     )
     if any(threshold < 1 for threshold in thresholds):
         raise ValueError("feature support thresholds must be positive")
@@ -1071,6 +1359,20 @@ def select_features(
     unknown = enabled - ALL_FEATURE_FAMILIES
     if unknown:
         raise ValueError(f"unknown enabled feature families: {sorted(unknown)!r}")
+    unknown_excluded = excluded - ALL_FEATURE_FAMILIES
+    if unknown_excluded:
+        raise ValueError(
+            f"unknown excluded feature families: {sorted(unknown_excluded)!r}"
+        )
+    has_enabled_mechanic_support = any(
+        feature_id.startswith(f"{F_MECHANIC}|")
+        for feature_id in support
+    ) and F_MECHANIC in enabled and F_MECHANIC not in excluded
+    if has_enabled_mechanic_support and mechanic_pair_diversity is None:
+        raise ValueError(
+            "MECH feature selection requires training-only pair diversity"
+        )
+    pair_diversity = mechanic_pair_diversity or {}
 
     def clears_constituent_pairs(feature_id: str) -> bool:
         parts = feature_id.split("|")
@@ -1096,6 +1398,11 @@ def select_features(
             min_support_team_context=min_support_team_context,
             min_support_relationship=min_support_relationship,
             min_support_high_order=min_support_high_order,
+            min_support_mechanic=min_support_mechanic,
+        )
+        and (
+            fid.split("|", 1)[0] != F_MECHANIC
+            or pair_diversity.get(fid, 0) >= min_mechanic_pair_diversity
         )
         and clears_constituent_pairs(fid)
     ]
@@ -1112,6 +1419,9 @@ def build_design_matrix(
     feature_index: dict[str, int],
     default_skill: Mapping[str, str],
     relationships: CatalogRelationships | None = None,
+    *,
+    mechanics: MechanicsContract | None = None,
+    mech_certainty_mode: str = "explicit_only",
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return ``(X, y)`` for the paired logistic regression.
 
@@ -1124,7 +1434,13 @@ def build_design_matrix(
     X = np.zeros((n, d), dtype=np.float64)
     y = np.zeros(n, dtype=np.int64)
     for i, b in enumerate(battles):
-        for key, val in paired_difference(b, default_skill, relationships).items():
+        for key, val in paired_difference(
+            b,
+            default_skill,
+            relationships,
+            mechanics=mechanics,
+            mech_certainty_mode=mech_certainty_mode,
+        ).items():
             col = feature_index.get(key)
             if col is not None:
                 X[i, col] = val
@@ -1138,12 +1454,15 @@ def apply_family_shrinkage(
     *,
     team_context_shrinkage: float = TEAM_CONTEXT_SHRINKAGE,
     high_order_shrinkage: float = HIGH_ORDER_SHRINKAGE,
+    mechanic_shrinkage: float = MECHANIC_SHRINKAGE,
 ) -> np.ndarray:
-    """Apply explicit shrinkage to correlated context and higher-order terms."""
+    """Apply explicit family-specific post-fit coefficient shrinkage."""
     if not 0.0 <= team_context_shrinkage <= 1.0:
         raise ValueError("team-context shrinkage must be between zero and one")
     if not 0.0 <= high_order_shrinkage <= 1.0:
         raise ValueError("higher-order shrinkage must be between zero and one")
+    if not 0.0 <= mechanic_shrinkage <= 1.0:
+        raise ValueError("MECH shrinkage must be between zero and one")
     ordered = list(features)
     adjusted = np.asarray(coef, dtype=np.float64).copy()
     if len(adjusted) < len(ordered):
@@ -1154,6 +1473,8 @@ def apply_family_shrinkage(
             adjusted[index] *= team_context_shrinkage
         elif family in HIGH_ORDER_FAMILIES:
             adjusted[index] *= high_order_shrinkage
+        elif family in MECHANIC_FAMILIES:
+            adjusted[index] *= mechanic_shrinkage
     return adjusted
 
 

--- a/data/evaluate_recommendation_model.py
+++ b/data/evaluate_recommendation_model.py
@@ -1412,9 +1412,11 @@ def _fire_mechanic_audit(
             if "陆逊" in heroes and liehuo_instances:
                 lu_xun_liehuo_teams += 1
                 lu_xun_liehuo_activated += activated
-                for instance in liehuo_instances:
+                for carrier in sorted(
+                    {instance.carrier for instance in liehuo_instances}
+                ):
                     row = carrier_counts.setdefault(
-                        instance.carrier,
+                        carrier,
                         {"observed_teams": 0, "activated_teams": 0},
                     )
                     row["observed_teams"] += 1
@@ -1428,9 +1430,11 @@ def _fire_mechanic_audit(
                                 "provider_skill": witness.provider_skill,
                                 "provider_carrier": witness.provider_carrier,
                                 "provider_origin": witness.provider_origin,
+                                "provider_slot_index": witness.provider_slot_index,
                                 "consumer_skill": witness.consumer_skill,
                                 "consumer_carrier": witness.consumer_carrier,
                                 "consumer_origin": witness.consumer_origin,
+                                "consumer_slot_index": witness.consumer_slot_index,
                             }
                             for witness in feature_witnesses
                             if witness.provider_skill == "烈火张天"
@@ -1473,7 +1477,16 @@ def _fire_mechanic_audit(
                 distinct_fire_providers = [
                     instance
                     for instance in instances
-                    if instance != lu_xun_signature
+                    if (
+                        lu_xun_signature is None
+                        or (
+                            instance.carrier,
+                            instance.slot_index,
+                        ) != (
+                            lu_xun_signature.carrier,
+                            lu_xun_signature.slot_index,
+                        )
+                    )
                     and any(
                         relation.relation == "provides"
                         and relation.mechanic == fire_mechanic

--- a/data/evaluate_recommendation_model.py
+++ b/data/evaluate_recommendation_model.py
@@ -15,7 +15,7 @@ import os
 import sys
 import tempfile
 from collections import Counter
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
@@ -25,16 +25,20 @@ try:
     from build_recommendation_data import (
         ATOMIC_FAMILIES,
         HIGH_ORDER_SHRINKAGE,
+        MECHANIC_SHRINKAGE,
         PAIR_FAMILIES,
         PRODUCTION_ENABLED_FAMILIES,
         RELATIONSHIP_FAMILIES,
         TEAM_CONTEXT_FAMILIES,
         TEAM_CONTEXT_SHRINKAGE,
         F_HERO_TRIO,
+        F_MECHANIC,
         F_SKILL_PAIR,
         F_TEAM_SKILL_TRIO,
         L2_C,
+        MIN_MECHANIC_PAIR_DIVERSITY,
         MIN_SUPPORT_HIGH_ORDER,
+        MIN_SUPPORT_MECHANIC,
         MIN_SUPPORT_PAIR,
         MIN_SUPPORT_RELATIONSHIP,
         MIN_SUPPORT_SINGLE,
@@ -50,18 +54,23 @@ try:
         _load_catalog_context,
         _selection_prior_atomic_components,
         _sigmoid,
+        active_mechanic_skill_instances,
         apply_family_shrinkage,
         build_design_matrix,
         compute_corpus_version,
         compute_evaluation_version,
+        compute_mechanic_witness_pair_counts,
         compute_support,
         fit_model,
         load_battles,
         load_yanwu_battles,
+        mechanic_feature_witnesses,
+        mechanic_id,
         select_features,
         team_features,
         validate_training_duplicate_policy,
     )
+    from mech_evaluation import MechanicsContract, load_evaluation_mechanics
     from recommendation_evaluation import (
         BOOTSTRAP_SAMPLES,
         EVALUATION_PROTOCOL_VERSION,
@@ -87,16 +96,20 @@ except ModuleNotFoundError:  # Support ``python -m data.evaluate_recommendation_
     from .build_recommendation_data import (
         ATOMIC_FAMILIES,
         HIGH_ORDER_SHRINKAGE,
+        MECHANIC_SHRINKAGE,
         PAIR_FAMILIES,
         PRODUCTION_ENABLED_FAMILIES,
         RELATIONSHIP_FAMILIES,
         TEAM_CONTEXT_FAMILIES,
         TEAM_CONTEXT_SHRINKAGE,
         F_HERO_TRIO,
+        F_MECHANIC,
         F_SKILL_PAIR,
         F_TEAM_SKILL_TRIO,
         L2_C,
+        MIN_MECHANIC_PAIR_DIVERSITY,
         MIN_SUPPORT_HIGH_ORDER,
+        MIN_SUPPORT_MECHANIC,
         MIN_SUPPORT_PAIR,
         MIN_SUPPORT_RELATIONSHIP,
         MIN_SUPPORT_SINGLE,
@@ -112,18 +125,23 @@ except ModuleNotFoundError:  # Support ``python -m data.evaluate_recommendation_
         _load_catalog_context,
         _selection_prior_atomic_components,
         _sigmoid,
+        active_mechanic_skill_instances,
         apply_family_shrinkage,
         build_design_matrix,
         compute_corpus_version,
         compute_evaluation_version,
+        compute_mechanic_witness_pair_counts,
         compute_support,
         fit_model,
         load_battles,
         load_yanwu_battles,
+        mechanic_feature_witnesses,
+        mechanic_id,
         select_features,
         team_features,
         validate_training_duplicate_policy,
     )
+    from .mech_evaluation import MechanicsContract, load_evaluation_mechanics
     from .recommendation_evaluation import (
         BOOTSTRAP_SAMPLES,
         EVALUATION_PROTOCOL_VERSION,
@@ -170,6 +188,10 @@ PAIR_SUPPORT_CANDIDATES = (5, 8, 12)
 TEAM_CONTEXT_SUPPORT_CANDIDATES = (8, 12, 20)
 TEAM_CONTEXT_SHRINKAGE_CANDIDATES = (0.25, 0.5, 0.75, 1.0)
 RELATIONSHIP_SUPPORT_CANDIDATES = (8, 12, 20)
+MECH_CERTAINTY_CANDIDATES = ("explicit_only", "all_reviewed")
+MECH_SUPPORT_CANDIDATES = (12, 20, 30)
+MECH_SHRINKAGE_CANDIDATES = (0.25, 0.5, 0.75)
+MECH_TOP_WITNESS_PAIRS = 5
 HERO_TRIO_SUPPORT_CANDIDATES = (20, 50)
 TEAM_SKILL_TRIO_SUPPORT_CANDIDATES = (50,)
 SELECTION_PRIOR_HERO_STRENGTH_CANDIDATES = (0.0, 0.2, 0.4, 0.6)
@@ -192,6 +214,11 @@ class EvaluationConfig:
     include_sp: bool = True
     include_ths_tsp: bool = TEAM_CONTEXT_FAMILIES <= PRODUCTION_ENABLED_FAMILIES
     include_hc_b: bool = RELATIONSHIP_FAMILIES <= PRODUCTION_ENABLED_FAMILIES
+    include_mech: bool = False
+    mech_certainty_mode: str = "explicit_only"
+    min_support_mechanic: int = MIN_SUPPORT_MECHANIC
+    mechanic_shrinkage: float = MECHANIC_SHRINKAGE
+    min_mechanic_pair_diversity: int = MIN_MECHANIC_PAIR_DIVERSITY
     include_ht: bool = F_HERO_TRIO in PRODUCTION_ENABLED_FAMILIES
     include_ts3: bool = F_TEAM_SKILL_TRIO in PRODUCTION_ENABLED_FAMILIES
     team_context_shrinkage: float = TEAM_CONTEXT_SHRINKAGE
@@ -212,6 +239,8 @@ class EvaluationConfig:
                 self.min_support_team_context,
                 self.min_support_relationship,
                 self.min_support_high_order,
+                self.min_support_mechanic,
+                self.min_mechanic_pair_diversity,
             )
         ):
             raise ValueError("support thresholds must be positive")
@@ -219,6 +248,10 @@ class EvaluationConfig:
             raise ValueError("team-context shrinkage must be between zero and one")
         if not 0.0 <= self.high_order_shrinkage <= 1.0:
             raise ValueError("higher-order shrinkage must be between zero and one")
+        if not 0.0 <= self.mechanic_shrinkage <= 1.0:
+            raise ValueError("MECH shrinkage must be between zero and one")
+        if self.mech_certainty_mode not in MECH_CERTAINTY_CANDIDATES:
+            raise ValueError("unsupported MECH certainty mode")
         for name, value in (
             ("hero strength", self.selection_prior_hero_strength),
             ("skill strength", self.selection_prior_skill_strength),
@@ -253,6 +286,11 @@ class EvaluationConfig:
             "include_sp": self.include_sp,
             "include_ths_tsp": self.include_ths_tsp,
             "include_hc_b": self.include_hc_b,
+            "include_mech": self.include_mech,
+            "mech_certainty_mode": self.mech_certainty_mode,
+            "min_support_mechanic": self.min_support_mechanic,
+            "mechanic_shrinkage": self.mechanic_shrinkage,
+            "min_mechanic_pair_diversity": self.min_mechanic_pair_diversity,
             "include_ht": self.include_ht,
             "include_ts3": self.include_ts3,
             "team_context_shrinkage": self.team_context_shrinkage,
@@ -267,6 +305,7 @@ class EvaluationConfig:
         return (
             0 if not self.include_ts3 else 1,
             0 if not self.include_ht else 1,
+            0 if not self.include_mech else 1,
             0 if not self.include_hc_b else 1,
             0 if not self.include_ths_tsp else 1,
             0 if not self.include_sp else 1,
@@ -275,6 +314,10 @@ class EvaluationConfig:
             -self.min_support_team_context,
             -self.min_support_relationship,
             -self.min_support_high_order,
+            0 if self.mech_certainty_mode == "explicit_only" else 1,
+            -self.min_support_mechanic,
+            self.mechanic_shrinkage,
+            -self.min_mechanic_pair_diversity,
             self.team_context_shrinkage,
             self.selection_prior_hero_strength,
             self.selection_prior_skill_strength,
@@ -309,6 +352,7 @@ class PredictionRows:
     n_features: int
     nonzero_rows: int
     atomic_diagnostics: dict[str, Any]
+    mechanic_diagnostics: dict[str, Any] = field(default_factory=dict)
 
 
 def _atomic_diagnostics(
@@ -369,6 +413,7 @@ def _load_evaluation_corpus(
     web_upload_dir: str,
     web_upload_state_path: str,
     database_path: str,
+    mech_catalog_path: str,
     yanwu_corpus_path: str | None = None,
     yanwu_manifest_path: str = "data/external/yanwu-release.json",
 ) -> tuple[
@@ -376,8 +421,10 @@ def _load_evaluation_corpus(
     dict[str, Any],
     _CatalogSeasons,
     CatalogRelationships,
+    MechanicsContract,
 ]:
     catalog_context = _load_catalog_context(database_path)
+    mechanics = load_evaluation_mechanics(database_path, mech_catalog_path)
     manual_battles, errors = load_battles(
         battles_dir,
         catalog_names=catalog_context.names,
@@ -436,6 +483,7 @@ def _load_evaluation_corpus(
         catalog_context.metadata,
         catalog_context.seasons,
         catalog_context.relationships,
+        mechanics,
     )
 
 
@@ -737,12 +785,62 @@ def _fit_and_predict(
     default_skill: Mapping[str, str],
     catalog_seasons: _CatalogSeasons,
     relationships: CatalogRelationships | None,
+    mechanics: MechanicsContract | None = None,
     *,
     test_group_ids: Sequence[str] | None = None,
+    mechanic_selection_indices: Sequence[int] | None = None,
 ) -> PredictionRows:
     train = [battles[index] for index in train_indices]
     test = [battles[index] for index in test_indices]
-    support = compute_support(train, default_skill, relationships)
+    if config.include_mech and mechanics is None:
+        raise ValueError("enabled MECH evaluation requires a validated contract")
+    active_mechanics = mechanics if config.include_mech else None
+    support = compute_support(
+        train,
+        default_skill,
+        relationships,
+        mechanics=active_mechanics,
+        mech_certainty_mode=config.mech_certainty_mode,
+    )
+    mechanic_evidence = (
+        [battles[index] for index in mechanic_selection_indices]
+        if mechanic_selection_indices is not None
+        else train
+    )
+    mechanic_support: dict[str, int] = {}
+    mechanic_pair_counts: dict[str, dict[tuple[str, str], int]] = {}
+    mechanic_pair_diversity: dict[str, int] = {}
+    if active_mechanics is not None:
+        evidence_support = compute_support(
+            mechanic_evidence,
+            default_skill,
+            relationships,
+            mechanics=active_mechanics,
+            mech_certainty_mode=config.mech_certainty_mode,
+        )
+        mechanic_support = {
+            feature_id: count
+            for feature_id, count in evidence_support.items()
+            if feature_id.startswith(f"{F_MECHANIC}|")
+        }
+        # M support and diversity remain frozen to original training rows even
+        # when the final coefficients are refit on training plus development.
+        support = {
+            feature_id: count
+            for feature_id, count in support.items()
+            if not feature_id.startswith(f"{F_MECHANIC}|")
+        }
+        support.update(mechanic_support)
+        mechanic_pair_counts = compute_mechanic_witness_pair_counts(
+            mechanic_evidence,
+            default_skill,
+            active_mechanics,
+            certainty_mode=config.mech_certainty_mode,
+        )
+        mechanic_pair_diversity = {
+            feature_id: len(pair_counts)
+            for feature_id, pair_counts in mechanic_pair_counts.items()
+        }
     enabled_families = set(ATOMIC_FAMILIES | PAIR_FAMILIES)
     if not config.include_sp:
         enabled_families.discard(F_SKILL_PAIR)
@@ -750,6 +848,8 @@ def _fit_and_predict(
         enabled_families.update(TEAM_CONTEXT_FAMILIES)
     if config.include_hc_b:
         enabled_families.update(RELATIONSHIP_FAMILIES)
+    if config.include_mech:
+        enabled_families.add(F_MECHANIC)
     if config.include_ht:
         enabled_families.add(F_HERO_TRIO)
     if config.include_ts3:
@@ -761,6 +861,9 @@ def _fit_and_predict(
         min_support_team_context=config.min_support_team_context,
         min_support_relationship=config.min_support_relationship,
         min_support_high_order=config.min_support_high_order,
+        min_support_mechanic=config.min_support_mechanic,
+        min_mechanic_pair_diversity=config.min_mechanic_pair_diversity,
+        mechanic_pair_diversity=mechanic_pair_diversity,
         enabled_families=enabled_families,
     )
     feature_index = {
@@ -768,10 +871,20 @@ def _fit_and_predict(
         for index, feature_id in enumerate(features)
     }
     X_train, y_train = build_design_matrix(
-        train, feature_index, default_skill, relationships
+        train,
+        feature_index,
+        default_skill,
+        relationships,
+        mechanics=active_mechanics,
+        mech_certainty_mode=config.mech_certainty_mode,
     )
     X_test, y_test = build_design_matrix(
-        test, feature_index, default_skill, relationships
+        test,
+        feature_index,
+        default_skill,
+        relationships,
+        mechanics=active_mechanics,
+        mech_certainty_mode=config.mech_certainty_mode,
     )
     fitted_coef, intercept = fit_model(X_train, y_train, c=config.c)
     coef = apply_family_shrinkage(
@@ -779,6 +892,7 @@ def _fit_and_predict(
         fitted_coef,
         team_context_shrinkage=config.team_context_shrinkage,
         high_order_shrinkage=config.high_order_shrinkage,
+        mechanic_shrinkage=config.mechanic_shrinkage,
     )
     atomic_components = _selection_prior_atomic_components(
         features,
@@ -830,6 +944,57 @@ def _fit_and_predict(
             axis=1,
         )
     probabilities = _sigmoid(logits)
+    selected_mechanic_features = [
+        feature_id
+        for feature_id in features
+        if feature_id.startswith(f"{F_MECHANIC}|")
+    ]
+    mechanic_diagnostics: dict[str, Any] = {}
+    if active_mechanics is not None:
+        supported = [
+            feature_id
+            for feature_id, count in sorted(mechanic_support.items())
+            if count >= config.min_support_mechanic
+        ]
+        diversity_qualified = [
+            feature_id
+            for feature_id in sorted(mechanic_support)
+            if mechanic_pair_diversity.get(feature_id, 0)
+            >= config.min_mechanic_pair_diversity
+        ]
+        selected_set = set(selected_mechanic_features)
+        mechanic_diagnostics = {
+            "emitted_feature_count": len(mechanic_support),
+            "supported_feature_count": len(supported),
+            "diversity_qualified_feature_count": len(diversity_qualified),
+            "selected_feature_count": len(selected_mechanic_features),
+            "features": {
+                feature_id: {
+                    "training_battle_support": mechanic_support[feature_id],
+                    "distinct_ordered_skill_pair_count": (
+                        mechanic_pair_diversity.get(feature_id, 0)
+                    ),
+                    "selected": feature_id in selected_set,
+                    "weight_after_shrinkage": (
+                        round(float(coef[feature_index[feature_id]]), 9)
+                        if feature_id in selected_set
+                        else None
+                    ),
+                    "top_witness_pairs": [
+                        {
+                            "provider_skill": pair[0],
+                            "consumer_skill": pair[1],
+                            "training_battle_count": count,
+                        }
+                        for pair, count in sorted(
+                            mechanic_pair_counts.get(feature_id, {}).items(),
+                            key=lambda item: (-item[1], item[0][0], item[0][1]),
+                        )[:MECH_TOP_WITNESS_PAIRS]
+                    ] if feature_id in selected_set else [],
+                }
+                for feature_id in sorted(mechanic_support)
+            },
+        }
     baseline_probability = float(np.mean(y_train)) if len(y_train) else 0.5
     row_group_ids = (
         list(test_group_ids)
@@ -847,6 +1012,7 @@ def _fit_and_predict(
         n_features=len(features) + len(prior_only_weights),
         nonzero_rows=int(np.count_nonzero(nonzero_test_rows)),
         atomic_diagnostics=_atomic_diagnostics(atomic_components),
+        mechanic_diagnostics=mechanic_diagnostics,
     )
 
 
@@ -1132,6 +1298,239 @@ def _targeted_context_diagnostics(
     }
 
 
+def _mechanic_training_coverage(
+    training_battles: Sequence[Battle],
+    default_skill: Mapping[str, str],
+    mechanics: MechanicsContract,
+) -> dict[str, Any]:
+    """Compare certainty-mode coverage using original training rows only."""
+    coverage: dict[str, Any] = {}
+    for certainty_mode in MECH_CERTAINTY_CANDIDATES:
+        support = compute_support(
+            list(training_battles),
+            default_skill,
+            mechanics=mechanics,
+            mech_certainty_mode=certainty_mode,
+        )
+        mechanic_support = {
+            feature_id: count
+            for feature_id, count in sorted(support.items())
+            if feature_id.startswith(f"{F_MECHANIC}|")
+        }
+        pair_counts = compute_mechanic_witness_pair_counts(
+            training_battles,
+            default_skill,
+            mechanics,
+            certainty_mode=certainty_mode,
+        )
+        activated_teams = 0
+        activated_battles = 0
+        for battle in training_battles:
+            team_flags = [
+                bool(
+                    mechanic_feature_witnesses(
+                        team,
+                        default_skill,
+                        mechanics,
+                        certainty_mode=certainty_mode,
+                    )
+                )
+                for team in (battle.team1, battle.team2)
+            ]
+            activated_teams += sum(team_flags)
+            activated_battles += any(team_flags)
+        coverage[certainty_mode] = {
+            "emitted_feature_count": len(mechanic_support),
+            "activated_training_battles": activated_battles,
+            "activated_training_teams": activated_teams,
+            "features": {
+                feature_id: {
+                    "training_battle_support": count,
+                    "distinct_ordered_skill_pair_count": len(
+                        pair_counts.get(feature_id, {})
+                    ),
+                }
+                for feature_id, count in mechanic_support.items()
+            },
+        }
+    return coverage
+
+
+def _fire_mechanic_audit(
+    battles: Sequence[Battle],
+    default_skill: Mapping[str, str],
+    mechanics: MechanicsContract,
+) -> dict[str, Any]:
+    """Audit the motivating 火攻 relationship without causal interpretation."""
+    fire_mechanic = "debuff:huo_gong"
+    fire_feature = mechanic_id(fire_mechanic, "benefits_from", "enemy")
+
+    def matching_relationships(skill_name: str, relation_name: str) -> list[dict[str, str]]:
+        return [
+            {
+                "relation": relation.relation,
+                "mechanic": relation.mechanic,
+                "subject": relation.subject,
+                "certainty": relation.certainty,
+            }
+            for relation in mechanics.skill_relationships[skill_name]
+            if relation.relation == relation_name
+            and relation.mechanic == fire_mechanic
+        ]
+
+    carrier_counts: dict[str, dict[str, int]] = {}
+    lu_xun_liehuo_teams = 0
+    lu_xun_liehuo_activated = 0
+    zhang_without_consumer_teams = 0
+    zhang_without_consumer_activated = 0
+    lu_xun_without_distinct_provider_teams = 0
+    lu_xun_without_distinct_provider_activated = 0
+    example: dict[str, Any] | None = None
+
+    for battle in battles:
+        for team_number, team in enumerate((battle.team1, battle.team2), start=1):
+            heroes = {str(hero.get("name", "")) for hero in team}
+            instances = active_mechanic_skill_instances(
+                team,
+                default_skill,
+                mechanics,
+            )
+            witnesses = mechanic_feature_witnesses(
+                team,
+                default_skill,
+                mechanics,
+                certainty_mode="explicit_only",
+            )
+            feature_witnesses = witnesses.get(fire_feature, ())
+            activated = bool(feature_witnesses)
+            liehuo_instances = [
+                instance
+                for instance in instances
+                if instance.skill_name == "烈火张天"
+                and instance.origin == "equipped"
+            ]
+            if "陆逊" in heroes and liehuo_instances:
+                lu_xun_liehuo_teams += 1
+                lu_xun_liehuo_activated += activated
+                for instance in liehuo_instances:
+                    row = carrier_counts.setdefault(
+                        instance.carrier,
+                        {"observed_teams": 0, "activated_teams": 0},
+                    )
+                    row["observed_teams"] += 1
+                    row["activated_teams"] += activated
+                if example is None and activated:
+                    example = {
+                        "battle": battle.filename,
+                        "team": team_number,
+                        "witnesses": [
+                            {
+                                "provider_skill": witness.provider_skill,
+                                "provider_carrier": witness.provider_carrier,
+                                "provider_origin": witness.provider_origin,
+                                "consumer_skill": witness.consumer_skill,
+                                "consumer_carrier": witness.consumer_carrier,
+                                "consumer_origin": witness.consumer_origin,
+                            }
+                            for witness in feature_witnesses
+                            if witness.provider_skill == "烈火张天"
+                            and witness.consumer_skill == "火烧连营"
+                        ],
+                    }
+
+            fire_consumers = [
+                instance
+                for instance in instances
+                if any(
+                    relation.relation in ("benefits_from", "requires", "consumes")
+                    and relation.mechanic == fire_mechanic
+                    and relation.certainty == "explicit"
+                    for relation in mechanics.skill_relationships[
+                        instance.skill_name
+                    ]
+                )
+            ]
+            if (
+                "张昭" in heroes
+                and "陆逊" not in heroes
+                and liehuo_instances
+                and not fire_consumers
+            ):
+                zhang_without_consumer_teams += 1
+                zhang_without_consumer_activated += activated
+
+            if "陆逊" in heroes:
+                lu_xun_signature = next(
+                    (
+                        instance
+                        for instance in instances
+                        if instance.carrier == "陆逊"
+                        and instance.skill_name == "火烧连营"
+                        and instance.origin == "signature"
+                    ),
+                    None,
+                )
+                distinct_fire_providers = [
+                    instance
+                    for instance in instances
+                    if instance != lu_xun_signature
+                    and any(
+                        relation.relation == "provides"
+                        and relation.mechanic == fire_mechanic
+                        and relation.certainty == "explicit"
+                        for relation in mechanics.skill_relationships[
+                            instance.skill_name
+                        ]
+                    )
+                ]
+                if lu_xun_signature is not None and not distinct_fire_providers:
+                    lu_xun_without_distinct_provider_teams += 1
+                    lu_xun_without_distinct_provider_activated += activated
+
+    return {
+        "feature_id": fire_feature,
+        "contract_chain": {
+            "陆逊_canonical_signature": default_skill.get("陆逊"),
+            "烈火张天_provider_relationships": matching_relationships(
+                "烈火张天", "provides"
+            ),
+            "火烧连营_consumer_relationships": matching_relationships(
+                "火烧连营", "benefits_from"
+            ),
+            "activates_expected_feature": (
+                default_skill.get("陆逊") == "火烧连营"
+                and bool(matching_relationships("烈火张天", "provides"))
+                and bool(matching_relationships("火烧连营", "benefits_from"))
+            ),
+        },
+        "observational_counts_full_corpus": {
+            "陆逊_plus_烈火张天": {
+                "observed_teams": lu_xun_liehuo_teams,
+                "activated_teams": lu_xun_liehuo_activated,
+                "by_烈火张天_carrier": {
+                    carrier: carrier_counts[carrier]
+                    for carrier in sorted(carrier_counts)
+                },
+            },
+            "张昭_plus_烈火张天_without_陆逊_or_other_fire_consumer": {
+                "observed_teams": zhang_without_consumer_teams,
+                "activated_teams": zhang_without_consumer_activated,
+            },
+            "陆逊_without_distinct_fire_provider": {
+                "observed_teams": lu_xun_without_distinct_provider_teams,
+                "activated_teams": lu_xun_without_distinct_provider_activated,
+            },
+        },
+        "first_observed_陆逊_烈火张天_witness": example,
+        "interpretation": (
+            "MECH attributes the indirect team relationship through 陆逊's "
+            "canonical 火烧连营 signature. It does not claim 张昭 personally "
+            "requires 烈火张天, and the fitted coefficient is an observational "
+            "residual association rather than causal proof or a hard rule."
+        ),
+    }
+
+
 def evaluate_protocol(
     battles: Sequence[Battle],
     default_skill: Mapping[str, str],
@@ -1139,10 +1538,14 @@ def evaluate_protocol(
     locked_test_manifest: Mapping[str, Any],
     *,
     relationships: CatalogRelationships | None = None,
+    mechanics: MechanicsContract | None = None,
     catalog_version: str,
     c_candidates: Sequence[float] = C_CANDIDATES,
     single_support_candidates: Sequence[int] = SINGLE_SUPPORT_CANDIDATES,
     pair_support_candidates: Sequence[int] = PAIR_SUPPORT_CANDIDATES,
+    mech_certainty_candidates: Sequence[str] = MECH_CERTAINTY_CANDIDATES,
+    mech_support_candidates: Sequence[int] = MECH_SUPPORT_CANDIDATES,
+    mech_shrinkage_candidates: Sequence[float] = MECH_SHRINKAGE_CANDIDATES,
     selection_prior_hero_strength_candidates: Sequence[float] = (
         SELECTION_PRIOR_HERO_STRENGTH_CANDIDATES
     ),
@@ -1177,6 +1580,7 @@ def evaluate_protocol(
                 default_skill,
                 catalog_seasons,
                 relationships,
+                mechanics,
             )
             cache[config] = rows
         return rows
@@ -1282,18 +1686,19 @@ def evaluate_protocol(
         selection_prior_log_ratio_clip=SELECTION_PRIOR_LOG_RATIO_CLIP,
     )
 
-    # Staged identity-only context ablation. Each stage varies one bounded
-    # family/support decision on development rows only; the locked test is not
-    # touched until the final stage has been selected.
-    current_production_config = EvaluationConfig(
+    # Staged context ablation. Each stage varies one bounded family/support
+    # decision on development rows only; the locked test is not touched until
+    # every stage, including evaluation-only MECH, has been selected.
+    pre_context_baseline_config = EvaluationConfig(
         include_ths_tsp=False,
         include_hc_b=False,
+        include_mech=False,
         include_ht=False,
         include_ts3=False,
     )
     context_configs = [
         replace(
-            current_production_config,
+            pre_context_baseline_config,
             include_ths_tsp=True,
             min_support_team_context=support_floor,
             team_context_shrinkage=shrinkage,
@@ -1317,16 +1722,49 @@ def evaluate_protocol(
         relationship_configs,
         key=lambda config: _selection_sort_key(config, development_rows(config)),
     )
-    ht_enabled_configs = [
+    mech_enabled_configs = [
         replace(
             best_relationship_config,
+            include_mech=True,
+            mech_certainty_mode=certainty_mode,
+            min_support_mechanic=support_floor,
+            mechanic_shrinkage=shrinkage,
+            min_mechanic_pair_diversity=MIN_MECHANIC_PAIR_DIVERSITY,
+        )
+        for certainty_mode in sorted(set(mech_certainty_candidates))
+        for support_floor in sorted(set(mech_support_candidates))
+        for shrinkage in sorted(set(mech_shrinkage_candidates))
+    ] if mechanics is not None else []
+    best_enabled_mech_config = (
+        min(
+            mech_enabled_configs,
+            key=lambda config: _selection_sort_key(
+                config,
+                development_rows(config),
+            ),
+        )
+        if mech_enabled_configs
+        else None
+    )
+    best_mech_config = (
+        _select_calibrated_optional_config(
+            best_relationship_config,
+            mech_enabled_configs,
+            development_rows,
+        )
+        if mech_enabled_configs
+        else best_relationship_config
+    )
+    ht_enabled_configs = [
+        replace(
+            best_mech_config,
             include_ht=True,
             min_support_high_order=support_floor,
         )
         for support_floor in HERO_TRIO_SUPPORT_CANDIDATES
     ]
     best_ht_config = _select_calibrated_optional_config(
-        best_relationship_config,
+        best_mech_config,
         ht_enabled_configs,
         development_rows,
     )
@@ -1347,7 +1785,10 @@ def evaluate_protocol(
     final_train_indices = tuple(
         sorted((*split.train_indices, *split.development_indices))
     )
-    production_config = current_production_config
+    # The locked comparison is final selected versus the actual reviewed
+    # production configuration. MECH remains disabled in both runtime code and
+    # this production baseline regardless of the development decision.
+    production_config = EvaluationConfig()
     selected_test = _fit_and_predict(
         selected_config,
         final_train_indices,
@@ -1357,7 +1798,9 @@ def evaluate_protocol(
         default_skill,
         catalog_seasons,
         relationships,
+        mechanics,
         test_group_ids=split.test_group_ids,
+        mechanic_selection_indices=split.train_indices,
     )
     production_test = _fit_and_predict(
         production_config,
@@ -1368,7 +1811,9 @@ def evaluate_protocol(
         default_skill,
         catalog_seasons,
         relationships,
+        mechanics,
         test_group_ids=split.test_group_ids,
+        mechanic_selection_indices=split.train_indices,
     )
 
     pre_yanwu_train_indices = tuple(
@@ -1385,6 +1830,7 @@ def evaluate_protocol(
         default_skill,
         catalog_seasons,
         relationships,
+        mechanics,
         test_group_ids=split.test_group_ids,
     )
     controlled_candidate = production_test
@@ -1412,6 +1858,117 @@ def evaluate_protocol(
 
     no_prior_rows = development_rows(no_prior_config)
     production_prior_rows = development_rows(production_prior_config)
+    training_battles = [battles[index] for index in split.train_indices]
+    if mechanics is None or best_enabled_mech_config is None:
+        mechanic_report: dict[str, Any] = {
+            "decision": "disabled_no_validated_mechanics_contract",
+            "selected_configuration": None,
+            "candidates": [],
+        }
+    else:
+        baseline_mech_rows = development_rows(best_relationship_config)
+        best_enabled_mech_rows = development_rows(best_enabled_mech_config)
+        selected_mech_rows = development_rows(best_mech_config)
+        mechanic_report = {
+            "decision": (
+                "enabled_by_development_calibration_gate"
+                if best_mech_config.include_mech
+                else "disabled_by_development_calibration_gate"
+            ),
+            "gate": (
+                "MECH may be enabled only when both development log loss and "
+                "Brier score improve; accuracy is descriptive only"
+            ),
+            "catalog_sha256": mechanics.catalog_sha256,
+            "selected_configuration": (
+                {
+                    "certainty_mode": best_mech_config.mech_certainty_mode,
+                    "min_support_mechanic": best_mech_config.min_support_mechanic,
+                    "mechanic_shrinkage": best_mech_config.mechanic_shrinkage,
+                    "min_mechanic_pair_diversity": (
+                        best_mech_config.min_mechanic_pair_diversity
+                    ),
+                }
+                if best_mech_config.include_mech
+                else None
+            ),
+            "best_enabled_configuration": {
+                "certainty_mode": best_enabled_mech_config.mech_certainty_mode,
+                "min_support_mechanic": (
+                    best_enabled_mech_config.min_support_mechanic
+                ),
+                "mechanic_shrinkage": (
+                    best_enabled_mech_config.mechanic_shrinkage
+                ),
+                "min_mechanic_pair_diversity": (
+                    best_enabled_mech_config.min_mechanic_pair_diversity
+                ),
+            },
+            "baseline_development": _selection_summary(
+                best_relationship_config,
+                baseline_mech_rows,
+            ),
+            "selected_development": _selection_summary(
+                best_mech_config,
+                selected_mech_rows,
+            ),
+            "selected_minus_baseline_development": _paired_delta_report(
+                selected_mech_rows,
+                baseline_mech_rows,
+                bootstrap_samples=bootstrap_samples,
+            ),
+            "best_enabled_minus_baseline_development": _paired_delta_report(
+                best_enabled_mech_rows,
+                baseline_mech_rows,
+                bootstrap_samples=bootstrap_samples,
+            ),
+            "candidates": [
+                {
+                    "certainty_mode": config.mech_certainty_mode,
+                    "min_support_mechanic": config.min_support_mechanic,
+                    "mechanic_shrinkage": config.mechanic_shrinkage,
+                    "min_mechanic_pair_diversity": (
+                        config.min_mechanic_pair_diversity
+                    ),
+                    "development": _selection_summary(
+                        config,
+                        development_rows(config),
+                    ),
+                    "feature_counts": {
+                        key: value
+                        for key, value in development_rows(
+                            config
+                        ).mechanic_diagnostics.items()
+                        if key != "features"
+                    },
+                }
+                for config in mech_enabled_configs
+            ],
+            "training_only_certainty_coverage": _mechanic_training_coverage(
+                training_battles,
+                default_skill,
+                mechanics,
+            ),
+            "best_enabled_feature_diagnostics": (
+                best_enabled_mech_rows.mechanic_diagnostics
+            ),
+            "final_selected_development_feature_diagnostics": (
+                development_rows(selected_config).mechanic_diagnostics
+            ),
+            "final_refit_feature_diagnostics": (
+                selected_test.mechanic_diagnostics
+            ),
+            "火攻_audit": _fire_mechanic_audit(
+                battles,
+                default_skill,
+                mechanics,
+            ),
+            "interpretation": (
+                "A positive M coefficient is an average residual observational "
+                "association after existing identity features. It is not causal "
+                "proof and is not a hard recommendation rule."
+            ),
+        }
     report = {
         "protocol": {
             "version": EVALUATION_PROTOCOL_VERSION,
@@ -1434,7 +1991,10 @@ def evaluate_protocol(
                 "merged through exact/near-duplicate matchup clusters"
             ),
             "split_membership_excludes": ["season", "winner", "outcome"],
-            "selection_data": "training and development groups only",
+            "selection_data": (
+                "configuration choice uses development metrics; feature support, "
+                "MECH pair diversity, and witness ranking use training rows only"
+            ),
             "locked_test_use": "one final evaluation after configuration selection",
             "session_gap_seconds": SESSION_GAP_SECONDS,
             "calendar_day_grouping": False,
@@ -1460,6 +2020,9 @@ def evaluate_protocol(
             "catalog_version": catalog_version,
             "relationship_version": (
                 relationships.relationship_version if relationships is not None else None
+            ),
+            "mech_catalog_sha256_evaluation_only": (
+                mechanics.catalog_sha256 if mechanics is not None else None
             ),
             "n_battles": len(battles),
             "n_groups": len(set(group_ids)),
@@ -1499,7 +2062,7 @@ def evaluate_protocol(
         },
         "production_model": {
             "changed": EvaluationConfig().as_dict() != production_config.as_dict(),
-            "current_pre_pr_config": production_config.as_dict(),
+            "current_production_config": production_config.as_dict(),
             "reviewed_code_config": EvaluationConfig().as_dict(),
             "development_selected_config": selected_config.as_dict(),
             "atomic_support_buckets": production_test.atomic_diagnostics,
@@ -1548,9 +2111,9 @@ def evaluate_protocol(
             "selected_candidate": selected_config.as_dict(),
             "staged_team_context_ablations": {
                 "selection_data": "development rows only",
-                "stage_1_current_production_baseline": _selection_summary(
-                    current_production_config,
-                    development_rows(current_production_config),
+                "stage_1_pre_context_baseline": _selection_summary(
+                    pre_context_baseline_config,
+                    development_rows(pre_context_baseline_config),
                 ),
                 "stage_2_plus_ths_tsp": {
                     "selected": _selection_summary(
@@ -1563,7 +2126,7 @@ def evaluate_protocol(
                     ],
                     "selected_minus_previous": _paired_delta_report(
                         development_rows(best_context_config),
-                        development_rows(current_production_config),
+                        development_rows(pre_context_baseline_config),
                         bootstrap_samples=bootstrap_samples,
                     ),
                 },
@@ -1582,10 +2145,10 @@ def evaluate_protocol(
                         bootstrap_samples=bootstrap_samples,
                     ),
                 },
-                "stage_4_ht": {
+                "stage_4_mech": {
                     "selected": _selection_summary(
-                        best_ht_config,
-                        development_rows(best_ht_config),
+                        best_mech_config,
+                        development_rows(best_mech_config),
                     ),
                     "disabled": _selection_summary(
                         best_relationship_config,
@@ -1593,15 +2156,34 @@ def evaluate_protocol(
                     ),
                     "enabled_candidates": [
                         _selection_summary(config, development_rows(config))
-                        for config in ht_enabled_configs
+                        for config in mech_enabled_configs
                     ],
                     "selected_minus_previous": _paired_delta_report(
-                        development_rows(best_ht_config),
+                        development_rows(best_mech_config),
                         development_rows(best_relationship_config),
                         bootstrap_samples=bootstrap_samples,
                     ),
                 },
-                "stage_5_ts3": {
+                "stage_5_ht": {
+                    "selected": _selection_summary(
+                        best_ht_config,
+                        development_rows(best_ht_config),
+                    ),
+                    "disabled": _selection_summary(
+                        best_mech_config,
+                        development_rows(best_mech_config),
+                    ),
+                    "enabled_candidates": [
+                        _selection_summary(config, development_rows(config))
+                        for config in ht_enabled_configs
+                    ],
+                    "selected_minus_previous": _paired_delta_report(
+                        development_rows(best_ht_config),
+                        development_rows(best_mech_config),
+                        bootstrap_samples=bootstrap_samples,
+                    ),
+                },
+                "stage_6_ts3": {
                     "selected": _selection_summary(
                         selected_config,
                         development_rows(selected_config),
@@ -1675,6 +2257,7 @@ def evaluate_protocol(
                 ),
             },
         },
+        "mechanic_evaluation": mechanic_report,
         "targeted_diagnostics": _targeted_context_diagnostics(
             battles,
             final_train_indices,
@@ -1812,6 +2395,10 @@ def main(argv: list[str] | None = None) -> int:
         default="web/public/game-data/database.json",
     )
     parser.add_argument(
+        "--mech-catalog",
+        default="web/public/game-data/mech.json",
+    )
+    parser.add_argument(
         "--yanwu-manifest",
         type=Path,
         default=root / "data/external/yanwu-release.json",
@@ -1848,11 +2435,18 @@ def main(argv: list[str] | None = None) -> int:
             manifest,
             args.yanwu_cache_dir,
         )
-        battles, catalog, catalog_seasons, relationships = _load_evaluation_corpus(
+        (
+            battles,
+            catalog,
+            catalog_seasons,
+            relationships,
+            mechanics,
+        ) = _load_evaluation_corpus(
             args.battles_dir,
             args.web_upload_dir,
             args.web_upload_state,
             args.database,
+            args.mech_catalog,
             str(yanwu_corpus),
             str(args.yanwu_manifest),
         )
@@ -1862,6 +2456,7 @@ def main(argv: list[str] | None = None) -> int:
             catalog_seasons,
             locked_test_manifest,
             relationships=relationships,
+            mechanics=mechanics,
             catalog_version=catalog["catalog_version"],
             bootstrap_samples=args.bootstrap_samples,
         )

--- a/data/evaluation/MECH_EVALUATION.md
+++ b/data/evaluation/MECH_EVALUATION.md
@@ -24,13 +24,16 @@ PR A applies the following contract:
   excluded.
 - Mechanic IDs must be exactly equal. No registry-category ancestry is inferred.
 - Active instances are each hero's canonical signature from `default_skill`
-  plus every valid equipped tactic returned by the existing
-  `_non_default_skills` logic. OCR slot zero is not semantic input.
-- Signature tactics participate only in M. They remain excluded from `S`, `HS`,
-  `SP`, `THS`, `TSP`, selection counts, and all other ordinary tactic families.
-- Provider and consumer must be distinct skill instances. Distinct instances
-  with the same skill name may interact, while diversity remains the ordered
-  `(provider skill name, consumer skill name)` pair.
+  plus both validated equipped slots in capture order. OCR slot zero is not
+  semantic input. The M boundary neither name-filters nor deduplicates equipped
+  slots, so an equipped copy of a signature or another equipped tactic remains
+  a separate instance.
+- Signature tactics participate only in M. Ordinary tactic families continue to
+  use `_non_default_skills`, so signatures remain excluded from `S`, `HS`, `SP`,
+  `THS`, `TSP`, selection counts, and all other ordinary tactic families.
+- Provider and consumer must have different stable carrier/slot identities.
+  Distinct instances with the same skill name may interact, while diversity
+  remains the ordered `(provider skill name, consumer skill name)` pair.
 - Subjects are resolved relative to each carrier: `self` is the carrier,
   `ally` is the other two heroes, `team` is all three heroes, `enemy` is one
   abstract `ENEMY_TEAM`, `any` is all friendly heroes plus `ENEMY_TEAM`, and
@@ -87,24 +90,24 @@ Brier **0.213965**.
 
 | Certainty | Support | Shrink | Features | Accuracy | Log loss | Brier |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `all_reviewed` | 12 | 0.25 | 8,097 | 0.696181 | 0.651304 | 0.213343 |
-| `all_reviewed` | 12 | 0.50 | 8,097 | 0.694444 | 0.651911 | 0.213483 |
-| `all_reviewed` | 12 | 0.75 | 8,097 | 0.696181 | 0.652624 | 0.213652 |
-| `all_reviewed` | 20 | 0.25 | 8,095 | 0.696181 | 0.651296 | 0.213335 |
-| `all_reviewed` | 20 | 0.50 | 8,095 | 0.694444 | 0.651910 | 0.213474 |
-| `all_reviewed` | 20 | 0.75 | 8,095 | 0.696181 | 0.652628 | 0.213642 |
-| `all_reviewed` | 30 | 0.25 | 8,094 | 0.696181 | 0.651289 | 0.213346 |
-| `all_reviewed` | 30 | 0.50 | 8,094 | 0.694444 | 0.651861 | 0.213490 |
-| `all_reviewed` | 30 | 0.75 | 8,094 | 0.696181 | 0.652537 | 0.213662 |
-| `explicit_only` | 12 | 0.25 | 8,096 | 0.696181 | 0.652832 | 0.213573 |
-| `explicit_only` | 12 | 0.50 | 8,096 | 0.696181 | 0.653026 | 0.213708 |
-| `explicit_only` | 12 | 0.75 | 8,096 | 0.697917 | 0.653263 | 0.213854 |
-| `explicit_only` | 20 | 0.25 | 8,094 | 0.696181 | 0.652824 | 0.213566 |
-| `explicit_only` | 20 | 0.50 | 8,094 | 0.696181 | 0.653025 | 0.213699 |
-| `explicit_only` | 20 | 0.75 | 8,094 | 0.697917 | 0.653268 | 0.213844 |
-| `explicit_only` | 30 | 0.25 | 8,093 | 0.697917 | 0.652816 | 0.213577 |
-| `explicit_only` | 30 | 0.50 | 8,093 | 0.696181 | 0.652976 | 0.213715 |
-| `explicit_only` | 30 | 0.75 | 8,093 | 0.697917 | 0.653177 | 0.213864 |
+| `all_reviewed` | 12 | 0.25 | 8,097 | 0.695312 | 0.651281 | 0.213336 |
+| `all_reviewed` | 12 | 0.50 | 8,097 | 0.694444 | 0.651895 | 0.213477 |
+| `all_reviewed` | 12 | 0.75 | 8,097 | 0.696181 | 0.652615 | 0.213648 |
+| `all_reviewed` | 20 | 0.25 | 8,095 | 0.696181 | 0.651273 | 0.213328 |
+| `all_reviewed` | 20 | 0.50 | 8,095 | 0.694444 | 0.651893 | 0.213468 |
+| `all_reviewed` | 20 | 0.75 | 8,095 | 0.696181 | 0.652619 | 0.213638 |
+| `all_reviewed` | 30 | 0.25 | 8,094 | 0.696181 | 0.651265 | 0.213340 |
+| `all_reviewed` | 30 | 0.50 | 8,094 | 0.694444 | 0.651844 | 0.213484 |
+| `all_reviewed` | 30 | 0.75 | 8,094 | 0.696181 | 0.652529 | 0.213658 |
+| `explicit_only` | 12 | 0.25 | 8,096 | 0.696181 | 0.652812 | 0.213567 |
+| `explicit_only` | 12 | 0.50 | 8,096 | 0.696181 | 0.653014 | 0.213704 |
+| `explicit_only` | 12 | 0.75 | 8,096 | 0.697917 | 0.653258 | 0.213851 |
+| `explicit_only` | 20 | 0.25 | 8,094 | 0.696181 | 0.652805 | 0.213560 |
+| `explicit_only` | 20 | 0.50 | 8,094 | 0.696181 | 0.653013 | 0.213695 |
+| `explicit_only` | 20 | 0.75 | 8,094 | 0.697917 | 0.653263 | 0.213841 |
+| `explicit_only` | 30 | 0.25 | 8,093 | 0.697917 | 0.652797 | 0.213571 |
+| `explicit_only` | 30 | 0.50 | 8,093 | 0.696181 | 0.652964 | 0.213710 |
+| `explicit_only` | 30 | 0.75 | 8,093 | 0.697917 | 0.653173 | 0.213861 |
 
 The deterministic ordering selected **`all_reviewed`, support 30, shrinkage
 0.25, pair diversity 2**. Relative to the disabled M baseline, development
@@ -114,13 +117,13 @@ conservative requirement that both calibration metrics improve.
 
 After M selection, support-50 `HT` also cleared its existing gate. `TS3`
 remained disabled. The final development configuration had 8,111 features,
-accuracy **0.693576**, log loss **0.650631**, and Brier **0.213092**.
+accuracy **0.693576**, log loss **0.650608**, and Brier **0.213085**.
 
 ## Coverage, support, and witness diversity
 
 On original training rows, both certainty modes emitted 25 feature IDs.
-`explicit_only` activated 3,399 battles / 4,270 teams; `all_reviewed` activated
-4,285 battles / 5,979 teams. Under the selected support-30/diversity-2 policy:
+`explicit_only` activated 3,400 battles / 4,271 teams; `all_reviewed` activated
+4,286 battles / 5,980 teams. Under the selected support-30/diversity-2 policy:
 
 - emitted M features: **25**
 - support-qualified M features: **16**
@@ -134,25 +137,28 @@ and pair diversity remain frozen to original training rows.
 
 | Feature | Train support | Ordered pairs | Weight |
 | --- | ---: | ---: | ---: |
-| `M|buff:di_yu|benefits_from|friendly` | 340 | 9 | -0.003248936 |
-| `M|buff:di_yu|requires|friendly` | 292 | 10 | +0.007664798 |
-| `M|buff:gong_neng_xing_zeng_yi_zhuang_tai|benefits_from|friendly` | 427 | 16 | +0.011844788 |
-| `M|buff:gui_bi|benefits_from|friendly` | 140 | 4 | +0.032656845 |
-| `M|buff:gui_bi|requires|friendly` | 211 | 4 | +0.021339818 |
-| `M|buff:hui_xin|requires|friendly` | 344 | 6 | -0.001077420 |
-| `M|buff:qi_mou|benefits_from|friendly` | 59 | 6 | +0.028877811 |
-| `M|debuff:duan_liang|benefits_from|enemy` | 162 | 13 | +0.013622592 |
-| `M|debuff:duan_liang|requires|enemy` | 84 | 5 | -0.003765911 |
-| `M|debuff:feng_bao|benefits_from|enemy` | 420 | 9 | -0.042910738 |
-| `M|debuff:hong_shui|benefits_from|enemy` | 100 | 10 | +0.009486343 |
-| `M|debuff:hun_luan|benefits_from|enemy` | 40 | 6 | -0.021573505 |
-| `M|debuff:huo_gong|benefits_from|enemy` | 903 | 18 | +0.020666341 |
-| `M|debuff:shu_xing_jiang_di_zhuang_tai|benefits_from|enemy` | 1,556 | 41 | +0.067865599 |
-| `M|debuff:wei_ju|benefits_from|enemy` | 967 | 32 | -0.020040603 |
-| `M|debuff:yao_shu|benefits_from|enemy` | 756 | 8 | +0.016144639 |
+| `M|buff:di_yu|benefits_from|friendly` | 340 | 9 | -0.003243217 |
+| `M|buff:di_yu|requires|friendly` | 292 | 10 | +0.007674193 |
+| `M|buff:gong_neng_xing_zeng_yi_zhuang_tai|benefits_from|friendly` | 427 | 16 | +0.011851019 |
+| `M|buff:gui_bi|benefits_from|friendly` | 140 | 4 | +0.032658963 |
+| `M|buff:gui_bi|requires|friendly` | 211 | 5 | +0.021336632 |
+| `M|buff:hui_xin|requires|friendly` | 344 | 6 | -0.001069491 |
+| `M|buff:qi_mou|benefits_from|friendly` | 59 | 6 | +0.028887623 |
+| `M|debuff:duan_liang|benefits_from|enemy` | 162 | 13 | +0.013621836 |
+| `M|debuff:duan_liang|requires|enemy` | 84 | 5 | -0.003772382 |
+| `M|debuff:feng_bao|benefits_from|enemy` | 420 | 9 | -0.042927737 |
+| `M|debuff:hong_shui|benefits_from|enemy` | 100 | 10 | +0.009491967 |
+| `M|debuff:hun_luan|benefits_from|enemy` | 40 | 6 | -0.021568905 |
+| `M|debuff:huo_gong|benefits_from|enemy` | 903 | 18 | +0.020679097 |
+| `M|debuff:shu_xing_jiang_di_zhuang_tai|benefits_from|enemy` | 1,556 | 41 | +0.067881907 |
+| `M|debuff:wei_ju|benefits_from|enemy` | 967 | 32 | -0.020043158 |
+| `M|debuff:yao_shu|benefits_from|enemy` | 757 | 9 | +0.017458309 |
 
-The ignored JSON report retains deterministic per-feature support, pair counts,
-post-shrink weights, and up to five top ordered witness pairs for review.
+The accepted `2025-09-27-112353.json` training battle now contributes the
+ordered `(妖风大作, 妖风大作)` witness because 张宝's canonical signature and
+equipped slot are distinct instances. The ignored JSON report retains
+deterministic per-feature support, pair counts, post-shrink weights, and up to
+five top ordered witness pairs for review.
 
 ## 火攻 audit
 
@@ -179,7 +185,7 @@ Across the complete observational corpus:
 - **0 / 52** teams containing 陆逊 without a distinct 火攻 provider activated
   it, confirming that 火烧连营 does not satisfy its own provider/consumer loop.
 - The selected 火攻 feature had training support **903**, **18** distinct
-  ordered witness pairs, and final-refit weight **+0.020666341**. The specific
+  ordered witness pairs, and final-refit weight **+0.020679097**. The specific
   `(烈火张天, 火烧连营)` witness occurred in **214** training battles.
 
 MECH explains why a team containing 张昭, 陆逊, and 烈火张天 can have an

--- a/data/evaluation/MECH_EVALUATION.md
+++ b/data/evaluation/MECH_EVALUATION.md
@@ -25,12 +25,14 @@ PR A applies the following contract:
 - Mechanic IDs must be exactly equal. No registry-category ancestry is inferred.
 - Active instances are each hero's canonical signature from `default_skill`
   plus both validated equipped slots in capture order. OCR slot zero is not
-  semantic input. The M boundary neither name-filters nor deduplicates equipped
-  slots, so an equipped copy of a signature or another equipped tactic remains
-  a separate instance.
-- Signature tactics participate only in M. Ordinary tactic families continue to
-  use `_non_default_skills`, so signatures remain excluded from `S`, `HS`, `SP`,
-  `THS`, `TSP`, selection counts, and all other ordinary tactic families.
+  semantic M input. The M boundary neither name-filters nor deduplicates
+  equipped slots, so an equipped copy of a signature or another equipped tactic
+  remains a separate instance.
+- Canonical signature instances participate only in M. Ordinary tactic families
+  continue to use `_non_default_skills`, which excludes slot zero and the
+  current carrier's canonical signature by name. An observed signature transfer
+  in another carrier's equipped slot retains its existing ordinary-tactic
+  behavior.
 - Provider and consumer must have different stable carrier/slot identities.
   Distinct instances with the same skill name may interact, while diversity
   remains the ordered `(provider skill name, consumer skill name)` pair.
@@ -83,8 +85,8 @@ scored only after all staged choices were complete.
 
 ## Candidate grid and development results
 
-The M stage followed `THS`/`TSP` and `HC`/`B`, and preceded `HT` and `TS3`.
-All candidates fixed minimum pair diversity at 2. The preceding `HC`/`B`
+The 18-candidate M stage followed `THS`/`TSP` and `HC`/`B`, and preceded `HT`
+and `TS3`. All candidates fixed minimum pair diversity at 2. The preceding `HC`/`B`
 baseline had 8,078 features, accuracy **0.696181**, log loss **0.653495**, and
 Brier **0.213965**.
 

--- a/data/evaluation/MECH_EVALUATION.md
+++ b/data/evaluation/MECH_EVALUATION.md
@@ -1,0 +1,227 @@
+# Evaluation-only MECH feature decision (PR A)
+
+This note records the evaluation decision for reviewed mechanic relationships.
+The model remains the paired logistic / Bradley–Terry model. MECH is **not**
+enabled in production by this change: no browser scoring, runtime schema,
+telemetry label, production support floor, or production weight changed.
+
+A positive MECH coefficient is an average residual association after the
+existing identity features. It is observational, not causal proof and not a
+hard recommendation rule.
+
+## Feature contract
+
+The evaluation-only family is `M`, with binary feature IDs:
+
+```text
+M|<exact-mechanic-id>|<consumer-relation>|<target-side>
+```
+
+PR A applies the following contract:
+
+- The source relationship must be `provides`; consumer relationships are only
+  `benefits_from`, `requires`, and `consumes`. `removes` and `prevents` are
+  excluded.
+- Mechanic IDs must be exactly equal. No registry-category ancestry is inferred.
+- Active instances are each hero's canonical signature from `default_skill`
+  plus every valid equipped tactic returned by the existing
+  `_non_default_skills` logic. OCR slot zero is not semantic input.
+- Signature tactics participate only in M. They remain excluded from `S`, `HS`,
+  `SP`, `THS`, `TSP`, selection counts, and all other ordinary tactic families.
+- Provider and consumer must be distinct skill instances. Distinct instances
+  with the same skill name may interact, while diversity remains the ordered
+  `(provider skill name, consumer skill name)` pair.
+- Subjects are resolved relative to each carrier: `self` is the carrier,
+  `ally` is the other two heroes, `team` is all three heroes, `enemy` is one
+  abstract `ENEMY_TEAM`, `any` is all friendly heroes plus `ENEMY_TEAM`, and
+  `unknown` has no targets. A pair matches only when its target sets intersect.
+  An enemy intersection emits `enemy`, a friendly-hero intersection emits
+  `friendly`, and both are emitted when both genuinely intersect.
+- Features are presence encoded, so multiple witnesses do not increase feature
+  magnitude.
+- M is available only for one concrete team with exactly three distinct heroes.
+  Partial teams, offered/support pools, flattened collections, and cross-team
+  relationships cannot emit M.
+- `explicit_only` requires both relationships to be explicit.
+  `all_reviewed` admits explicit and inferred reviewed relationships.
+- Support is the number of original training battles where a feature appears on
+  either side, at most once per battle. Selection also requires at least two
+  distinct ordered skill-name witness pairs. Development and locked-test rows
+  are excluded from M support, pair diversity, feature selection, and witness
+  ranking, including when final coefficients are refit on training plus
+  development.
+
+Evaluation loads `mech.json` through the canonical validator in
+`manage_mech_catalog.py`, then applies a stricter zero-unresolved rule. Duplicate
+JSON keys, unsupported schema, stale registry/source hashes, incomplete or
+mismatched skill coverage, pending entries, unknown mechanics, invalid enums,
+and any unresolved entry fail closed before fitting.
+
+## Dataset and split protocol
+
+The run used the existing season-independent grouped stable-hash protocol and
+catalog/corpus state at this commit:
+
+- Corpus: **7,836 battles**, **3,246 leakage groups**
+- Training: **5,511 battles**, **2,584 groups**
+- Development: **1,152 battles**, **646 groups**
+- Locked pre-Yanwu test: **1,173 battles**, **16 persisted groups**
+- Corpus version: `36563473f49bd020`
+- Evaluation version: `c5560936635944bb`
+- Catalog version: `ed3db0590240`
+- MECH catalog SHA-256:
+  `961dadb2ca09bd84b3f3c88fcbb0114c92e22a5804421ecb51672859ca1716de`
+
+Capture/upload sessions and stable external report identities were merged
+through exact/near-duplicate matchup clusters. Season, winner, and outcome did
+not determine split membership. Configuration selection used development rows;
+M support and diversity used only original training rows. The locked test was
+scored only after all staged choices were complete.
+
+## Candidate grid and development results
+
+The M stage followed `THS`/`TSP` and `HC`/`B`, and preceded `HT` and `TS3`.
+All candidates fixed minimum pair diversity at 2. The preceding `HC`/`B`
+baseline had 8,078 features, accuracy **0.696181**, log loss **0.653495**, and
+Brier **0.213965**.
+
+| Certainty | Support | Shrink | Features | Accuracy | Log loss | Brier |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `all_reviewed` | 12 | 0.25 | 8,097 | 0.696181 | 0.651304 | 0.213343 |
+| `all_reviewed` | 12 | 0.50 | 8,097 | 0.694444 | 0.651911 | 0.213483 |
+| `all_reviewed` | 12 | 0.75 | 8,097 | 0.696181 | 0.652624 | 0.213652 |
+| `all_reviewed` | 20 | 0.25 | 8,095 | 0.696181 | 0.651296 | 0.213335 |
+| `all_reviewed` | 20 | 0.50 | 8,095 | 0.694444 | 0.651910 | 0.213474 |
+| `all_reviewed` | 20 | 0.75 | 8,095 | 0.696181 | 0.652628 | 0.213642 |
+| `all_reviewed` | 30 | 0.25 | 8,094 | 0.696181 | 0.651289 | 0.213346 |
+| `all_reviewed` | 30 | 0.50 | 8,094 | 0.694444 | 0.651861 | 0.213490 |
+| `all_reviewed` | 30 | 0.75 | 8,094 | 0.696181 | 0.652537 | 0.213662 |
+| `explicit_only` | 12 | 0.25 | 8,096 | 0.696181 | 0.652832 | 0.213573 |
+| `explicit_only` | 12 | 0.50 | 8,096 | 0.696181 | 0.653026 | 0.213708 |
+| `explicit_only` | 12 | 0.75 | 8,096 | 0.697917 | 0.653263 | 0.213854 |
+| `explicit_only` | 20 | 0.25 | 8,094 | 0.696181 | 0.652824 | 0.213566 |
+| `explicit_only` | 20 | 0.50 | 8,094 | 0.696181 | 0.653025 | 0.213699 |
+| `explicit_only` | 20 | 0.75 | 8,094 | 0.697917 | 0.653268 | 0.213844 |
+| `explicit_only` | 30 | 0.25 | 8,093 | 0.697917 | 0.652816 | 0.213577 |
+| `explicit_only` | 30 | 0.50 | 8,093 | 0.696181 | 0.652976 | 0.213715 |
+| `explicit_only` | 30 | 0.75 | 8,093 | 0.697917 | 0.653177 | 0.213864 |
+
+The deterministic ordering selected **`all_reviewed`, support 30, shrinkage
+0.25, pair diversity 2**. Relative to the disabled M baseline, development
+accuracy was unchanged, log loss improved by approximately **-0.0022**, and
+Brier improved by approximately **-0.0006**. It therefore cleared the
+conservative requirement that both calibration metrics improve.
+
+After M selection, support-50 `HT` also cleared its existing gate. `TS3`
+remained disabled. The final development configuration had 8,111 features,
+accuracy **0.693576**, log loss **0.650631**, and Brier **0.213092**.
+
+## Coverage, support, and witness diversity
+
+On original training rows, both certainty modes emitted 25 feature IDs.
+`explicit_only` activated 3,399 battles / 4,270 teams; `all_reviewed` activated
+4,285 battles / 5,979 teams. Under the selected support-30/diversity-2 policy:
+
+- emitted M features: **25**
+- support-qualified M features: **16**
+- diversity-qualified M features: **20**
+- selected M features: **16**
+- selected-feature support range: **40–1,556** training battles
+- selected-feature pair-diversity range: **4–41** ordered skill-name pairs
+
+Final-refit coefficients below include the selected 0.25 M shrinkage. Support
+and pair diversity remain frozen to original training rows.
+
+| Feature | Train support | Ordered pairs | Weight |
+| --- | ---: | ---: | ---: |
+| `M|buff:di_yu|benefits_from|friendly` | 340 | 9 | -0.003248936 |
+| `M|buff:di_yu|requires|friendly` | 292 | 10 | +0.007664798 |
+| `M|buff:gong_neng_xing_zeng_yi_zhuang_tai|benefits_from|friendly` | 427 | 16 | +0.011844788 |
+| `M|buff:gui_bi|benefits_from|friendly` | 140 | 4 | +0.032656845 |
+| `M|buff:gui_bi|requires|friendly` | 211 | 4 | +0.021339818 |
+| `M|buff:hui_xin|requires|friendly` | 344 | 6 | -0.001077420 |
+| `M|buff:qi_mou|benefits_from|friendly` | 59 | 6 | +0.028877811 |
+| `M|debuff:duan_liang|benefits_from|enemy` | 162 | 13 | +0.013622592 |
+| `M|debuff:duan_liang|requires|enemy` | 84 | 5 | -0.003765911 |
+| `M|debuff:feng_bao|benefits_from|enemy` | 420 | 9 | -0.042910738 |
+| `M|debuff:hong_shui|benefits_from|enemy` | 100 | 10 | +0.009486343 |
+| `M|debuff:hun_luan|benefits_from|enemy` | 40 | 6 | -0.021573505 |
+| `M|debuff:huo_gong|benefits_from|enemy` | 903 | 18 | +0.020666341 |
+| `M|debuff:shu_xing_jiang_di_zhuang_tai|benefits_from|enemy` | 1,556 | 41 | +0.067865599 |
+| `M|debuff:wei_ju|benefits_from|enemy` | 967 | 32 | -0.020040603 |
+| `M|debuff:yao_shu|benefits_from|enemy` | 756 | 8 | +0.016144639 |
+
+The ignored JSON report retains deterministic per-feature support, pair counts,
+post-shrink weights, and up to five top ordered witness pairs for review.
+
+## 火攻 audit
+
+The contract and observed teams demonstrate the intended indirect relationship:
+
+1. `default_skill[陆逊]` is the signature **火烧连营**.
+2. **烈火张天** explicitly `provides debuff:huo_gong` to `enemy`.
+3. **火烧连营** explicitly `benefits_from debuff:huo_gong` on `enemy`.
+4. Distinct instances therefore activate
+   `M|debuff:huo_gong|benefits_from|enemy`.
+
+The first deterministic observed witness in the report is battle
+`2025-09-06-055203.json`, team 1: 小乔 carries equipped 烈火张天 and 陆逊
+contributes signature 火烧连营.
+
+Across the complete observational corpus:
+
+- **333 / 333** teams containing 陆逊 plus an equipped 烈火张天 activated the
+  feature. 烈火张天 appeared on 35 different carriers; every carrier's observed
+  teams activated it. This included 张昭 (64/64), 孙权 (43/43), 步练师
+  (42/42), 陆逊 himself (5/5), and many lower-count carriers.
+- **0 / 4** teams containing 张昭 plus 烈火张天 but neither 陆逊 nor another
+  火攻 consumer activated it.
+- **0 / 52** teams containing 陆逊 without a distinct 火攻 provider activated
+  it, confirming that 火烧连营 does not satisfy its own provider/consumer loop.
+- The selected 火攻 feature had training support **903**, **18** distinct
+  ordered witness pairs, and final-refit weight **+0.020666341**. The specific
+  `(烈火张天, 火烧连营)` witness occurred in **214** training battles.
+
+MECH explains why a team containing 张昭, 陆逊, and 烈火张天 can have an
+indirect tactic relationship through 陆逊's signature. It does **not** claim
+that 张昭 personally requires 烈火张天.
+
+## Locked-test reporting
+
+After all stages were selected, the final candidate and current production
+configuration were refit and scored on the same locked population. The locked
+population has only 16 leakage groups, so this comparison is exploratory.
+
+| Configuration | Features | Accuracy | Log loss | Brier |
+| --- | ---: | ---: | ---: | ---: |
+| Current production (M disabled) | 9,412 | 0.7400 | 0.5743 | 0.1833 |
+| Final selected evaluation candidate | 9,428 | 0.7417 | 0.5694 | 0.1820 |
+| Candidate minus current | +16 | +0.0017 | -0.0049 | -0.0013 |
+
+Locked results were not used for configuration, support, diversity, feature, or
+witness selection.
+
+## Decision
+
+**MECH passed the development calibration gate** at `all_reviewed`, support 30,
+post-fit shrinkage 0.25, and minimum ordered-pair diversity 2. It is a candidate
+for a separate, explicitly reviewed production PR B.
+
+This PR remains evaluation-only even though the gate passed. A production PR
+would separately need runtime TypeScript extraction/scoring, artifact/schema
+review, browser cost and size analysis, model-version/cache implications, and
+product review. Nothing here automatically modifies production settings.
+
+## Limitations
+
+- Coefficients are observational residual associations and overlap in
+  attribution with `TSP`, `THS`, and `HT`; they are not causal effects.
+- PR A matches exact mechanic IDs only. It does not infer hierarchy such as
+  火攻 → 异常状态 → 负面状态 or 抵御 → 功能性增益状态.
+- `removes` and `prevents` are excluded because defensive counters and
+  self-inflicted statuses need a more careful model.
+- Certainty is a bounded evaluation configuration, not part of feature IDs.
+- Reviewed semantics remain dependent on catalog quality even though freshness,
+  completeness, and resolution fail closed.
+- No TypeScript/runtime support exists. The browser does not load `mech.json`,
+  and production model weights and behavior remain unchanged.

--- a/data/evaluation/TEAM_CONTEXT_EVALUATION.md
+++ b/data/evaluation/TEAM_CONTEXT_EVALUATION.md
@@ -152,9 +152,10 @@ implementation from that PR was ported.
 - `TS3` remains implemented only for evaluation. `TS4`, `TS5`, and `TS6` do not
   exist.
 - HPS/carrier-skill-teammate triples are excluded.
-- MECH remains outside recommendation scoring and this PR-1 decision. Its
-  separate current maintenance contract is documented in the
-  [README](../../README.md#reviewed-mech-catalog). The recommendation path does
-  not read that catalog or perform semantic description parsing, tokenization,
-  Chinese NLP, status/damage/healing extraction, embeddings, or neural-model
-  inference.
+- MECH remains outside production recommendation scoring and this PR-1
+  decision. Its later evaluation-only contract and decision are documented in
+  [MECH_EVALUATION.md](MECH_EVALUATION.md); catalog maintenance remains in the
+  [README](../../README.md#reviewed-mech-catalog). The production recommendation
+  path does not read that catalog or perform semantic description parsing,
+  tokenization, Chinese NLP, status/damage/healing extraction, embeddings, or
+  neural-model inference.

--- a/data/mech_evaluation.py
+++ b/data/mech_evaluation.py
@@ -1,0 +1,82 @@
+"""Strict, evaluation-only contract for reviewed MECH relationships.
+
+The general catalog lifecycle deliberately permits structurally valid unresolved
+items so human review can proceed incrementally. Model evaluation is stricter:
+it reuses the canonical validator and refuses to train unless every reviewed
+skill entry is complete, fresh, and resolved.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping
+
+try:
+    import manage_mech_catalog as catalog_manager
+except ModuleNotFoundError:  # Support ``import data.mech_evaluation``.
+    from . import manage_mech_catalog as catalog_manager
+
+
+@dataclass(frozen=True)
+class MechanicRelationship:
+    """One validated relationship attached to a reviewed skill."""
+
+    relation: str
+    mechanic: str
+    subject: str
+    certainty: str
+
+
+@dataclass(frozen=True)
+class MechanicsContract:
+    """Validated MECH input kept separate from runtime HC/B relationships."""
+
+    skill_relationships: Mapping[str, tuple[MechanicRelationship, ...]]
+    mechanic_ids: frozenset[str]
+    catalog_sha256: str
+
+
+def load_evaluation_mechanics(
+    database_path: str | Path = catalog_manager.DEFAULT_DATABASE,
+    catalog_path: str | Path = catalog_manager.DEFAULT_CATALOG,
+) -> MechanicsContract:
+    """Load the reviewed catalog and fail closed on any partial semantic input.
+
+    ``validate_catalog`` owns duplicate-key rejection, schema/shape checks,
+    registry and source freshness, exact skill coverage, relationship enums,
+    mechanic IDs, evidence, and completion. This adapter adds the evaluation-
+    specific zero-unresolved rule instead of duplicating that validator.
+    """
+
+    database = catalog_manager.load_database(Path(database_path))
+    catalog = catalog_manager.load_catalog(Path(catalog_path))
+    unresolved = catalog_manager.validate_catalog(catalog, database)
+    if unresolved:
+        skill_name, mechanic_name = unresolved[0]
+        raise catalog_manager.CatalogError(
+            "evaluation MECH catalog must have zero unresolved entries; "
+            f"first unresolved item is {skill_name!r}/{mechanic_name!r}"
+        )
+
+    relationships = {
+        skill_name: tuple(
+            MechanicRelationship(
+                relation=str(item["relation"]),
+                mechanic=str(item["mechanic"]),
+                subject=str(item["subject"]),
+                certainty=str(item["certainty"]),
+            )
+            for item in entry["relations"]
+        )
+        for skill_name, entry in sorted(catalog["skills"].items())
+    }
+    catalog_sha256 = hashlib.sha256(
+        catalog_manager.rendered_catalog(catalog)
+    ).hexdigest()
+    return MechanicsContract(
+        skill_relationships=MappingProxyType(relationships),
+        mechanic_ids=frozenset(catalog["mechanics"]),
+        catalog_sha256=catalog_sha256,
+    )

--- a/data/test_mech_evaluation.py
+++ b/data/test_mech_evaluation.py
@@ -185,6 +185,74 @@ def test_fire_signature_cannot_satisfy_its_own_provider_consumer_loop() -> None:
     assert FIRE_FEATURE not in _m_features(team, defaults, contract)
 
 
+def test_canonical_and_equipped_copy_are_distinct_mech_instances() -> None:
+    mechanic = "debuff:yao_shu"
+    feature_id = f"M|{mechanic}|benefits_from|enemy"
+    team = [
+        _hero("张宝", "妖风大作", "妖风大作", "普通甲"),
+        _hero("甲", "甲签", "普通乙", "普通丙"),
+        _hero("乙", "乙签", "普通丁", "普通戊"),
+    ]
+    defaults = {"张宝": "妖风大作", "甲": "甲签", "乙": "乙签"}
+    contract = _empty_contract_for(
+        team,
+        {
+            "妖风大作": (
+                _relation("provides", mechanic),
+                _relation("benefits_from", mechanic),
+            ),
+            "甲签": (),
+            "乙签": (),
+        },
+        mechanics=(mechanic,),
+    )
+
+    instances = active_mechanic_skill_instances(team, defaults, contract)
+    copies = [
+        instance
+        for instance in instances
+        if instance.carrier == "张宝" and instance.skill_name == "妖风大作"
+    ]
+    witnesses = mechanic_feature_witnesses(team, defaults, contract)[feature_id]
+
+    assert [(instance.origin, instance.slot_index) for instance in copies] == [
+        ("signature", 0),
+        ("equipped", 1),
+    ]
+    assert {
+        (witness.provider_slot_index, witness.consumer_slot_index)
+        for witness in witnesses
+        if witness.provider_carrier == witness.consumer_carrier == "张宝"
+    } == {(0, 1), (1, 0)}
+
+
+def test_repeated_equipped_names_retain_distinct_mech_slots() -> None:
+    team = [
+        _hero("甲", "甲签", "循环", "循环"),
+        _hero("乙", "乙签", "普通甲", "普通乙"),
+        _hero("丙", "丙签", "普通丙", "普通丁"),
+    ]
+    defaults = {"甲": "甲签", "乙": "乙签", "丙": "丙签"}
+    contract = _empty_contract_for(
+        team,
+        {
+            "甲签": (),
+            "乙签": (),
+            "丙签": (),
+            "循环": (_relation("provides"), _relation("consumes")),
+        },
+    )
+    feature_id = "M|debuff:huo_gong|consumes|enemy"
+
+    witnesses = mechanic_feature_witnesses(team, defaults, contract)[feature_id]
+
+    assert {
+        (witness.provider_slot_index, witness.consumer_slot_index)
+        for witness in witnesses
+        if witness.provider_carrier == witness.consumer_carrier == "甲"
+    } == {(1, 2), (2, 1)}
+
+
 def test_signature_participates_only_in_mech_not_ordinary_tactic_families() -> None:
     team, defaults, contract = _fire_team()
     features = team_features(team, defaults, mechanics=contract)
@@ -604,6 +672,7 @@ def test_active_instances_use_canonical_signature_not_ocr_slot_zero() -> None:
         instance.carrier == "陆逊"
         and instance.skill_name == "火烧连营"
         and instance.origin == "signature"
+        and instance.slot_index == 0
         for instance in instances
     )
     assert not any(instance.skill_name == "OCR槽零错误" for instance in instances)

--- a/data/test_mech_evaluation.py
+++ b/data/test_mech_evaluation.py
@@ -1,0 +1,640 @@
+"""Focused regression tests for evaluation-only MECH feature training."""
+from __future__ import annotations
+
+import copy
+import json
+import os
+import sys
+from pathlib import Path
+from types import MappingProxyType
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import evaluate_recommendation_model as evaluator  # noqa: E402
+import manage_mech_catalog as catalog_manager  # noqa: E402
+from build_recommendation_data import (  # noqa: E402
+    F_MECHANIC,
+    PRODUCTION_ENABLED_FAMILIES,
+    Battle,
+    _CatalogSeasons,
+    active_mechanic_skill_instances,
+    apply_family_shrinkage,
+    compute_mechanic_witness_pair_counts,
+    compute_support,
+    mechanic_feature_witnesses,
+    select_features,
+    team_features,
+)
+from mech_evaluation import (  # noqa: E402
+    MechanicRelationship,
+    MechanicsContract,
+    load_evaluation_mechanics,
+)
+
+FIRE_FEATURE = "M|debuff:huo_gong|benefits_from|enemy"
+FIRE = "debuff:huo_gong"
+
+
+def _relation(
+    relation: str,
+    mechanic: str = FIRE,
+    subject: str = "enemy",
+    certainty: str = "explicit",
+) -> MechanicRelationship:
+    return MechanicRelationship(relation, mechanic, subject, certainty)
+
+
+def _contract(
+    relationships: dict[str, tuple[MechanicRelationship, ...]],
+    *,
+    mechanics: tuple[str, ...] = (FIRE,),
+) -> MechanicsContract:
+    return MechanicsContract(
+        skill_relationships=MappingProxyType(dict(sorted(relationships.items()))),
+        mechanic_ids=frozenset(mechanics),
+        catalog_sha256="test-mech-catalog",
+    )
+
+
+def _hero(name: str, signature: str, first: str, second: str) -> dict[str, object]:
+    return {"name": name, "skills": [signature, first, second]}
+
+
+def _empty_contract_for(
+    team: list[dict[str, object]],
+    overrides: dict[str, tuple[MechanicRelationship, ...]],
+    *,
+    mechanics: tuple[str, ...] = (FIRE,),
+) -> MechanicsContract:
+    skills = {
+        str(skill): ()
+        for hero in team
+        for skill in hero["skills"]
+    }
+    skills.update(overrides)
+    return _contract(skills, mechanics=mechanics)
+
+
+def _fire_team(carrier: str = "张昭") -> tuple[
+    list[dict[str, object]], dict[str, str], MechanicsContract
+]:
+    equipped = {
+        "陆逊": ("普通甲", "普通乙"),
+        "张昭": ("普通丙", "普通丁"),
+        "孙权": ("普通戊", "普通己"),
+    }
+    first, _ = equipped[carrier]
+    equipped[carrier] = ("烈火张天", first)
+    team = [
+        _hero("陆逊", "OCR槽零错误", *equipped["陆逊"]),
+        _hero("张昭", "OCR槽零错误", *equipped["张昭"]),
+        _hero("孙权", "OCR槽零错误", *equipped["孙权"]),
+    ]
+    defaults = {"陆逊": "火烧连营", "张昭": "张昭签名", "孙权": "孙权签名"}
+    contract = _empty_contract_for(
+        team,
+        {
+            "火烧连营": (
+                _relation("provides"),
+                _relation("benefits_from"),
+            ),
+            "烈火张天": (_relation("provides"),),
+            "张昭签名": (),
+            "孙权签名": (),
+        },
+    )
+    return team, defaults, contract
+
+
+def _m_features(
+    team: list[dict[str, object]],
+    defaults: dict[str, str],
+    contract: MechanicsContract,
+    *,
+    concrete_team: bool = True,
+    certainty_mode: str = "explicit_only",
+) -> dict[str, int]:
+    return {
+        feature_id: value
+        for feature_id, value in team_features(
+            team,
+            defaults,
+            concrete_team=concrete_team,
+            mechanics=contract,
+            mech_certainty_mode=certainty_mode,
+        ).items()
+        if feature_id.startswith("M|")
+    }
+
+
+def test_mech_is_not_production_enabled() -> None:
+    assert F_MECHANIC not in PRODUCTION_ENABLED_FAMILIES
+
+
+def test_lu_xun_and_distinct_liehuo_emit_fire_feature_for_any_carrier() -> None:
+    for carrier in ("陆逊", "张昭", "孙权"):
+        team, defaults, contract = _fire_team(carrier)
+        witnesses = mechanic_feature_witnesses(team, defaults, contract)
+
+        assert _m_features(team, defaults, contract)[FIRE_FEATURE] == 1
+        assert any(
+            witness.provider_skill == "烈火张天"
+            and witness.provider_carrier == carrier
+            and witness.consumer_skill == "火烧连营"
+            and witness.consumer_origin == "signature"
+            for witness in witnesses[FIRE_FEATURE]
+        )
+
+
+def test_zhang_zhao_and_liehuo_without_fire_consumer_do_not_emit() -> None:
+    team = [
+        _hero("张昭", "错", "烈火张天", "甲"),
+        _hero("孙权", "错", "乙", "丙"),
+        _hero("周瑜", "错", "丁", "戊"),
+    ]
+    defaults = {"张昭": "张昭签名", "孙权": "孙权签名", "周瑜": "周瑜签名"}
+    contract = _empty_contract_for(
+        team,
+        {
+            "烈火张天": (_relation("provides"),),
+            "张昭签名": (),
+            "孙权签名": (),
+            "周瑜签名": (),
+        },
+    )
+
+    assert FIRE_FEATURE not in _m_features(team, defaults, contract)
+
+
+def test_fire_signature_cannot_satisfy_its_own_provider_consumer_loop() -> None:
+    team, defaults, contract = _fire_team()
+    for hero in team:
+        hero["skills"] = [hero["skills"][0], "普通一", "普通二"]
+    contract = _empty_contract_for(
+        team,
+        {
+            "火烧连营": (_relation("provides"), _relation("benefits_from")),
+            "张昭签名": (),
+            "孙权签名": (),
+        },
+    )
+
+    assert FIRE_FEATURE not in _m_features(team, defaults, contract)
+
+
+def test_signature_participates_only_in_mech_not_ordinary_tactic_families() -> None:
+    team, defaults, contract = _fire_team()
+    features = team_features(team, defaults, mechanics=contract)
+
+    assert FIRE_FEATURE in features
+    assert not any(
+        feature_id == "S|火烧连营"
+        or feature_id.startswith("HS|") and feature_id.endswith("|火烧连营")
+        or feature_id.startswith("SP|") and "火烧连营" in feature_id.split("|")
+        or feature_id.startswith("THS|") and feature_id.endswith("|火烧连营")
+        or feature_id.startswith("TSP|") and "火烧连营" in feature_id.split("|")
+        or feature_id.startswith("TS3|") and "火烧连营" in feature_id.split("|")
+        for feature_id in features
+    )
+
+
+def test_partial_non_concrete_and_cross_team_collections_emit_no_mech() -> None:
+    fire_team, defaults, contract = _fire_team()
+    provider_team = copy.deepcopy(fire_team)
+    provider_team[0] = _hero("周瑜", "错", "普通庚", "普通辛")
+    consumer_team = copy.deepcopy(fire_team)
+    for hero in consumer_team:
+        hero["skills"] = [hero["skills"][0], "普通一", "普通二"]
+    defaults["周瑜"] = "周瑜签名"
+    relationships = dict(contract.skill_relationships)
+    relationships.update(
+        {
+            "周瑜签名": (),
+            "普通庚": (),
+            "普通辛": (),
+            "普通一": (),
+            "普通二": (),
+        }
+    )
+    contract = _contract(relationships)
+
+    assert not _m_features(fire_team[:2], defaults, contract)
+    assert not _m_features(fire_team, defaults, contract, concrete_team=False)
+    assert FIRE_FEATURE not in _m_features(provider_team, defaults, contract)
+    assert FIRE_FEATURE not in _m_features(consumer_team, defaults, contract)
+    assert not _m_features(
+        [*provider_team, *consumer_team],
+        defaults,
+        contract,
+        concrete_team=False,
+    )
+
+
+def test_exact_mechanic_ids_are_required_without_parent_inference() -> None:
+    team = [
+        _hero("甲", "错", "火攻提供", "空一"),
+        _hero("乙", "错", "异常消费", "空二"),
+        _hero("丙", "错", "空三", "空四"),
+    ]
+    defaults = {"甲": "甲签", "乙": "乙签", "丙": "丙签"}
+    contract = _empty_contract_for(
+        team,
+        {
+            "甲签": (),
+            "乙签": (),
+            "丙签": (),
+            "火攻提供": (_relation("provides", "debuff:huo_gong"),),
+            "异常消费": (
+                _relation("benefits_from", "debuff:yi_chang_zhuang_tai"),
+            ),
+        },
+        mechanics=("debuff:huo_gong", "debuff:yi_chang_zhuang_tai"),
+    )
+
+    assert not _m_features(team, defaults, contract)
+
+
+def test_subject_compatible_relationships_match_on_friendly_side() -> None:
+    team = [
+        _hero("甲", "错", "提供", "消费"),
+        _hero("乙", "错", "空一", "空二"),
+        _hero("丙", "错", "空三", "空四"),
+    ]
+    defaults = {"甲": "甲签", "乙": "乙签", "丙": "丙签"}
+    contract = _empty_contract_for(
+        team,
+        {
+            "甲签": (),
+            "乙签": (),
+            "丙签": (),
+            "提供": (_relation("provides", subject="self"),),
+            "消费": (_relation("requires", subject="team"),),
+        },
+    )
+
+    assert "M|debuff:huo_gong|requires|friendly" in _m_features(
+        team, defaults, contract
+    )
+
+
+@pytest.mark.parametrize("consumer_subject", ["self", "unknown"])
+def test_subject_incompatible_or_unknown_relationships_do_not_match(
+    consumer_subject: str,
+) -> None:
+    team = [
+        _hero("甲", "错", "提供", "空一"),
+        _hero("乙", "错", "消费", "空二"),
+        _hero("丙", "错", "空三", "空四"),
+    ]
+    defaults = {"甲": "甲签", "乙": "乙签", "丙": "丙签"}
+    contract = _empty_contract_for(
+        team,
+        {
+            "甲签": (),
+            "乙签": (),
+            "丙签": (),
+            "提供": (_relation("provides", subject="self"),),
+            "消费": (_relation("benefits_from", subject=consumer_subject),),
+        },
+    )
+
+    assert not _m_features(team, defaults, contract)
+
+
+def test_certainty_modes_bound_reviewed_inferred_relationships() -> None:
+    team, defaults, base = _fire_team()
+    relationships = dict(base.skill_relationships)
+    relationships["烈火张天"] = (_relation("provides", certainty="inferred"),)
+    contract = _contract(relationships)
+
+    assert FIRE_FEATURE not in _m_features(team, defaults, contract)
+    assert FIRE_FEATURE in _m_features(
+        team,
+        defaults,
+        contract,
+        certainty_mode="all_reviewed",
+    )
+
+
+@pytest.mark.parametrize("relation_name", ["removes", "prevents"])
+def test_removes_and_prevents_never_create_pr_a_features(
+    relation_name: str,
+) -> None:
+    team, defaults, base = _fire_team()
+    relationships = dict(base.skill_relationships)
+    relationships["火烧连营"] = (_relation("provides"),)
+    relationships["烈火张天"] = (
+        _relation("provides"),
+        _relation(relation_name),
+    )
+    contract = _contract(relationships)
+
+    assert not _m_features(team, defaults, contract)
+
+
+def test_binary_presence_ignores_duplicate_witness_magnitude() -> None:
+    team, defaults, base = _fire_team()
+    team[2]["skills"][1] = "第二提供"
+    relationships = dict(base.skill_relationships)
+    relationships["第二提供"] = (_relation("provides"),)
+    contract = _contract(relationships)
+
+    features = team_features(team, defaults, mechanics=contract)
+    witnesses = mechanic_feature_witnesses(team, defaults, contract)
+
+    assert features[FIRE_FEATURE] == 1
+    assert len(witnesses[FIRE_FEATURE]) == 2
+
+
+def test_support_counts_a_mech_feature_once_per_battle() -> None:
+    team, defaults, contract = _fire_team()
+    battle = Battle("mirror.json", team, copy.deepcopy(team), 1)
+
+    support = compute_support(
+        [battle],
+        defaults,
+        mechanics=contract,
+    )
+
+    assert support[FIRE_FEATURE] == 1
+
+
+def test_pair_diversity_is_ordered_and_uses_only_supplied_training_rows() -> None:
+    team, defaults, base = _fire_team()
+    first = Battle("first.json", team, [], 1)
+    second_team = copy.deepcopy(team)
+    second_team[1]["skills"][1] = "第二提供"
+    relationships = dict(base.skill_relationships)
+    relationships["第二提供"] = (_relation("provides"),)
+    contract = _contract(relationships)
+    second = Battle("held-out.json", second_team, [], 1)
+
+    training_only = compute_mechanic_witness_pair_counts(
+        [first], defaults, contract
+    )
+    with_held_out = compute_mechanic_witness_pair_counts(
+        [first, second], defaults, contract
+    )
+
+    assert set(training_only[FIRE_FEATURE]) == {("烈火张天", "火烧连营")}
+    assert set(with_held_out[FIRE_FEATURE]) == {
+        ("烈火张天", "火烧连营"),
+        ("第二提供", "火烧连营"),
+    }
+
+
+def test_single_pair_mech_feature_fails_diversity_floor() -> None:
+    support = {FIRE_FEATURE: 30}
+
+    assert FIRE_FEATURE not in select_features(
+        support,
+        enabled_families={F_MECHANIC},
+        min_support_mechanic=12,
+        min_mechanic_pair_diversity=2,
+        mechanic_pair_diversity={FIRE_FEATURE: 1},
+    )
+    assert FIRE_FEATURE in select_features(
+        support,
+        enabled_families={F_MECHANIC},
+        min_support_mechanic=12,
+        min_mechanic_pair_diversity=2,
+        mechanic_pair_diversity={FIRE_FEATURE: 2},
+    )
+
+
+def test_mech_shrinkage_applies_only_to_m() -> None:
+    features = ["H|甲", FIRE_FEATURE, "HT|甲|乙|丙"]
+    raw = np.asarray([2.0, 4.0, 6.0])
+
+    adjusted = apply_family_shrinkage(
+        features,
+        raw,
+        team_context_shrinkage=1.0,
+        high_order_shrinkage=1.0,
+        mechanic_shrinkage=0.25,
+    )
+
+    np.testing.assert_array_equal(adjusted, np.asarray([2.0, 1.0, 6.0]))
+
+
+def test_optional_gate_rejects_mech_when_either_calibration_metric_regresses() -> None:
+    reference = evaluator.EvaluationConfig(include_mech=False)
+    enabled = evaluator.EvaluationConfig(include_mech=True)
+
+    def rows(probabilities: list[float]) -> evaluator.PredictionRows:
+        return evaluator.PredictionRows(
+            outcomes=[1, 1, 0],
+            probabilities=probabilities,
+            baseline_probabilities=[0.5] * 3,
+            group_ids=["a", "b", "c"],
+            sources=["uploaded_by_me"] * 3,
+            n_features=1,
+            nonzero_rows=3,
+            atomic_diagnostics={},
+        )
+
+    development = {
+        reference: rows([0.7, 0.7, 0.3]),
+        enabled: rows([0.99, 0.99, 0.6]),
+    }
+
+    assert evaluator._select_calibrated_optional_config(
+        reference,
+        [enabled],
+        development.__getitem__,
+    ) == reference
+
+
+def _fit_corpus() -> tuple[
+    list[Battle], dict[str, str], MechanicsContract, _CatalogSeasons
+]:
+    team, defaults, base = _fire_team()
+    relationships = dict(base.skill_relationships)
+    relationships["第二提供"] = (_relation("provides"),)
+    contract = _contract(relationships)
+    battles: list[Battle] = []
+    for index in range(24):
+        positive = copy.deepcopy(team)
+        if index % 2:
+            positive[1]["skills"][1] = "第二提供"
+        negative = [
+            _hero("曹操", "错", "普通一", "普通二"),
+            _hero("荀彧", "错", "普通三", "普通四"),
+            _hero("郭嘉", "错", "普通五", "普通六"),
+        ]
+        if index % 2:
+            team1, team2, winner = negative, positive, 2
+        else:
+            team1, team2, winner = positive, negative, 1
+        battles.append(Battle(f"{index:03d}.json", team1, team2, winner, season=1))
+    defaults.update({"曹操": "曹操签", "荀彧": "荀彧签", "郭嘉": "郭嘉签"})
+    all_skills = dict(contract.skill_relationships)
+    all_skills.update({"曹操签": (), "荀彧签": (), "郭嘉签": ()})
+    for battle in battles:
+        for battle_team in (battle.team1, battle.team2):
+            for hero in battle_team:
+                for skill in hero["skills"][1:]:
+                    all_skills.setdefault(str(skill), ())
+    contract = _contract(all_skills)
+    heroes = {
+        str(hero["name"]): 1
+        for battle in battles
+        for battle_team in (battle.team1, battle.team2)
+        for hero in battle_team
+    }
+    skills = {
+        str(skill): 1
+        for battle in battles
+        for battle_team in (battle.team1, battle.team2)
+        for hero in battle_team
+        for skill in hero["skills"]
+    }
+    skills.update({signature: 1 for signature in defaults.values()})
+    return battles, defaults, contract, _CatalogSeasons(heroes=heroes, skills=skills)
+
+
+def test_mech_evaluation_is_deterministic_and_disabled_path_is_unchanged() -> None:
+    battles, defaults, contract, seasons = _fit_corpus()
+    groups = tuple(f"group-{index}" for index in range(len(battles)))
+    config = evaluator.EvaluationConfig(
+        include_ths_tsp=False,
+        include_hc_b=False,
+        include_mech=True,
+        min_support_mechanic=1,
+        min_mechanic_pair_diversity=2,
+        mechanic_shrinkage=0.5,
+        include_ht=False,
+        include_ts3=False,
+    )
+    first = evaluator._fit_and_predict(
+        config,
+        tuple(range(20)),
+        tuple(range(20, 24)),
+        battles,
+        groups,
+        defaults,
+        seasons,
+        None,
+        contract,
+    )
+    second = evaluator._fit_and_predict(
+        config,
+        tuple(range(20)),
+        tuple(range(20, 24)),
+        battles,
+        groups,
+        defaults,
+        seasons,
+        None,
+        contract,
+    )
+    disabled = evaluator.EvaluationConfig(
+        include_ths_tsp=False,
+        include_hc_b=False,
+        include_mech=False,
+        include_ht=False,
+        include_ts3=False,
+    )
+    disabled_with_contract = evaluator._fit_and_predict(
+        disabled,
+        tuple(range(20)),
+        tuple(range(20, 24)),
+        battles,
+        groups,
+        defaults,
+        seasons,
+        None,
+        contract,
+    )
+    disabled_without_contract = evaluator._fit_and_predict(
+        disabled,
+        tuple(range(20)),
+        tuple(range(20, 24)),
+        battles,
+        groups,
+        defaults,
+        seasons,
+        None,
+        None,
+    )
+
+    assert first == second
+    assert first.mechanic_diagnostics["selected_feature_count"] == 1
+    assert disabled_with_contract == disabled_without_contract
+
+
+def test_evaluator_does_not_use_held_out_rows_for_mech_pair_diversity() -> None:
+    battles, defaults, contract, seasons = _fit_corpus()
+    groups = tuple(f"group-{index}" for index in range(len(battles)))
+    config = evaluator.EvaluationConfig(
+        include_ths_tsp=False,
+        include_hc_b=False,
+        include_mech=True,
+        min_support_mechanic=1,
+        min_mechanic_pair_diversity=2,
+        include_ht=False,
+        include_ts3=False,
+    )
+
+    rows = evaluator._fit_and_predict(
+        config,
+        tuple(range(0, 20, 2)),  # only 烈火张天 -> 火烧连营
+        tuple(range(1, 20, 2)),  # held out 第二提供 -> 火烧连营
+        battles,
+        groups,
+        defaults,
+        seasons,
+        None,
+        contract,
+    )
+
+    assert rows.mechanic_diagnostics["emitted_feature_count"] == 1
+    assert rows.mechanic_diagnostics["diversity_qualified_feature_count"] == 0
+    assert rows.mechanic_diagnostics["selected_feature_count"] == 0
+
+
+def test_active_instances_use_canonical_signature_not_ocr_slot_zero() -> None:
+    team, defaults, contract = _fire_team()
+    instances = active_mechanic_skill_instances(team, defaults, contract)
+
+    assert any(
+        instance.carrier == "陆逊"
+        and instance.skill_name == "火烧连营"
+        and instance.origin == "signature"
+        for instance in instances
+    )
+    assert not any(instance.skill_name == "OCR槽零错误" for instance in instances)
+
+
+def test_training_loader_rejects_unresolved_catalog(tmp_path: Path) -> None:
+    database = {
+        "skills": {
+            "甲": {"type": "主动", "prob": 100, "desc": "施加火攻"},
+        },
+        "buffs": {},
+        "debuffs": {
+            "huo_gong": {"name": "火攻"},
+        },
+    }
+    catalog = catalog_manager.new_catalog(database)
+    catalog["skills"]["甲"].update(
+        {
+            "extraction_status": "complete",
+            "unresolved": [
+                {"name": "火攻", "evidence": "火攻", "reason": "review pending"}
+            ],
+        }
+    )
+    database_path = tmp_path / "database.json"
+    catalog_path = tmp_path / "mech.json"
+    database_path.write_text(json.dumps(database, ensure_ascii=False), encoding="utf-8")
+    catalog_path.write_bytes(catalog_manager.rendered_catalog(catalog))
+
+    with pytest.raises(
+        catalog_manager.CatalogError,
+        match="zero unresolved entries",
+    ):
+        load_evaluation_mechanics(database_path, catalog_path)

--- a/data/test_recommendation_evaluation.py
+++ b/data/test_recommendation_evaluation.py
@@ -653,6 +653,7 @@ def test_main_runs_tiny_protocol_without_mutating_production_artifact(
         locked_test_manifest,
         *,
         relationships=None,
+        mechanics=None,
         catalog_version,
         bootstrap_samples,
     ):
@@ -662,6 +663,7 @@ def test_main_runs_tiny_protocol_without_mutating_production_artifact(
             loaded_catalog_seasons,
             locked_test_manifest,
             relationships=relationships,
+            mechanics=mechanics,
             catalog_version=catalog_version,
             c_candidates=(0.5,),
             single_support_candidates=(5,),
@@ -680,6 +682,7 @@ def test_main_runs_tiny_protocol_without_mutating_production_artifact(
             battles,
             {"catalog_version": "test-catalog", "default_skill": {}},
             catalog_seasons,
+            None,
             None,
         ),
     )
@@ -700,7 +703,7 @@ def test_main_runs_tiny_protocol_without_mutating_production_artifact(
 
     assert result == 0
     assert production_path.read_bytes() == production_bytes
-    assert report["production_model"]["changed"] is True
+    assert report["production_model"]["changed"] is False
     assert report["development_validation"]["n"] > 0
     assert report["locked_test"]["selected_candidate"]["metrics"]["n"] == 20
 


### PR DESCRIPTION
## Intent

Implement PR A as an evaluation-only test of whether the reviewed MECH relationships in web/public/game-data/mech.json add residual predictive signal beyond the existing H/S/HP/HS/SP/THS/TSP/HT/HC/B paired-logistic identity features. Reuse manage_mech_catalog.py validation and fail closed on partial or stale semantic input; extract binary exact-mechanic provides-to-benefits_from/requires/consumes interactions only inside one concrete three-hero team, include canonical signatures only for M, enforce distinct skill instances, subject overlap, certainty modes, training-only battle support and ordered skill-pair diversity, and bounded post-fit shrinkage. Insert the 18-candidate MECH stage after HC/B and before HT, require both development log loss and Brier improvement, preserve the locked-test protocol, emit bounded deterministic diagnostics including the 火攻 audit, and commit data/evaluation/MECH_EVALUATION.md. Keep MECH out of PRODUCTION_ENABLED_FAMILIES and make no production weights, web/TypeScript/runtime, browser fetch, schema version, relationship_version, telemetry, catalog, or production artifact changes; results_recommendation_evaluation.json remains ignored. Validate data tests, strict MECH status/validation, byte-identical production build, deterministic evaluation, and open/update the PR without merging.

## What Changed

- Add strict MECH catalog loading and binary exact-mechanic feature extraction for distinct skill instances within concrete three-hero teams, with certainty, subject-overlap, training-only support/diversity, and bounded shrinkage controls.
- Insert an 18-candidate MECH ablation between HC/B and HT, requiring development log-loss and Brier improvements while preserving the locked-test protocol and emitting deterministic diagnostics, including the 火攻 audit.
- Add focused data tests and document the selected `all_reviewed`, support-30, 0.25-shrinkage result while keeping `M` outside production-enabled families.

## Risk Assessment

✅ Low: The change is evaluation-only, keeps MECH outside production families and artifacts, preserves the locked-test boundary, and the distinct-instance fix is consistently reflected in extraction, diagnostics, tests, and the committed decision record.

## Testing

Inspected the base-to-target scope, ran focused and canonical data tests, strict MECH validation, a byte-identical production rebuild, two deterministic full evaluations, generated-report acceptance checks, and stale/pending fail-closed CLI checks; all succeeded and the worktree is clean. This is an evaluation-only CLI/data change, so JSON reports and CLI transcripts—not screenshots—are the applicable reviewer-visible evidence.

<details>
<summary>Evidence: Generated full MECH evaluation report</summary>

```text
{
  "controlled_yanwu_comparison": {
    "baseline_training": {
      "metrics": {
        "accuracy": 0.74,
        "baseline": {
          "accuracy": 0.4996,
          "brier": 0.25,
          "by_source": {
            "external_yanwu": {
              "accuracy": null,
              "brier": null,
              "confidence_interval_status": "omitted_too_few_groups",
              "confidence_intervals_95": {
                "accuracy": null,
                "brier": null,
                "log_loss": null
              },
              "log_loss": null,
              "n": 0,
              "n_groups": 0,
              "n_groups_by_stratum": {}
            },
            "uploaded_by_me": {
              "accuracy": 0.5026,
              "brier": 0.25,
              "confidence_interval_status": "exploratory_few_groups",
              "confidence_intervals_95": {
                "accuracy": {
                  "high": 0.5273,
                  "low": 0.4748
                },
                "brier": {
                  "high": 0.2501,
                  "low": 0.2499
                },
                "log_loss": {
                  "high": 0.6934,
                  "low": 0.6929
                }
              },
              "log_loss": 0.6931,
              "n": 1158,
              "n_groups": 12,
              "n_groups_by_stratum": {
                "all": 12
              }
            },
            "uploaded_by_others": {
              "accuracy": 0.2667,
              "brier": 0.2511,
              "confidence_interval_status": "exploratory_few_groups",
              "confidence_intervals_95": {
                "accuracy": {
                  "high": 0.381,
                  "low": 0.0
                },
                "brier": {
                  "high": 0.2523,
                  "low": 0.2506
                },
                "log_loss": {
                  "high": 0.6977,
                  "low": 0.6942
                }
              },
              "log_loss": 0.6953,
              "n": 15,
              "n_groups": 5,
              "n_groups_by_stratum": {
                "all": 5
              }
            }
          },
          "confidence_interval_status": "exploratory_few_groups",
          "confidence_intervals_95": {
            "accuracy": {
              "high": 0.5227,
              "low": 0.4699
            },
            "brier": {
              "high": 0.2501,
              "low": 0.2499
            },
            "log_loss": {
              "high": 0.6934,
              "low": 0.6929
            }
          },
          "log_loss": 0.6932,
          "n": 1173,
          "n_groups": 16,
          "n_groups_by_stratum": {
            "all": 16
          }
        },
        "brier": 0.1885,
        "by_source": {
          "external_yanwu": {
            "accuracy": null,
            "brier": null,
            "confidence_interval_status": "omitted_too_few_groups",
            "confidence_intervals_95": {
              "accuracy": null,
              "brier": null,
              "log_loss": null
            },
            "log_loss": null,
            "n": 0,
            "n_groups": 0,
            "n_groups_by_stratum": {}
          },
          "uploaded_by_me": {
            "accuracy": 0.7401,
            "brier": 0.1881,
            "confidence_interval_status": "exploratory_few_groups",
            "confidence_intervals_95": {
              "accuracy": {
                "high": 0.7634,
                "low": 0.7168
              },
              "brier": {
                "high": 0.2054,
                "low": 0.1711
              },
              "log_loss": {
                "high": 0.6512,
                "low": 0.5386
              }
            },
            "log_loss": 0.592,
            "n": 1158,
            "n_groups": 12,
            "n_groups_by_stratum": {
              "all": 12
            }
          },
          "uploaded_by_others": {
            "accuracy": 0.7333,
            "brier": 0.2179,
            "confidence_interval_status": "exploratory_few_groups",
            "confidence_intervals_95": {
              "accuracy": {
                "high": 0.9231,
                "low": 0.25
              },
              "brier": {
                "high": 0.6516,
                "low": 0.0794
              },
              "log_loss": {
                "high": 2.2962,
                "low": 0.2552
              }
            },
            "log_loss": 0.737,
            "n": 15,
            "n_groups": 5,
            "n_groups_by_stratum": {
              "all": 5
            }
          }
        },
        "confidence_interval_status": "exploratory_few_groups",
        "confidence_intervals_95": {
          "accuracy": {
            "high": 0.7633,
            "low": 0.7165
          },
          "brier": {
            "high": 0.2065,
            "low": 0.1709
          },
          "log_loss": {
            "high": 0.6517,
            "low": 0.54
          }
        },
        "feature_coverage": 1.0,
        "log_loss": 0.5939,
        "n": 1173,
        "n_features": 3396,
        "n_groups": 16,
        "n_groups_by_stratum": {
          "all": 16
        }
      },
      "n_battles": 2184,
      "n_groups": 74
    },
    "candidate_minus_baseline": {
      "accuracy": 0.0,
      "brier": -0.0051,
      "by_source": {
        "external_yanwu": {
          "accuracy": null,
          "brier": null,
          "confidence_interval_status": "omitted_too_few_groups",
          "confidence_intervals_95": {
            "accuracy": null,
            "brier": null,
            "log_loss": null
          },
          "log_loss": null,
          "n": 0,
          "n_groups": 0,
          "n_groups_by_stratum": {}
        },
        "uploaded_by_me": {
          "accuracy": 0.0009,
          "brier": -0.0051,
          "confidence_interval_status": "exploratory_few_groups",
          "confidence_intervals_95": {
            "accuracy": {
              "high": 0.0153,
              "low": -0.0124
            },
            "brier": {
              "high": 0.001,
              "low": -0.0121
            },
            "log_loss": {
              "high": -0.0007,
              "low": -0.0446
            }
          },
          "log_loss": -0.0196,
          "n": 1158,
          "n_groups": 12,
          "n_groups_by_stratum": {
            "all": 12
          }
        },
        "uploaded_by_others": {
          "accuracy": -0.0667,
          "brier": -0.0039,
          "confidence_interval_status": "exploratory_few_groups",
          "confidence_intervals_95": {
            "accuracy": {
              "high": 0.0,
              "low": -0.1111
            },
            "brier": {
              "high": 0.0225,
              "low": -0.0799
            },
            "log_loss": {
              "high": 0.0386,
              "low": -0.192
            }
          },
          "log_loss": -0.0224,
          "n": 15,
          "n_groups": 5,
          "n_groups_by_stratum": {
            "all": 5
          }
        }
      },
      "confidence_interval_status": "exploratory_few_groups",
      "confidence_intervals_95": {
        "accuracy": {
          "high": 0.0146,
          "low": -0.0149
        },
        "brier": {
          "high": 0.0014,
          "low": -0.0119
        },
        "log_loss": {
          "high": -0.0001,
          "low": -0.0444
        }
      },
      "log_loss": -0.0196,
      "n": 1173,
      "n_groups": 16,
      "n_groups_by_stratum": {
        "all": 16
      }
    },
    "candidate_training": {
      "metrics": {
        "accuracy": 0.74,
        "baseline": {
          "accuracy": 0.5004,
          "brier": 0.2509,
          "by_source": {
            "external_yanwu": {
              "accuracy": null,
              "brier": null,
              "confidence_interval_status": "omitted_too_few_groups",
              "confidence_intervals_95": {
                "accuracy": null,
                "brier": null,
                "log_loss": null
              },
              "log_loss": null,
              "n": 0,
              "n_groups": 0,
              "n_groups

... [269586 bytes truncated] ...

       },
        {
          "accuracy": 0.696181,
          "brier": 0.213654,
          "config": {
            "C": 0.05,
            "high_order_shrinkage": 0.35,
            "include_hc_b": true,
            "include_ht": true,
            "include_mech": false,
            "include_sp": true,
            "include_ths_tsp": true,
            "include_ts3": false,
            "mech_certainty_mode": "explicit_only",
            "mechanic_shrinkage": 0.5,
            "min_mechanic_pair_diversity": 2,
            "min_support_high_order": 50,
            "min_support_mechanic": 12,
            "min_support_pair": 8,
            "min_support_relationship": 12,
            "min_support_single": 8,
            "min_support_team_context": 20,
            "selection_prior_hero_strength": 0.4,
            "selection_prior_log_ratio_clip": 2.0,
            "selection_prior_skill_strength": 0.3,
            "selection_prior_smoothing": 20.0,
            "team_context_shrinkage": 0.5
          },
          "feature_coverage": 0.9991,
          "log_loss": 0.65262,
          "n": 1152,
          "n_features": 8095,
          "n_groups": 646
        },
        {
          "accuracy": 0.696181,
          "brier": 0.21357,
          "config": {
            "C": 0.05,
            "high_order_shrinkage": 0.35,
            "include_hc_b": true,
            "include_ht": true,
            "include_mech": false,
            "include_sp": true,
            "include_ths_tsp": true,
            "include_ts3": false,
            "mech_certainty_mode": "explicit_only",
            "mechanic_shrinkage": 0.5,
            "min_mechanic_pair_diversity": 2,
            "min_support_high_order": 50,
            "min_support_mechanic": 12,
            "min_support_pair": 5,
            "min_support_relationship": 12,
            "min_support_single": 3,
            "min_support_team_context": 20,
            "selection_prior_hero_strength": 0.4,
            "selection_prior_log_ratio_clip": 2.0,
            "selection_prior_skill_strength": 0.3,
            "selection_prior_smoothing": 20.0,
            "team_context_shrinkage": 0.5
          },
          "feature_coverage": 0.9991,
          "log_loss": 0.652873,
          "n": 1152,
          "n_features": 9706,
          "n_groups": 646
        },
        {
          "accuracy": 0.696181,
          "brier": 0.213563,
          "config": {
            "C": 0.05,
            "high_order_shrinkage": 0.35,
            "include_hc_b": true,
            "include_ht": true,
            "include_mech": false,
            "include_sp": true,
            "include_ths_tsp": true,
            "include_ts3": false,
            "mech_certainty_mode": "explicit_only",
            "mechanic_shrinkage": 0.5,
            "min_mechanic_pair_diversity": 2,
            "min_support_high_order": 50,
            "min_support_mechanic": 12,
            "min_support_pair": 5,
            "min_support_relationship": 12,
            "min_support_single": 5,
            "min_support_team_context": 20,
            "selection_prior_hero_strength": 0.4,
            "selection_prior_log_ratio_clip": 2.0,
            "selection_prior_skill_strength": 0.3,
            "selection_prior_smoothing": 20.0,
            "team_context_shrinkage": 0.5
          },
          "feature_coverage": 0.9991,
          "log_loss": 0.652883,
          "n": 1152,
          "n_features": 9706,
          "n_groups": 646
        },
        {
          "accuracy": 0.696181,
          "brier": 0.213568,
          "config": {
            "C": 0.05,
            "high_order_shrinkage": 0.35,
            "include_hc_b": true,
            "include_ht": true,
            "include_mech": false,
            "include_sp": true,
            "include_ths_tsp": true,
            "include_ts3": false,
            "mech_certainty_mode": "explicit_only",
            "mechanic_shrinkage": 0.5,
            "min_mechanic_pair_diversity": 2,
            "min_support_high_order": 50,
            "min_support_mechanic": 12,
            "min_support_pair": 5,
            "min_support_relationship": 12,
            "min_support_single": 8,
            "min_support_team_context": 20,
            "selection_prior_hero_strength": 0.4,
            "selection_prior_log_ratio_clip": 2.0,
            "selection_prior_skill_strength": 0.3,
            "selection_prior_smoothing": 20.0,
            "team_context_shrinkage": 0.5
          },
          "feature_coverage": 0.9991,
          "log_loss": 0.65291,
          "n": 1152,
          "n_features": 9706,
          "n_groups": 646
        },
        {
          "accuracy": 0.693576,
          "brier": 0.213938,
          "config": {
            "C": 0.05,
            "high_order_shrinkage": 0.35,
            "include_hc_b": true,
            "include_ht": true,
            "include_mech": false,
            "include_sp": true,
            "include_ths_tsp": true,
            "include_ts3": false,
            "mech_certainty_mode": "explicit_only",
            "mechanic_shrinkage": 0.5,
            "min_mechanic_pair_diversity": 2,
            "min_support_high_order": 50,
            "min_support_mechanic": 12,
            "min_support_pair": 12,
            "min_support_relationship": 12,
            "min_support_single": 3,
            "min_support_team_context": 20,
            "selection_prior_hero_strength": 0.4,
            "selection_prior_log_ratio_clip": 2.0,
            "selection_prior_skill_strength": 0.3,
            "selection_prior_smoothing": 20.0,
            "team_context_shrinkage": 0.5
          },
          "feature_coverage": 0.9991,
          "log_loss": 0.652984,
          "n": 1152,
          "n_features": 6997,
          "n_groups": 646
        },
        {
          "accuracy": 0.693576,
          "brier": 0.213931,
          "config": {
            "C": 0.05,
            "high_order_shrinkage": 0.35,
            "include_hc_b": true,
            "include_ht": true,
            "include_mech": false,
            "include_sp": true,
            "include_ths_tsp": true,
            "include_ts3": false,
            "mech_certainty_mode": "explicit_only",
            "mechanic_shrinkage": 0.5,
            "min_mechanic_pair_diversity": 2,
            "min_support_high_order": 50,
            "min_support_mechanic": 12,
            "min_support_pair": 12,
            "min_support_relationship": 12,
            "min_support_single": 5,
            "min_support_team_context": 20,
            "selection_prior_hero_strength": 0.4,
            "selection_prior_log_ratio_clip": 2.0,
            "selection_prior_skill_strength": 0.3,
            "selection_prior_smoothing": 20.0,
            "team_context_shrinkage": 0.5
          },
          "feature_coverage": 0.9991,
          "log_loss": 0.652995,
          "n": 1152,
          "n_features": 6997,
          "n_groups": 646
        },
        {
          "accuracy": 0.693576,
          "brier": 0.213936,
          "config": {
            "C": 0.05,
            "high_order_shrinkage": 0.35,
            "include_hc_b": true,
            "include_ht": true,
            "include_mech": false,
            "include_sp": true,
            "include_ths_tsp": true,
            "include_ts3": false,
            "mech_certainty_mode": "explicit_only",
            "mechanic_shrinkage": 0.5,
            "min_mechanic_pair_diversity": 2,
            "min_support_high_order": 50,
            "min_support_mechanic": 12,
            "min_support_pair": 12,
            "min_support_relationship": 12,
            "min_support_single": 8,
            "min_support_team_context": 20,
            "selection_prior_hero_strength": 0.4,
            "selection_prior_log_ratio_clip": 2.0,
            "selection_prior_skill_strength": 0.3,
            "selection_prior_smoothing": 20.0,
            "team_context_shrinkage": 0.5
          },
          "feature_coverage": 0.9991,
          "log_loss": 0.653021,
          "n": 1152,
          "n_features": 6997,
          "n_groups": 646
        }
      ],
      "selected": {
        "min_support_pair": 8,
        "min_support_single": 3
      }
    }
  }
}
```
</details>
<details>
<summary>Evidence: Reviewer-focused MECH acceptance summary</summary>

```text
{
  "bounded_diagnostics": {
    "max_top_witness_pairs_per_feature": 5,
    "selected_mech_features": 16
  },
  "development_gate": {
    "baseline_brier": 0.213965,
    "baseline_log_loss": 0.653495,
    "both_improved": true,
    "selected_brier": 0.21334,
    "selected_log_loss": 0.651265
  },
  "evaluation_report_sha256": "1a1cf54a58c72e381e82da3e07ff8a92c865f0a5547b82bf2301369a7dc7abb2",
  "fire_audit": {
    "feature": "M|debuff:huo_gong|benefits_from|enemy",
    "first_observed_witness": {
      "battle": "2025-09-06-055203.json",
      "team": 1,
      "witnesses": [
        {
          "consumer_carrier": "陆逊",
          "consumer_origin": "signature",
          "consumer_skill": "火烧连营",
          "consumer_slot_index": 0,
          "provider_carrier": "小乔",
          "provider_origin": "equipped",
          "provider_skill": "烈火张天",
          "provider_slot_index": 1
        }
      ]
    },
    "lu_xun_plus_liehuo": {
      "activated_teams": 333,
      "observed_teams": 333
    },
    "lu_xun_without_distinct_provider": {
      "activated_teams": 0,
      "observed_teams": 52
    },
    "ordered_skill_pair_diversity": 18,
    "post_shrink_weight": 0.020679097,
    "training_battle_support": 903,
    "zhang_zhao_without_consumer": {
      "activated_teams": 0,
      "observed_teams": 4
    }
  },
  "locked_test_rows_for_each_final_model": 1173,
  "mech_decision": "enabled_by_development_calibration_gate",
  "mech_grid_candidate_count": 18,
  "production": {
    "changed": false,
    "mech_enabled": false
  },
  "protocol": {
    "locked_test_use": "one final evaluation after configuration selection",
    "name": "grouped-stable-hash-locked-holdout",
    "selection_data": "configuration choice uses development metrics; feature support, MECH pair diversity, and witness ranking use training rows only",
    "split_battles": {
      "development": 1152,
      "locked_test": 1173,
      "train": 5511
    }
  },
  "selected_mech_configuration": {
    "certainty_mode": "all_reviewed",
    "mechanic_shrinkage": 0.25,
    "min_mechanic_pair_diversity": 2,
    "min_support_mechanic": 30
  },
  "stage_order": [
    "stage_1_pre_context_baseline",
    "stage_2_plus_ths_tsp",
    "stage_3_plus_hc_b",
    "stage_4_mech",
    "stage_5_ht",
    "stage_6_ts3"
  ]
}
```
</details>
<details>
<summary>Evidence: End-to-end evaluation CLI transcript</summary>

```text
uv run python data/sync_yanwu_corpus.py --manifest "data/external/yanwu-release.json" --cache-dir ".cache/yanwu"
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- index
Yanwu corpus cache hit: .cache/yanwu/217564dccbb54bc72cf73b3b0206aed08884cecaeac2d65eb8cd8e2d7861e887.normalized.json (39898 cumulative source rows -> 8154 first-appearance reports; 4479 accepted, 3675 excluded).
uv run python data/evaluate_recommendation_model.py --output results_recommendation_evaluation.json
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- index
✓ Wrote results_recommendation_evaluation.json: selected {'C': 0.05, 'min_support_single': 5, 'min_support_pair': 8, 'min_support_team_context': 20, 'min_support_relationship': 12, 'min_support_high_order': 50, 'include_sp': True, 'include_ths_tsp': True, 'include_hc_b': True, 'include_mech': True, 'mech_certainty_mode': 'all_reviewed', 'min_support_mechanic': 30, 'mechanic_shrinkage': 0.25, 'min_mechanic_pair_diversity': 2, 'include_ht': True, 'include_ts3': False, 'team_context_shrinkage': 0.5, 'high_order_shrinkage': 0.35, 'selection_prior_hero_strength': 0.4, 'selection_prior_skill_strength': 0.3, 'selection_prior_smoothing': 20.0, 'selection_prior_log_ratio_clip': 2.0}; development logloss=0.6506, locked accuracy=0.7417, controlled Yanwu conclusion=inconclusive_no_improvement_claim.
  Production weights were not changed.
```
</details>
<details>
<summary>Evidence: Evaluation byte-determinism evidence</summary>

```text
1a1cf54a58c72e381e82da3e07ff8a92c865f0a5547b82bf2301369a7dc7abb2  results_recommendation_evaluation.json
run 1 SHA-256: 1a1cf54a58c72e381e82da3e07ff8a92c865f0a5547b82bf2301369a7dc7abb2
run 2 SHA-256: 1a1cf54a58c72e381e82da3e07ff8a92c865f0a5547b82bf2301369a7dc7abb2
result: BYTE_IDENTICAL
```
</details>
<details>
<summary>Evidence: Production build byte-identity evidence</summary>

```text
production artifact SHA-256 before rebuild: f9ce74f76c65d9abec1b78da75c34b801a2ee63571c943f076301f9a4617e9e1
uv run python data/sync_yanwu_corpus.py --manifest "data/external/yanwu-release.json" --cache-dir ".cache/yanwu"
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- index
Yanwu corpus cache hit: .cache/yanwu/217564dccbb54bc72cf73b3b0206aed08884cecaeac2d65eb8cd8e2d7861e887.normalized.json (39898 cumulative source rows -> 8154 first-appearance reports; 4479 accepted, 3675 excluded).
uv run python data/build_recommendation_data.py
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- index
✓ Wrote web/src/recommendation_data.json: 7836 battles, 10454 model features.
  Backtest (n=1544): acc=0.7312 (baseline 0.524), logloss=0.5874, brier=0.1897
production artifact SHA-256 after rebuild:  f9ce74f76c65d9abec1b78da75c34b801a2ee63571c943f076301f9a4617e9e1
byte comparison against committed target artifact: IDENTICAL
base-commit production artifact SHA-256: f9ce74f76c65d9abec1b78da75c34b801a2ee63571c943f076301f9a4617e9e1
rebuilt production artifact SHA-256:     f9ce74f76c65d9abec1b78da75c34b801a2ee63571c943f076301f9a4617e9e1
byte comparison against base artifact:  IDENTICAL
```
</details>
<details>
<summary>Evidence: Stale and partial MECH fail-closed evidence</summary>

```text
--- stale catalog ---
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- index
Evaluation failed: skills['一计决胜'].source_hash is stale
exit code: 1
output artifact created: no
--- partial catalog ---
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- index
Evaluation failed: skills['一计决胜'].source_hash must be a lowercase SHA-256 hex digest
exit code: 1
output artifact created: no
--- partial catalog (valid fresh hash, pending semantic extraction) ---
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- index
Evaluation failed: skills['一计决胜'] is pending; final validation requires complete
exit code: 1
output artifact created: no
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"560415597b6159001ac73dff5259b5fc01caf26e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `data/build_recommendation_data.py:983` - The required contract says to “include canonical signatures only for M” and “enforce distinct skill instances,” but M builds equipped instances through `_non_default_skills`, which removes any equipped skill equal to the carrier&#39;s canonical signature and deduplicates repeated names. This is reachable: `data/battles/2025-09-27-112353.json` has 张宝 with canonical and equipped 妖风大作, and that skill both provides and benefits_from `debuff:yao_shu`; the equipped copy is discarded, so the valid two-instance interaction is suppressed. Enumerate the canonical signature plus validated equipped slots at the M-specific boundary, retaining a stable slot identity, while leaving `_non_default_skills` unchanged for ordinary identity families; then regenerate the evaluation results and decision document.

🔧 Fix: Preserve distinct MECH skill slot instances
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 7de7e3b456b7641b7fd3ad3cb59a8fbcb34dd590..ffa5fb11f8a26e15ad32ed65b1741ed1b7a868c7` and scoped `git diff --quiet` checks — inspected the change boundary and confirmed no production web/runtime/catalog/agent files changed.</code>
- <code>`uv run pytest data/test_mech_evaluation.py data/test_recommendation_evaluation.py -v` — exercised focused MECH extraction, distinct-instance and subject semantics, certainty modes, training-only support/diversity, shrinkage, calibration gating, determinism, and locked-test behavior.</code>
- <code>`make test-data` — exercised the canonical data-workspace validation command.</code>
- <code>`uv run python data/manage_mech_catalog.py status &amp;&amp; uv run python data/manage_mech_catalog.py validate` — verified the reviewed catalog is current, complete, and has no unresolved mechanics.</code>
- <code>`make build-recommendation` followed by SHA-256 and `cmp` checks against both the target and base artifacts — verified the rebuilt production recommendation artifact is byte-identical.</code>
- <code>`make evaluate-recommendation` twice followed by `shasum -a 256` and `cmp` — executed the complete user-facing evaluation flow and verified byte-deterministic output.</code>
- <code>`uv run python -` assertions over the generated evaluation report — verified the 18-candidate MECH stage occurs after HC/B and before HT, both development calibration metrics improve, production keeps MECH disabled, the locked test is preserved, diagnostics are bounded, and the 火攻 audit matches observed witnesses.</code>
- <code>`uv run python data/evaluate_recommendation_model.py --mech-catalog &lt;stale-or-pending-fixture&gt; --output &lt;evidence-output&gt;` — verified the real evaluator exits nonzero and creates no report for stale or partial semantic catalogs.</code>
- <code>Removed the ignored evaluation result and test caches, then checked `git status --short` to confirm a clean worktree.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
