### PR TITLE
feat(web): unify analytics relationship rankings

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -276,15 +276,17 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   hero/skill tables rank by model weight with deterministic tie-breakers.
 - One two-level relationship panel keeps six independent full-family rankings out
   of a crowded tab bar: 武将搭配 has 两人同队 (HP) and exact 三人同队 (HT); 战法搭配 has
-  自己携带 (HS) and 队内存在战法 (THS); 特殊加成 has catalog-backed 缘分 (B) and
-  aggregate 机制联动 (M). THS means the tactic can exist anywhere in the exact team,
-  including on the named hero. B shows its activation count and catalog members. M
-  shows the human-readable mechanic, 联动方式 (interaction mode), and friendly/enemy side; its
+  自己携带 (HS) and 队内战法 (THS); 特殊加成 has catalog-backed 缘分 (B) and aggregate
+  机制联动 (M). THS means the tactic can exist anywhere in the exact team, including
+  on the named hero. B shows its required member count and catalog members. M shows the
+  human-readable mechanic, 联动方式 (interaction mode), and friendly/enemy side; its
   weight belongs to that aggregate relationship and is never assigned to one concrete
-  skill pair. HC, SP, TSP, and disabled TS3 are excluded from this panel. The browser
+  skill pair. HC, SP, TSP, and disabled TS3 are excluded from this panel. Each included
+  family retains every fitted relationship, including negative weights. The browser
   filters the complete selected family before rendering, initially shows at most 40
-  matching rows, and reveals subsequent matches in deterministic batches of 40 through
-  an accessible 显示更多 control; expanding one mode or query never carries into another.
+  matching rows, reports visible, matching, and full-family counts where they differ,
+  and reveals subsequent matches in deterministic batches of 40 through an accessible
+  显示更多 control; expanding one mode or query never carries into another.
 - Relationship filters preserve each full-list rank. HP/HT use contained heroes;
   HS/THS use their encoded hero or tactic; B uses catalog members. M remains an
   unfiltered aggregate because tactic participation is not presented as a concrete-pair

--- a/web/README.md
+++ b/web/README.md
@@ -33,7 +33,7 @@ the model data is generated and community reports are imported.
   Function quota. Players can then rearrange heroes and tactics with pointer,
   touch, keyboard, or tap-to-place controls, and copy an exact-lineup validation
   prompt backed by the public game database and formula reference
-- **Analytics Dashboard**: Player-friendly, question-led analytics — hero/skill rankings by 胜率参考 (smoothed win rate, with 参考场次 as supporting context), 组合分 synergy tables, usage, and optional (collapsed) model diagnostics
+- **Analytics Dashboard**: Player-friendly, question-led analytics — hero/skill model-weight rankings, one responsive six-mode relationship ranking, usage, and optional (collapsed) model diagnostics
 - **Auto-save**: Game progress automatically saved in a versioned,
   non-expiring `localStorage` record; the Team Builder uses its own
   `localStorage` key, while season data remains in a separate cookie
@@ -264,17 +264,32 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   and the exact count-derived percentages remain visible for every row.
 - The telemetry rankings and paired-model **历史战报分析** are separate, named page
   sections. Battle-count provenance, the historical-experience caveat, filters, and the
-  win-rate/synergy tables live only inside the battle-report section.
+  model-weight/relationship tables live only inside the battle-report section.
 - The telemetry artifact still retains diagnostic round, position, score-margin,
   recommendation-agreement, preference-model status/evidence, and evaluation aggregates,
   but Analytics does not show them in this player-facing ranking section.
   Backward-compatible schema-v2/v3/v4 readers remain for stale deployed assets;
   schema-v2 artifacts have no item analytics, so the section is omitted entirely.
 - Question-led layout with a plain-language guide to the three player-facing measures:
-  胜率参考 (smoothed win rate), 组合分 (combo score — the model's extra pairing/hero-skill
-  bonus, shown only on the synergy tables), and 参考场次 (reference battles). Individual
-  hero/skill tables are ranked by 胜率参考 (descending, with deterministic tie-breakers);
-  usage and top synergies keep their own orderings.
+  模型权重 (an individual hero/skill's relative-strength coefficient), 组合分 (an
+  additional relationship coefficient), and 参考场次 (supporting battles). Individual
+  hero/skill tables rank by model weight with deterministic tie-breakers.
+- One two-level relationship panel keeps six independent full-family rankings out
+  of a crowded tab bar: 武将搭配 has 两人同队 (HP) and exact 三人同队 (HT); 战法搭配 has
+  自己携带 (HS) and 队内存在战法 (THS); 特殊加成 has catalog-backed 缘分 (B) and
+  aggregate 机制联动 (M). THS means the tactic can exist anywhere in the exact team,
+  including on the named hero. B shows its activation count and catalog members. M
+  shows the human-readable mechanic, 联动方式 (interaction mode), and friendly/enemy side; its
+  weight belongs to that aggregate relationship and is never assigned to one concrete
+  skill pair. HC, SP, TSP, and disabled TS3 are excluded from this panel. The browser
+  filters the complete selected family before rendering, initially shows at most 40
+  matching rows, and reveals subsequent matches in deterministic batches of 40 through
+  an accessible 显示更多 control; expanding one mode or query never carries into another.
+- Relationship filters preserve each full-list rank. HP/HT use contained heroes;
+  HS/THS use their encoded hero or tactic; B uses catalog members. M remains an
+  unfiltered aggregate because tactic participation is not presented as a concrete-pair
+  attribution. Inapplicable filters are explicitly described as not applied. Usage and
+  relationship families keep their own independent orderings.
 - In the 全部战法 skill ranking, a skill is labelled `影 · <name>` only when the
   source battle explicitly carried 影 provenance (for example an upstream `影・`
   tactic) or its skill catalog entry is marked `shadow: true`. Sharing a name with

--- a/web/src/components/analytics/RelationshipRankingPanel.tsx
+++ b/web/src/components/analytics/RelationshipRankingPanel.tsx
@@ -1,0 +1,550 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import LinkIcon from '@mui/icons-material/Link';
+import { formatSignedWeight } from '../../services/featureLabels';
+import type {
+  AnalyticsRelationshipFamily,
+  AnalyticsRelationshipRanking,
+  AnalyticsRelationshipRankings,
+} from '../../services/recommendationEngine';
+
+type RelationshipGroup = 'heroes' | 'skills' | 'special';
+
+export const RELATIONSHIP_PAGE_SIZE = 40;
+
+interface RelationshipMode {
+  family: AnalyticsRelationshipFamily;
+  label: string;
+  emptyLabel: string;
+  description: string;
+}
+
+interface RelationshipGroupOption {
+  value: RelationshipGroup;
+  label: string;
+  modes: readonly RelationshipMode[];
+}
+
+const RELATIONSHIP_GROUPS: readonly RelationshipGroupOption[] = [
+  {
+    value: 'heroes',
+    label: '武将搭配',
+    modes: [
+      {
+        family: 'HP',
+        label: '两人同队',
+        emptyLabel: '两人同队关系',
+        description: '展示两名武将同队时的额外组合分。',
+      },
+      {
+        family: 'HT',
+        label: '三人同队',
+        emptyLabel: '三人同队关系',
+        description: '展示完整三人队伍中三名确切武将共同出现时的额外组合分。',
+      },
+    ],
+  },
+  {
+    value: 'skills',
+    label: '战法搭配',
+    modes: [
+      {
+        family: 'HS',
+        label: '自己携带',
+        emptyLabel: '武将自己携带战法关系',
+        description: '展示某名武将自己携带某个战法时的额外组合分。',
+      },
+      {
+        family: 'THS',
+        label: '队内战法',
+        emptyLabel: '武将队内存在战法关系',
+        description:
+          '展示某名武将的确切三人队伍内存在某个战法时的额外组合分；该战法也可以由这名武将自己携带。',
+      },
+    ],
+  },
+  {
+    value: 'special',
+    label: '特殊加成',
+    modes: [
+      {
+        family: 'B',
+        label: '缘分',
+        emptyLabel: '缘分关系',
+        description: '展示目录中的缘分、激活所需人数和所有可参与成员。',
+      },
+      {
+        family: 'M',
+        label: '机制联动',
+        emptyLabel: '机制联动关系',
+        description:
+          '展示目录中的汇总机制关系。组合分属于整个机制、联动方式和作用侧，不属于任何一对具体战法。',
+      },
+    ],
+  },
+];
+
+const MODE_BY_FAMILY = new Map(
+  RELATIONSHIP_GROUPS.flatMap((group) =>
+    group.modes.map((mode) => [mode.family, mode] as const)
+  )
+);
+
+const groupForFamily = (
+  family: AnalyticsRelationshipFamily
+): RelationshipGroupOption =>
+  RELATIONSHIP_GROUPS.find((group) =>
+    group.modes.some((mode) => mode.family === family)
+  ) ?? RELATIONSHIP_GROUPS[0];
+
+/** Apply only identity filters that have a precise meaning for the active family. */
+export function filterRelationshipRankings(
+  rows: readonly AnalyticsRelationshipRanking[],
+  family: AnalyticsRelationshipFamily,
+  selectedHeroes: readonly string[],
+  selectedSkills: readonly string[]
+): AnalyticsRelationshipRanking[] {
+  const heroes = new Set(selectedHeroes);
+  const skills = new Set(selectedSkills);
+  const matchesHero = (row: AnalyticsRelationshipRanking): boolean =>
+    row.heroes.some((hero) => heroes.has(hero));
+  const matchesSkill = (row: AnalyticsRelationshipRanking): boolean =>
+    row.skills.some((skill) => skills.has(skill));
+
+  if (family === 'M') return [...rows];
+  if (family === 'HP' || family === 'HT' || family === 'B') {
+    return heroes.size > 0 ? rows.filter(matchesHero) : [...rows];
+  }
+  if (heroes.size === 0 && skills.size === 0) return [...rows];
+  return rows.filter(
+    (row) =>
+      (heroes.size > 0 && matchesHero(row)) ||
+      (skills.size > 0 && matchesSkill(row))
+  );
+}
+
+const filterStatus = (
+  family: AnalyticsRelationshipFamily,
+  selectedHeroes: readonly string[],
+  selectedSkills: readonly string[],
+  visibleCount: number,
+  matchingCount: number,
+  familyTotal: number
+): string => {
+  const hasHeroes = selectedHeroes.length > 0;
+  const hasSkills = selectedSkills.length > 0;
+  const visibleSummary = `当前显示 ${visibleCount} / ${matchingCount}`;
+  if (family === 'M') {
+    return hasHeroes || hasSkills
+      ? `机制联动是汇总机制关系，武将和战法筛选不适用于此榜，未应用；${visibleSummary}。`
+      : `${visibleSummary}。`;
+  }
+  if (family === 'HP' || family === 'HT' || family === 'B') {
+    if (hasHeroes) {
+      return `所选武将匹配 ${matchingCount} / ${familyTotal} 条全榜关系；${visibleSummary} 条匹配结果，排名保留全榜名次${hasSkills ? '；已选战法不用于此关系类型' : ''}。`;
+    }
+    return hasSkills
+      ? `战法筛选不适用于此关系类型，未应用；${visibleSummary}。`
+      : `${visibleSummary}。`;
+  }
+  return hasHeroes || hasSkills
+    ? `所选武将或战法匹配 ${matchingCount} / ${familyTotal} 条全榜关系；${visibleSummary} 条匹配结果，排名保留全榜名次。`
+    : `${visibleSummary}。`;
+};
+
+const HeroChip = ({ name }: { name: string }) => (
+  <Chip
+    data-testid="relationship-hero"
+    label={name}
+    color="primary"
+    size="small"
+    sx={{ maxWidth: '100%' }}
+  />
+);
+
+const SkillChip = ({ name }: { name: string }) => (
+  <Chip
+    data-testid="relationship-skill"
+    label={name}
+    color="secondary"
+    size="small"
+    variant="outlined"
+    sx={{ maxWidth: '100%' }}
+  />
+);
+
+const RelationshipWording = ({ row }: { row: AnalyticsRelationshipRanking }) => {
+  if (row.family === 'HP') {
+    return (
+      <Stack direction="row" gap={0.5} flexWrap="wrap" alignItems="center">
+        <HeroChip name={row.heroes[0]} />
+        <Typography component="span" variant="body2">同队</Typography>
+        <HeroChip name={row.heroes[1]} />
+      </Stack>
+    );
+  }
+  if (row.family === 'HT') {
+    return (
+      <Stack gap={0.5}>
+        <Typography variant="caption" color="text.secondary">三人同队</Typography>
+        <Stack direction="row" gap={0.5} flexWrap="wrap">
+          {row.heroes.map((hero) => <HeroChip key={hero} name={hero} />)}
+        </Stack>
+      </Stack>
+    );
+  }
+  if (row.family === 'HS' || row.family === 'THS') {
+    return (
+      <Stack direction="row" gap={0.5} flexWrap="wrap" alignItems="center">
+        <HeroChip name={row.heroes[0]} />
+        <Typography component="span" variant="body2">
+          {row.family === 'HS' ? '携带' : '队内存在'}
+        </Typography>
+        <SkillChip name={row.skills[0]} />
+      </Stack>
+    );
+  }
+  if (row.family === 'B' && row.bond) {
+    const memberNames = row.bond.members.join('、');
+    return (
+      <Stack gap={0.5}>
+        <Stack direction="row" gap={0.75} flexWrap="wrap" alignItems="center">
+          <Typography variant="body2" fontWeight={700}>{row.bond.name}</Typography>
+          <Typography variant="caption" color="text.secondary">
+            需要 {row.bond.required_members} 名成员激活
+          </Typography>
+        </Stack>
+        <Box
+          component="details"
+          sx={{ color: 'text.secondary', fontSize: '0.75rem' }}
+        >
+          <Box
+            component="summary"
+            aria-label={`查看缘分成员：${memberNames}`}
+            sx={{ cursor: 'pointer', width: 'fit-content' }}
+          >
+            查看 {row.bond.members.length} 位可参与成员
+          </Box>
+          <Stack direction="row" gap={0.5} flexWrap="wrap" sx={{ mt: 0.75 }}>
+            {row.bond.members.map((hero) => <HeroChip key={hero} name={hero} />)}
+          </Stack>
+        </Box>
+      </Stack>
+    );
+  }
+  if (row.family === 'M' && row.mechanic) {
+    return (
+      <Stack gap={0.25}>
+        <Typography variant="body2" fontWeight={700}>{row.mechanic.name}</Typography>
+        <Typography variant="caption" color="text.secondary">
+          联动方式：{row.mechanic.consumerRelationLabel} · 作用侧：{row.mechanic.sideLabel}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          汇总机制关系；该组合分不属于任何一对具体战法
+        </Typography>
+      </Stack>
+    );
+  }
+  return <Typography variant="body2">{row.label}</Typography>;
+};
+
+interface RelationshipRankingPanelProps {
+  rankings: AnalyticsRelationshipRankings;
+  selectedHeroes: readonly string[];
+  selectedSkills: readonly string[];
+}
+
+const RelationshipRankingPanel = ({
+  rankings,
+  selectedHeroes,
+  selectedSkills,
+}: RelationshipRankingPanelProps) => {
+  const [family, setFamily] =
+    useState<AnalyticsRelationshipFamily>('HP');
+  const group = groupForFamily(family);
+  const mode = MODE_BY_FAMILY.get(family) ?? group.modes[0];
+  const rows = useMemo(
+    () =>
+      filterRelationshipRankings(
+        rankings[family],
+        family,
+        selectedHeroes,
+        selectedSkills
+      ),
+    [family, rankings, selectedHeroes, selectedSkills]
+  );
+  const queryKey = JSON.stringify([family, selectedHeroes, selectedSkills]);
+  const [visibility, setVisibility] = useState({
+    queryKey,
+    limit: RELATIONSHIP_PAGE_SIZE,
+  });
+  const visibleLimit =
+    visibility.queryKey === queryKey
+      ? visibility.limit
+      : RELATIONSHIP_PAGE_SIZE;
+  useEffect(() => {
+    setVisibility((current) =>
+      current.queryKey === queryKey
+        ? current
+        : { queryKey, limit: RELATIONSHIP_PAGE_SIZE }
+    );
+  }, [queryKey]);
+  const visibleRows = rows.slice(0, visibleLimit);
+  const remainingCount = rows.length - visibleRows.length;
+  const nextPageCount = Math.min(RELATIONSHIP_PAGE_SIZE, remainingCount);
+
+  return (
+    <Card data-testid="relationship-ranking-panel" sx={{ mb: 4 }}>
+      <CardContent sx={{ p: { xs: 1.5, sm: 2.5 } }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', mb: 0.75 }}>
+          <LinkIcon sx={{ mr: 1, color: 'info.main' }} />
+          <Typography component="h4" variant="h6">关系搭配排名</Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          每种关系独立排名，不会混成一个总榜。组合分是关系的额外模型权重，不是单场胜负预测。
+        </Typography>
+
+        <Typography id="relationship-group-label" variant="subtitle2" sx={{ mb: 0.75 }}>
+          先选关系分组
+        </Typography>
+        <ToggleButtonGroup
+          value={group.value}
+          exclusive
+          aria-labelledby="relationship-group-label"
+          aria-label="关系排名分组"
+          onChange={(_, nextGroup: RelationshipGroup | null) => {
+            if (!nextGroup) return;
+            const option = RELATIONSHIP_GROUPS.find(
+              (candidate) => candidate.value === nextGroup
+            );
+            if (option) setFamily(option.modes[0].family);
+          }}
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+            width: '100%',
+            mb: 1.5,
+            '& .MuiToggleButtonGroup-grouped': {
+              minWidth: 0,
+              minHeight: 40,
+              px: { xs: 0.5, sm: 1.5 },
+              py: 0.5,
+              lineHeight: 1.25,
+            },
+          }}
+        >
+          {RELATIONSHIP_GROUPS.map((option) => (
+            <ToggleButton
+              key={option.value}
+              value={option.value}
+              data-relationship-group={option.value}
+            >
+              {option.label}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+
+        <Typography id="relationship-mode-label" variant="subtitle2" sx={{ mb: 0.75 }}>
+          再选关系类型
+        </Typography>
+        <ToggleButtonGroup
+          value={family}
+          exclusive
+          aria-labelledby="relationship-mode-label"
+          aria-label={`${group.label}关系类型`}
+          onChange={(_, nextFamily: AnalyticsRelationshipFamily | null) => {
+            if (nextFamily) setFamily(nextFamily);
+          }}
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+            width: '100%',
+            mb: 1.5,
+            '& .MuiToggleButtonGroup-grouped': {
+              minWidth: 0,
+              minHeight: 40,
+              px: 1,
+              py: 0.5,
+            },
+          }}
+        >
+          {group.modes.map((option) => (
+            <ToggleButton
+              key={option.family}
+              value={option.family}
+              data-relationship-family={option.family}
+              aria-controls="relationship-ranking-table"
+            >
+              {option.label}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+
+        <Typography
+          id="relationship-ranking-title"
+          component="h5"
+          variant="subtitle1"
+          fontWeight={700}
+        >
+          {mode.label}排名
+        </Typography>
+        <Typography
+          id="relationship-ranking-description"
+          variant="body2"
+          color="text.secondary"
+          sx={{ mb: 0.5 }}
+        >
+          {mode.description}
+        </Typography>
+        <Typography
+          role="status"
+          aria-live="polite"
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: 'block', mb: 1 }}
+        >
+          {filterStatus(
+            family,
+            selectedHeroes,
+            selectedSkills,
+            visibleRows.length,
+            rows.length,
+            rankings[family].length
+          )}
+        </Typography>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: { xs: 'block', sm: 'none' }, mb: 0.75 }}
+        >
+          排名表采用紧凑布局，可聚焦后滚动；缘分成员可按需展开。
+        </Typography>
+
+        <TableContainer
+          id="relationship-ranking-table"
+          role="region"
+          aria-label={`${mode.label}关系排名表格，可滚动`}
+          aria-describedby="relationship-ranking-description"
+          tabIndex={0}
+          sx={{ maxHeight: 720, overflowX: 'auto' }}
+        >
+          <Table
+            size="small"
+            stickyHeader
+            aria-label={`${mode.label}关系排名`}
+            sx={{
+              width: '100%',
+              tableLayout: 'fixed',
+              '& .MuiTableCell-root': {
+                px: { xs: 0.5, sm: 1.5 },
+                py: { xs: 0.75, sm: 1 },
+                overflowWrap: 'anywhere',
+              },
+              '& .MuiTableCell-head': {
+                fontSize: { xs: '0.72rem', sm: '0.875rem' },
+                lineHeight: 1.2,
+              },
+              '& .MuiChip-root': {
+                height: { xs: 22, sm: 24 },
+                maxWidth: '100%',
+              },
+              '& .MuiChip-label': {
+                px: { xs: 0.625, sm: 1 },
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              },
+            }}
+          >
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ width: { xs: '12%', sm: 72 } }}>排名</TableCell>
+                <TableCell sx={{ width: { xs: '52%', sm: 'auto' } }}>搭配</TableCell>
+                <TableCell align="right" sx={{ width: { xs: '18%', sm: 112 } }}>组合分</TableCell>
+                <TableCell align="right" sx={{ width: { xs: '18%', sm: 112 } }}>参考场次</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {visibleRows.map((row) => (
+                <TableRow
+                  key={row.featureId}
+                  data-testid="relationship-ranking-row"
+                  data-feature-family={row.family}
+                >
+                  <TableCell sx={{ fontVariantNumeric: 'tabular-nums' }}>
+                    {row.rank}
+                  </TableCell>
+                  <TableCell><RelationshipWording row={row} /></TableCell>
+                  <TableCell
+                    align="right"
+                    sx={{
+                      color:
+                        row.weight > 0
+                          ? 'success.main'
+                          : row.weight < 0
+                            ? 'error.main'
+                            : 'text.secondary',
+                      fontWeight: 700,
+                      fontVariantNumeric: 'tabular-nums',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {formatSignedWeight(row.weight, 3)}
+                  </TableCell>
+                  <TableCell
+                    align="right"
+                    sx={{ fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}
+                  >
+                    {row.support}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {rows.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4} align="center">
+                    暂无{mode.emptyLabel}数据
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        {remainingCount > 0 && (
+          <Button
+            type="button"
+            variant="outlined"
+            data-testid="relationship-show-more"
+            aria-controls="relationship-ranking-table"
+            aria-label={`显示更多${mode.label}关系：再显示 ${nextPageCount} 条`}
+            onClick={() =>
+              setVisibility({
+                queryKey,
+                limit: visibleLimit + RELATIONSHIP_PAGE_SIZE,
+              })
+            }
+            sx={{ mt: 1.5, minHeight: 40 }}
+          >
+            显示更多（再显示 {nextPageCount} 条）
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default RelationshipRankingPanel;

--- a/web/src/components/analytics/__tests__/RelationshipRankingPanel.render.test.tsx
+++ b/web/src/components/analytics/__tests__/RelationshipRankingPanel.render.test.tsx
@@ -1,0 +1,221 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import RelationshipRankingPanel from '../RelationshipRankingPanel';
+import type {
+  AnalyticsRelationshipFamily,
+  AnalyticsRelationshipRanking,
+  AnalyticsRelationshipRankings,
+} from '../../../services/recommendationEngine';
+
+const emptyRankings: AnalyticsRelationshipRankings = {
+  HP: [],
+  HT: [],
+  HS: [],
+  THS: [],
+  B: [],
+  M: [],
+};
+
+const makeRows = (
+  family: AnalyticsRelationshipFamily,
+  count: number
+): AnalyticsRelationshipRanking[] =>
+  Array.from({ length: count }, (_, index) => {
+    const rank = index + 1;
+    const primaryHero =
+      family === 'HP' && rank <= 60
+        ? '共同武将'
+        : family === 'HP' && rank === 65
+          ? '深层武将'
+          : `武将${rank}`;
+    const heroes =
+      family === 'HP'
+        ? [primaryHero, `搭档${rank}`]
+        : family === 'HT'
+          ? [`武将${rank}甲`, `武将${rank}乙`, `武将${rank}丙`]
+          : family === 'HS' || family === 'THS'
+            ? [primaryHero]
+            : family === 'B'
+              ? [primaryHero, `搭档${rank}`]
+              : [];
+    const skills =
+      family === 'HS' || family === 'THS' ? [`战法${rank}`] : [];
+    const bond =
+      family === 'B'
+        ? {
+            name: `缘分${rank}`,
+            required_members: 2 as const,
+            members: heroes,
+          }
+        : undefined;
+    const mechanic =
+      family === 'M'
+        ? {
+            name: `机制${rank}`,
+            consumerRelation: 'requires',
+            consumerRelationLabel: '需要',
+            side: 'friendly' as const,
+            sideLabel: '友方',
+          }
+        : undefined;
+    return {
+      rank,
+      featureId: `${family}|fixture-${String(rank).padStart(3, '0')}`,
+      family,
+      label: `${family}-${rank}`,
+      weight: rank <= 80 ? 1 - rank / 100 : -(rank - 80) / 100,
+      support: 100 + rank,
+      heroes,
+      skills,
+      ...(bond ? { bond } : {}),
+      ...(mechanic ? { mechanic } : {}),
+    };
+  });
+
+const pagedRankings: AnalyticsRelationshipRankings = {
+  HP: makeRows('HP', 85),
+  HT: makeRows('HT', 36),
+  HS: makeRows('HS', 85),
+  THS: makeRows('THS', 85),
+  B: makeRows('B', 34),
+  M: makeRows('M', 17),
+};
+
+const renderPanel = (
+  rankings: AnalyticsRelationshipRankings = pagedRankings,
+  selectedHeroes: string[] = [],
+  selectedSkills: string[] = []
+) =>
+  render(
+    <RelationshipRankingPanel
+      rankings={rankings}
+      selectedHeroes={selectedHeroes}
+      selectedSkills={selectedSkills}
+    />
+  );
+
+describe('RelationshipRankingPanel empty states', () => {
+  test('names the active relationship type in all six modes', () => {
+    renderPanel(emptyRankings);
+
+    const panel = screen.getByTestId('relationship-ranking-panel');
+    expect(within(panel).getByText('暂无两人同队关系数据')).toBeVisible();
+
+    fireEvent.click(within(panel).getByRole('button', { name: '三人同队' }));
+    expect(within(panel).getByText('暂无三人同队关系数据')).toBeVisible();
+
+    fireEvent.click(within(panel).getByRole('button', { name: '战法搭配' }));
+    expect(within(panel).getByText('暂无武将自己携带战法关系数据')).toBeVisible();
+
+    fireEvent.click(within(panel).getByRole('button', { name: '队内战法' }));
+    expect(within(panel).getByText('暂无武将队内存在战法关系数据')).toBeVisible();
+
+    fireEvent.click(within(panel).getByRole('button', { name: '特殊加成' }));
+    expect(within(panel).getByText('暂无缘分关系数据')).toBeVisible();
+
+    fireEvent.click(within(panel).getByRole('button', { name: '机制联动' }));
+    expect(within(panel).getByText('暂无机制联动关系数据')).toBeVisible();
+  });
+});
+
+describe('RelationshipRankingPanel progressive disclosure', () => {
+  test('renders 40 rows initially, reveals 40 at a time, and keeps negative rows reachable', () => {
+    renderPanel();
+    const panel = screen.getByTestId('relationship-ranking-panel');
+
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(40);
+    expect(within(panel).getByRole('status')).toHaveTextContent('当前显示 40 / 85');
+
+    const firstMore = within(panel).getByRole('button', {
+      name: '显示更多两人同队关系：再显示 40 条',
+    });
+    fireEvent.click(firstMore);
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(80);
+    expect(within(panel).getByRole('status')).toHaveTextContent('当前显示 80 / 85');
+
+    const lastMore = within(panel).getByRole('button', {
+      name: '显示更多两人同队关系：再显示 5 条',
+    });
+    fireEvent.click(lastMore);
+    const allRows = within(panel).getAllByTestId('relationship-ranking-row');
+    expect(allRows).toHaveLength(85);
+    expect(allRows[80]).toHaveTextContent('−0.010');
+    expect(within(panel).getByRole('status')).toHaveTextContent('当前显示 85 / 85');
+    expect(within(panel).queryByTestId('relationship-show-more')).not.toBeInTheDocument();
+  });
+
+  test('does not offer more when a family fits within the data-driven page size', () => {
+    renderPanel();
+    const panel = screen.getByTestId('relationship-ranking-panel');
+
+    fireEvent.click(within(panel).getByRole('button', { name: '三人同队' }));
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(36);
+    expect(within(panel).queryByTestId('relationship-show-more')).not.toBeInTheDocument();
+
+    fireEvent.click(within(panel).getByRole('button', { name: '特殊加成' }));
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(34);
+    expect(within(panel).queryByTestId('relationship-show-more')).not.toBeInTheDocument();
+
+    fireEvent.click(within(panel).getByRole('button', { name: '机制联动' }));
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(17);
+    expect(within(panel).queryByTestId('relationship-show-more')).not.toBeInTheDocument();
+  });
+
+  test('filters before limiting and displays an immutable global rank below 40', () => {
+    renderPanel(pagedRankings, ['深层武将']);
+    const panel = screen.getByTestId('relationship-ranking-panel');
+    const rows = within(panel).getAllByTestId('relationship-ranking-row');
+
+    expect(rows).toHaveLength(1);
+    expect(within(rows[0]).getAllByRole('cell')[0]).toHaveTextContent('65');
+    expect(rows[0]).toHaveTextContent('深层武将');
+    expect(within(panel).getByRole('status')).toHaveTextContent(
+      '所选武将匹配 1 / 85 条全榜关系；当前显示 1 / 1 条匹配结果，排名保留全榜名次'
+    );
+    expect(within(panel).queryByTestId('relationship-show-more')).not.toBeInTheDocument();
+  });
+
+  test('resets expansion after family and selected-filter changes', () => {
+    const view = renderPanel();
+    const panel = screen.getByTestId('relationship-ranking-panel');
+
+    fireEvent.click(within(panel).getByTestId('relationship-show-more'));
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(80);
+
+    fireEvent.click(within(panel).getByRole('button', { name: '三人同队' }));
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(36);
+    fireEvent.click(within(panel).getByRole('button', { name: '两人同队' }));
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(40);
+
+    fireEvent.click(within(panel).getByTestId('relationship-show-more'));
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(80);
+    view.rerender(
+      <RelationshipRankingPanel
+        rankings={pagedRankings}
+        selectedHeroes={['共同武将']}
+        selectedSkills={[]}
+      />
+    );
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(40);
+    expect(within(panel).getByRole('status')).toHaveTextContent(
+      '所选武将匹配 60 / 85 条全榜关系；当前显示 40 / 60 条匹配结果'
+    );
+    const filteredMore = within(panel).getByRole('button', {
+      name: '显示更多两人同队关系：再显示 20 条',
+    });
+    expect(filteredMore).toBeVisible();
+    fireEvent.click(filteredMore);
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(60);
+
+    view.rerender(
+      <RelationshipRankingPanel
+        rankings={pagedRankings}
+        selectedHeroes={['共同武将']}
+        selectedSkills={['不适用战法']}
+      />
+    );
+    expect(within(panel).getAllByTestId('relationship-ranking-row')).toHaveLength(40);
+    expect(within(panel).getByRole('status')).toHaveTextContent(
+      '已选战法不用于此关系类型'
+    );
+  });
+});

--- a/web/src/components/analytics/__tests__/RelationshipRankingPanel.test.ts
+++ b/web/src/components/analytics/__tests__/RelationshipRankingPanel.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import { filterRelationshipRankings } from '../RelationshipRankingPanel';
+import type {
+  AnalyticsRelationshipFamily,
+  AnalyticsRelationshipRanking,
+} from '../../../services/recommendationEngine';
+
+const row = (
+  family: AnalyticsRelationshipFamily,
+  rank: number,
+  heroes: string[] = [],
+  skills: string[] = []
+): AnalyticsRelationshipRanking => ({
+  rank,
+  featureId: `${family}|${rank}`,
+  family,
+  label: `${family}-${rank}`,
+  weight: 1 / rank,
+  support: rank * 10,
+  heroes,
+  skills,
+});
+
+describe('filterRelationshipRankings', () => {
+  test('applies only meaningful identity filters across all six modes and preserves true ranks', () => {
+    const hp = [row('HP', 3, ['甲', '乙']), row('HP', 9, ['丙', '丁'])];
+    const ht = [row('HT', 4, ['甲', '乙', '丙']), row('HT', 11, ['丁', '戊', '己'])];
+    const hs = [row('HS', 5, ['甲'], ['火攻']), row('HS', 12, ['乙'], ['治疗'])];
+    const ths = [row('THS', 6, ['甲'], ['增益']), row('THS', 14, ['丙'], ['火攻'])];
+    const bond = [row('B', 7, ['甲', '乙']), row('B', 16, ['丙', '丁'])];
+    const mechanic = [row('M', 2), row('M', 8)];
+
+    expect(filterRelationshipRankings(hp, 'HP', ['丙'], ['火攻']).map(({ rank }) => rank)).toEqual([9]);
+    expect(filterRelationshipRankings(ht, 'HT', ['乙'], []).map(({ rank }) => rank)).toEqual([4]);
+    expect(filterRelationshipRankings(hs, 'HS', ['乙'], ['火攻']).map(({ rank }) => rank)).toEqual([5, 12]);
+    expect(filterRelationshipRankings(ths, 'THS', [], ['火攻']).map(({ rank }) => rank)).toEqual([14]);
+    expect(filterRelationshipRankings(bond, 'B', ['丁'], ['治疗']).map(({ rank }) => rank)).toEqual([16]);
+    expect(filterRelationshipRankings(mechanic, 'M', ['甲'], ['火攻'])).toEqual(mechanic);
+  });
+
+  test('does not treat an inapplicable skill filter as filtering hero or bond rows', () => {
+    const hp = [row('HP', 2, ['甲', '乙']), row('HP', 17, ['丙', '丁'])];
+    const bond = [row('B', 4, ['甲', '乙']), row('B', 19, ['丙', '丁'])];
+
+    expect(filterRelationshipRankings(hp, 'HP', [], ['火攻'])).toEqual(hp);
+    expect(filterRelationshipRankings(bond, 'B', [], ['火攻'])).toEqual(bond);
+  });
+});

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -24,7 +24,6 @@ import {
   ToggleButtonGroup,
 } from '@mui/material';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
-import LinkIcon from '@mui/icons-material/Link';
 import ClearIcon from '@mui/icons-material/Clear';
 import InsightsIcon from '@mui/icons-material/Insights';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -38,6 +37,7 @@ import { heroRankingRank, skillRankingRank } from '../utils/rankings';
 import AutocompleteInput from '../components/common/AutocompleteInput';
 import TagList from '../components/common/TagList';
 import ResponsiveDisclosure from '../components/common/ResponsiveDisclosure';
+import RelationshipRankingPanel from '../components/analytics/RelationshipRankingPanel';
 import type { HeroMeta, SkillMeta } from '../types/game';
 import type { AnalyticsResult } from '../services/recommendationEngine';
 import type { TelemetryData, TelemetryItemAggregate } from '../types/telemetryData';
@@ -392,23 +392,10 @@ const Analytics = () => {
   const skillRankMap = new Map(sortedSkills.map((s, i) => [s.name, i + 1]));
   const heroUsageRankMap = new Map(data.hero_usage.map(([h], i) => [h, i + 1]));
   const skillUsageRankMap = new Map(data.skill_usage.map(([s], i) => [s, i + 1]));
-  const heroPairRankMap = new Map(data.top_hero_pairs.map((p, i) => [p.label, i + 1]));
-  const heroSkillRankMap = new Map(data.top_hero_skills.map((p, i) => [p.label, i + 1]));
-
   const filteredHeroes = hasHeroFilter ? sortedHeroes.filter((h) => heroFilterSet.has(h.name)) : sortedHeroes;
   const filteredSkills = hasSkillFilter ? sortedSkills.filter((s) => skillFilterSet.has(s.name)) : sortedSkills;
   const filteredHeroUsage = hasHeroFilter ? data.hero_usage.filter(([h]) => heroFilterSet.has(h)) : data.hero_usage;
   const filteredSkillUsage = hasSkillFilter ? data.skill_usage.filter(([s]) => skillFilterSet.has(s)) : data.skill_usage;
-  const filteredHeroPairs = hasHeroFilter
-    ? data.top_hero_pairs.filter((p) => p.label.split(' + ').some((n) => heroFilterSet.has(n)))
-    : data.top_hero_pairs;
-  const filteredHeroSkills = (hasHeroFilter || hasSkillFilter)
-    ? data.top_hero_skills.filter((p) => {
-        const [hero, skill] = p.label.split(' · ');
-        return (hasHeroFilter && heroFilterSet.has(hero)) || (hasSkillFilter && skillFilterSet.has(skill));
-      })
-    : data.top_hero_skills;
-
   const mq = data.model_quality;
 
   return (
@@ -492,7 +479,7 @@ const Analytics = () => {
               <Grid size={{ xs: 12, md: 4 }}>
                 <Typography variant="subtitle2" gutterBottom>2. 组合分</Typography>
                 <Typography variant="body2" color="text.secondary">
-                  仅用于下面的搭配榜，表示武将配对、武将战法组合在一起时的额外帮助。它与上面的单项模型权重分开计算。
+                  仅用于下面的关系榜，表示武将同队、战法搭配、缘分或汇总机制关系带来的额外帮助。各关系类型独立排名，并与上面的单项模型权重分开计算。
                 </Typography>
               </Grid>
               <Grid size={{ xs: 12, md: 4 }}>
@@ -521,7 +508,7 @@ const Analytics = () => {
             )}
           </Box>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-            输入你手上或想了解的武将、战法，下面所有的排名和搭配都会只显示相关内容。
+            输入你手上或想了解的武将、战法。单项和使用排名沿用全局筛选；关系榜只在所选身份对当前关系类型有明确含义时筛选，并会说明不适用的情况。
           </Typography>
           <Grid container spacing={2} sx={{ mb: 1 }}>
             <Grid size={{ xs: 12, md: 6 }}>
@@ -665,73 +652,13 @@ const Analytics = () => {
           <Typography component="h3" variant="h5">再看哪些搭配效果好</Typography>
         </Box>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          放在一起会互相加分的组合。组合分越高，同队时对整体阵容的帮助越大。
+          六种关系各自按组合分排名：先选分组，再选具体关系类型，不会把不同模型家族混在一个总榜中。
         </Typography>
-        <Card sx={{ mb: 4 }}>
-          <CardContent>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-              <LinkIcon sx={{ mr: 1, color: 'info.main' }} />
-              <Typography component="h4" variant="h6">最搭的武将组合</Typography>
-            </Box>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              这些武将同队时，模型给出的额外组合分最高。
-            </Typography>
-            <ResponsiveDisclosure label="最强武将配对">
-            <ScrollableAnalyticsTable label="最强武将配对">
-              <Table size="small" stickyHeader>
-                <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将配对</TableCell><TableCell align="right">组合分</TableCell><TableCell align="right">参考场次</TableCell></TableRow></TableHead>
-                <TableBody>
-                  {filteredHeroPairs.map((p) => (
-                    <TableRow key={p.label}>
-                      <TableCell>{heroPairRankMap.get(p.label)}</TableCell>
-                      <TableCell>
-                        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-                          {p.label.split(' + ').map((n, i) => <Chip key={i} label={n} color="primary" size="small" />)}
-                        </Box>
-                      </TableCell>
-                      <TableCell align="right" sx={{ color: 'success.main', fontWeight: 'bold' }}>{fmtStrength(p.weight)}</TableCell>
-                      <TableCell align="right">{p.support}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </ScrollableAnalyticsTable>
-            </ResponsiveDisclosure>
-          </CardContent>
-        </Card>
-
-        <Card sx={{ mb: 4 }}>
-          <CardContent>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-              <LinkIcon sx={{ mr: 1, color: 'secondary.main' }} />
-              <Typography component="h4" variant="h6">最搭的武将与战法</Typography>
-            </Box>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              某个武将带上某个战法时，模型给出的额外组合分最高。
-            </Typography>
-            <ResponsiveDisclosure label="最强武将战法组合">
-            <ScrollableAnalyticsTable label="最强武将战法组合">
-              <Table size="small" stickyHeader>
-                <TableHead><TableRow><TableCell>排名</TableCell><TableCell>武将</TableCell><TableCell>战法</TableCell><TableCell align="right">组合分</TableCell><TableCell align="right">参考场次</TableCell></TableRow></TableHead>
-                <TableBody>
-                  {filteredHeroSkills.map((p) => {
-                    const [hero, skill] = p.label.split(' · ');
-                    return (
-                      <TableRow key={p.label}>
-                        <TableCell>{heroSkillRankMap.get(p.label)}</TableCell>
-                        <TableCell><Chip label={hero} color="primary" size="small" /></TableCell>
-                        <TableCell><Chip label={skill} color="secondary" size="small" variant="outlined" /></TableCell>
-                        <TableCell align="right" sx={{ color: 'success.main', fontWeight: 'bold' }}>{fmtStrength(p.weight)}</TableCell>
-                        <TableCell align="right">{p.support}</TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </ScrollableAnalyticsTable>
-            </ResponsiveDisclosure>
-          </CardContent>
-        </Card>
+        <RelationshipRankingPanel
+          rankings={data.relationshipRankings}
+          selectedHeroes={selectedHeroes}
+          selectedSkills={selectedSkills}
+        />
 
         {/* Section 3: what everyone uses */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>

--- a/web/src/services/__tests__/featureLabels.test.ts
+++ b/web/src/services/__tests__/featureLabels.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest';
+import type { RecommendationCatalog } from '../../types/recommendation';
+import {
+  labelAnalyticsRelationship,
+  labelFeature,
+} from '../featureLabels';
+
+const catalog = {
+  mechanics: {
+    mechanic_names: {
+      'debuff:huo_gong': '火攻',
+    },
+  },
+} as unknown as RecommendationCatalog;
+
+describe('labelAnalyticsRelationship M validation', () => {
+  test('renders a valid catalog mechanic with a human-readable relation and exact side', () => {
+    expect(
+      labelAnalyticsRelationship(
+        'M|debuff:huo_gong|benefits_from|enemy',
+        catalog
+      )
+    ).toMatchObject({
+      label: '机制联动：火攻 · 受益于（敌方）',
+      mechanic: {
+        name: '火攻',
+        consumerRelation: 'benefits_from',
+        consumerRelationLabel: '受益于',
+        side: 'enemy',
+        sideLabel: '敌方',
+      },
+    });
+  });
+
+  test.each([
+    [
+      'M|debuff:huo_gong|requires',
+      /Malformed Analytics M feature; expected mechanic, relation, and side/,
+    ],
+    [
+      'M|debuff:unknown|requires|friendly',
+      /unknown catalog mechanic: debuff:unknown/,
+    ],
+    [
+      'M|debuff:huo_gong|provides|friendly',
+      /unsupported consumer relation: provides/,
+    ],
+    [
+      'M|debuff:huo_gong|requires|neutral',
+      /invalid side: neutral/,
+    ],
+  ])('fails closed for invalid feature %s', (featureId, message) => {
+    expect(() => labelAnalyticsRelationship(featureId, catalog)).toThrow(
+      message
+    );
+  });
+});
+
+describe('labelFeature general mechanic fallbacks', () => {
+  test('retains canonical mechanic and unknown relation values without a catalog', () => {
+    expect(
+      labelFeature('M|debuff:canonical_id|custom_relation|other').label
+    ).toBe('机制联动：debuff:canonical_id · custom_relation（友方）');
+  });
+});

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -3252,6 +3252,145 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
   });
 });
 
+describe('getAnalytics — unified relationship rankings', () => {
+  test('exposes only the six enabled relationship families with explicit catalog labels', () => {
+    const data = makeData({
+      enabled_families: [
+        'H',
+        'S',
+        'HP',
+        'HT',
+        'HS',
+        'THS',
+        'B',
+        'M',
+        'HC',
+        'SP',
+        'TSP',
+      ],
+      weights: {
+        'HP|甲|乙': 0.8,
+        'HP|甲|丙': 0.8,
+        'HT|甲|乙|丙': 0.7,
+        'HS|甲|火攻': 0.6,
+        'THS|乙|治疗': 0.5,
+        'B|测试缘分': 0.4,
+        'M|debuff:internal_mechanic|benefits_from|enemy': 0.3,
+        'HC|3': 9,
+        'SP|甲|火攻|治疗': 8,
+        'TSP|火攻|治疗': 7,
+        'TS3|火攻|治疗|增益': 6,
+      },
+      support: {
+        'HP|甲|乙': 80,
+        'HP|甲|丙': 70,
+        'HT|甲|乙|丙': 60,
+        'HS|甲|火攻': 50,
+        'THS|乙|治疗': 40,
+        'B|测试缘分': 30,
+        'M|debuff:internal_mechanic|benefits_from|enemy': 20,
+      },
+      n_features: 11,
+    });
+    data.catalog.relationships.bonds = [
+      {
+        name: '测试缘分',
+        required_members: 2,
+        members: ['丙', '乙', '甲'].sort(),
+      },
+    ];
+    data.catalog.mechanics.mechanic_names = {
+      'debuff:internal_mechanic': '人类可读机制',
+    };
+
+    const rankings = getAnalytics(
+      data,
+      { heroes: {}, skills: {} } as never
+    ).relationshipRankings;
+
+    expect(Object.keys(rankings)).toEqual(['HP', 'HT', 'HS', 'THS', 'B', 'M']);
+    expect(rankings.HP.map(({ featureId, rank }) => [featureId, rank])).toEqual([
+      ['HP|甲|丙', 1],
+      ['HP|甲|乙', 2],
+    ]);
+    expect(rankings.HP[1]).toMatchObject({
+      label: '甲 同队 乙',
+      weight: 0.8,
+      support: 80,
+      heroes: ['甲', '乙'],
+    });
+    expect(rankings.HT[0]).toMatchObject({
+      label: '甲、乙、丙 三人同队',
+      heroes: ['甲', '乙', '丙'],
+    });
+    expect(rankings.HS[0]).toMatchObject({
+      label: '甲 携带 火攻',
+      heroes: ['甲'],
+      skills: ['火攻'],
+    });
+    expect(rankings.THS[0]).toMatchObject({
+      label: '乙 队内存在 治疗',
+      heroes: ['乙'],
+      skills: ['治疗'],
+    });
+    expect(rankings.B[0]).toMatchObject({
+      label: '缘分 · 测试缘分',
+      bond: {
+        name: '测试缘分',
+        required_members: 2,
+        members: ['丙', '乙', '甲'].sort(),
+      },
+    });
+    expect(rankings.M[0]).toMatchObject({
+      label: '机制联动：人类可读机制 · 受益于（敌方）',
+      mechanic: {
+        name: '人类可读机制',
+        consumerRelationLabel: '受益于',
+        sideLabel: '敌方',
+      },
+    });
+    expect(rankings.M[0].label).not.toContain('internal_mechanic');
+    expect(JSON.stringify(rankings)).not.toContain('HC|3');
+    expect(JSON.stringify(rankings)).not.toContain('SP|');
+    expect(JSON.stringify(rankings)).not.toContain('TSP|');
+    expect(JSON.stringify(rankings)).not.toContain('TS3|');
+  });
+
+  test('retains every fitted row beyond 40 and uses stable feature-id ties', () => {
+    const weights = Object.fromEntries(
+      Array.from({ length: 45 }, (_, index) => [
+        `HP|甲${String(index).padStart(2, '0')}|乙`,
+        1,
+      ])
+    );
+    const data = makeData({
+      enabled_families: ['HP'],
+      weights,
+      support: Object.fromEntries(
+        Object.keys(weights).map((featureId, index) => [featureId, index])
+      ),
+      n_features: 45,
+    });
+
+    const rankings = getAnalytics(
+      data,
+      { heroes: {}, skills: {} } as never
+    ).relationshipRankings;
+
+    expect(rankings.HP).toHaveLength(45);
+    expect(rankings.HP[0].featureId).toBe('HP|甲00|乙');
+    expect(rankings.HP[44].featureId).toBe('HP|甲44|乙');
+    expect(rankings.HP.map(({ rank }) => rank)).toEqual(
+      Array.from({ length: 45 }, (_, index) => index + 1)
+    );
+    expect(rankings.HT).toEqual([]);
+    expect(rankings.HS).toEqual([]);
+    expect(rankings.THS).toEqual([]);
+    expect(rankings.B).toEqual([]);
+    expect(rankings.M).toEqual([]);
+  });
+});
+
 describe('integration with the real generated artifact', () => {
   test('artifact has the expected schema/shape', () => {
     expect(recommendationData.schema.version).toBe(7);
@@ -3311,6 +3450,12 @@ describe('integration with the real generated artifact', () => {
     expect(a.summary.total_battles).toBe(recommendationData.battle_counts.total_battles);
     expect(a.skills.find((skill) => skill.name === '星罗棋布')?.shadowTotal).toBe(0);
     expect(a.skills.find((skill) => skill.name === '万人之敌')?.shadowTotal).toBeGreaterThan(0);
+    for (const family of ['HP', 'HT', 'HS', 'THS', 'B', 'M'] as const) {
+      const fittedCount = Object.keys(recommendationData.model.weights).filter(
+        (featureId) => featureId.startsWith(`${family}|`)
+      ).length;
+      expect(a.relationshipRankings[family]).toHaveLength(fittedCount);
+    }
   });
 
   test('getAnalytics ranks heroes and skills by 强度加成 (strength) descending', () => {

--- a/web/src/services/featureLabels.ts
+++ b/web/src/services/featureLabels.ts
@@ -27,6 +27,133 @@ export const MECHANIC_RELATION_LABELS: Readonly<Record<string, string>> = {
   consumes: '消耗',
 };
 
+export const MECHANIC_SIDE_LABELS = {
+  friendly: '友方',
+  enemy: '敌方',
+} as const;
+
+const ANALYTICS_MECHANIC_CONSUMER_RELATIONS = [
+  'benefits_from',
+  'requires',
+  'consumes',
+] as const;
+
+type AnalyticsMechanicConsumerRelation =
+  (typeof ANALYTICS_MECHANIC_CONSUMER_RELATIONS)[number];
+
+const isAnalyticsMechanicConsumerRelation = (
+  relation: string
+): relation is AnalyticsMechanicConsumerRelation =>
+  ANALYTICS_MECHANIC_CONSUMER_RELATIONS.some(
+    (supported) => supported === relation
+  );
+
+export interface AnalyticsRelationshipLabel {
+  label: string;
+  family: string;
+  heroes: string[];
+  skills: string[];
+  mechanic?: {
+    name: string;
+    consumerRelation: AnalyticsMechanicConsumerRelation;
+    consumerRelationLabel: string;
+    side: keyof typeof MECHANIC_SIDE_LABELS;
+    sideLabel: string;
+  };
+}
+
+/**
+ * Player-facing relationship wording for the unified Analytics ranking.
+ * Unlike the compact evidence formatter below, this deliberately spells out
+ * the activation relationship. M labels fail closed unless every player-facing
+ * value can be resolved exactly from the reviewed catalog contract.
+ */
+export function labelAnalyticsRelationship(
+  featureId: string,
+  catalog: RecommendationCatalog
+): AnalyticsRelationshipLabel {
+  const [family, ...names] = featureId.split('|');
+  if (family === 'HP') {
+    return {
+      label: `${names[0]} 同队 ${names[1]}`,
+      family,
+      heroes: names.slice(0, 2),
+      skills: [],
+    };
+  }
+  if (family === 'HT') {
+    return {
+      label: `${names.slice(0, 3).join('、')} 三人同队`,
+      family,
+      heroes: names.slice(0, 3),
+      skills: [],
+    };
+  }
+  if (family === F_HERO_SKILL) {
+    return {
+      label: `${names[0]} 携带 ${names[1]}`,
+      family,
+      heroes: names.slice(0, 1),
+      skills: names.slice(1, 2),
+    };
+  }
+  if (family === F_TEAM_HERO_SKILL) {
+    return {
+      label: `${names[0]} 队内存在 ${names[1]}`,
+      family,
+      heroes: names.slice(0, 1),
+      skills: names.slice(1, 2),
+    };
+  }
+  if (family === F_BOND) {
+    return {
+      label: `缘分 · ${names[0]}`,
+      family,
+      heroes: [],
+      skills: [],
+    };
+  }
+  if (family === F_MECHANIC) {
+    if (names.length !== 3) {
+      throw new Error(
+        `Malformed Analytics M feature; expected mechanic, relation, and side: ${featureId}`
+      );
+    }
+    const [mechanic, consumerRelation, rawSide] = names;
+    const name = catalog.mechanics.mechanic_names[mechanic];
+    if (!name) {
+      throw new Error(
+        `Analytics M feature references an unknown catalog mechanic: ${mechanic}`
+      );
+    }
+    if (!isAnalyticsMechanicConsumerRelation(consumerRelation)) {
+      throw new Error(
+        `Analytics M feature has an unsupported consumer relation: ${consumerRelation}`
+      );
+    }
+    if (rawSide !== 'friendly' && rawSide !== 'enemy') {
+      throw new Error(`Analytics M feature has an invalid side: ${rawSide}`);
+    }
+    const side = rawSide;
+    const consumerRelationLabel = MECHANIC_RELATION_LABELS[consumerRelation];
+    const sideLabel = MECHANIC_SIDE_LABELS[side];
+    return {
+      label: `机制联动：${name} · ${consumerRelationLabel}（${sideLabel}）`,
+      family,
+      heroes: [],
+      skills: [],
+      mechanic: {
+        name,
+        consumerRelation,
+        consumerRelationLabel,
+        side,
+        sideLabel,
+      },
+    };
+  }
+  throw new Error(`Unsupported Analytics relationship family: ${family}`);
+}
+
 /** Format a model weight to fixed precision with an explicit sign. */
 export function formatSignedWeight(weight: number, digits: number): string {
   return `${weight >= 0 ? '+' : '−'}${Math.abs(weight).toFixed(digits)}`;

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -16,6 +16,7 @@ import type {
   RecommendationData,
   PairedModel,
   RecommendationCatalog,
+  BondRelationship,
 } from '../types/recommendation';
 import type {
   GameplayDatabase,
@@ -23,7 +24,10 @@ import type {
   TeamRanking,
   TeamSource,
 } from '../types/domain';
-import { labelFeature } from './featureLabels';
+import {
+  labelAnalyticsRelationship,
+  labelFeature,
+} from './featureLabels';
 import {
   type AssignedHero,
   type ActiveContribution,
@@ -5509,12 +5513,45 @@ export interface AnalyticsEntity {
   shadowTotal: number;
 }
 
-export interface TopSynergy {
+export const ANALYTICS_RELATIONSHIP_FAMILIES = [
+  'HP',
+  'HT',
+  'HS',
+  'THS',
+  'B',
+  'M',
+] as const;
+
+export type AnalyticsRelationshipFamily =
+  (typeof ANALYTICS_RELATIONSHIP_FAMILIES)[number];
+
+export interface AnalyticsRelationshipRanking {
+  /** Rank in the complete, unfiltered family list. */
+  rank: number;
+  /** Canonical id retained as a stable React/data key; never rendered to players. */
+  featureId: string;
+  family: AnalyticsRelationshipFamily;
+  /** Catalog-aware, explicit relationship wording. */
   label: string;
-  family: string;
+  /** Exact fitted model coefficient. */
   weight: number;
   support: number;
+  heroes: string[];
+  skills: string[];
+  bond?: BondRelationship;
+  mechanic?: {
+    name: string;
+    consumerRelation: string;
+    consumerRelationLabel: string;
+    side: 'friendly' | 'enemy';
+    sideLabel: string;
+  };
 }
+
+export type AnalyticsRelationshipRankings = Record<
+  AnalyticsRelationshipFamily,
+  AnalyticsRelationshipRanking[]
+>;
 
 export interface AnalyticsResult {
   summary: {
@@ -5539,10 +5576,8 @@ export interface AnalyticsResult {
   skills: AnalyticsEntity[];
   hero_usage: [string, number][];
   skill_usage: [string, number][];
-  /** Strongest fitted hero-pair synergies. */
-  top_hero_pairs: TopSynergy[];
-  /** Strongest fitted hero-skill assignments. */
-  top_hero_skills: TopSynergy[];
+  /** Complete independent rankings for the six player-facing relationship families. */
+  relationshipRankings: AnalyticsRelationshipRankings;
 }
 
 /**
@@ -5552,8 +5587,11 @@ export interface AnalyticsResult {
  * then name) so consumers can render them directly. The model column still exposes
  * each item's full-precision relative roster-strength
  * weight, and the smoothed-win-rate / reference-battle columns remain available.
- * Usage and synergy rankings keep their own orderings. Backtest metrics surface
- * model quality.
+ * Usage and relationship rankings keep their own orderings. Each enabled
+ * player-facing relationship family exposes every fitted weight, sorted by
+ * weight descending and then canonical feature id. The UI applies filters
+ * before progressively disclosing those immutable full-family ranks. Backtest
+ * metrics surface model quality.
  */
 export function getAnalytics(
   data: RecommendationData,
@@ -5598,15 +5636,59 @@ export function getAnalytics(
     .sort((x, y) => y.total - x.total || x.name.localeCompare(y.name))
     .map((r) => [r.name, r.total]);
 
-  const collectFamily = (prefix: string, limit: number): TopSynergy[] =>
-    (Object.entries(m.weights) as [string, number][])
-      .filter(([fid]) => fid.startsWith(prefix))
-      .sort((x, y) => y[1] - x[1])
-      .slice(0, limit)
-      .map(([fid, w]) => {
-        const { label, family } = labelFeature(fid);
-        return { label, family, weight: roundTo(w, 4), support: supportOf(m, fid) };
+  const bondByName = new Map(
+    data.catalog.relationships.bonds.map((bond) => [bond.name, bond])
+  );
+  const collectRelationshipFamily = (
+    family: AnalyticsRelationshipFamily
+  ): AnalyticsRelationshipRanking[] => {
+    if (!m.enabled_families.includes(family)) return [];
+    return (Object.entries(m.weights) as [string, number][])
+      .filter(([featureId]) => featureId.startsWith(`${family}|`))
+      .sort(([leftId, leftWeight], [rightId, rightWeight]) =>
+        rightWeight !== leftWeight
+          ? rightWeight - leftWeight
+          : leftId < rightId
+            ? -1
+            : leftId > rightId
+              ? 1
+              : 0
+      )
+      .map(([featureId, weight], index) => {
+        const display = labelAnalyticsRelationship(featureId, data.catalog);
+        const bondName = family === F_BOND ? featureId.split('|')[1] : null;
+        const bond = bondName ? bondByName.get(bondName) : undefined;
+        if (family === F_BOND && !bond) {
+          throw new Error(`Missing catalog bond for Analytics feature: ${bondName}`);
+        }
+        return {
+          rank: index + 1,
+          featureId,
+          family,
+          label: display.label,
+          weight,
+          support: supportOf(m, featureId),
+          heroes: bond ? [...bond.members] : display.heroes,
+          skills: display.skills,
+          ...(bond
+            ? {
+                bond: {
+                  ...bond,
+                  members: [...bond.members],
+                },
+              }
+            : {}),
+          ...(display.mechanic ? { mechanic: display.mechanic } : {}),
+        };
       });
+  };
+
+  const relationshipRankings = Object.fromEntries(
+    ANALYTICS_RELATIONSHIP_FAMILIES.map((family) => [
+      family,
+      collectRelationshipFamily(family),
+    ])
+  ) as AnalyticsRelationshipRankings;
 
   return {
     summary: {
@@ -5630,7 +5712,6 @@ export function getAnalytics(
     skills,
     hero_usage,
     skill_usage,
-    top_hero_pairs: collectFamily('HP|', 40),
-    top_hero_skills: collectFamily('HS|', 40),
+    relationshipRankings,
   };
 }

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -5583,7 +5583,7 @@ export interface AnalyticsResult {
 /**
  * Build the Analytics-page payload from the generated artifact. The `heroes` and
  * `skills` rankings are returned sorted by descending relative roster-strength
- * (`强度加成`), with deterministic tie-breakers (descending reference battles,
+ * (`模型权重`), with deterministic tie-breakers (descending reference battles,
  * then name) so consumers can render them directly. The model column still exposes
  * each item's full-precision relative roster-strength
  * weight, and the smoothed-win-rate / reference-battle columns remain available.
@@ -5619,7 +5619,7 @@ export function getAnalytics(
     shadowTotal: row.shadow_total ?? 0,
   });
 
-  // Rank both lists by 强度加成 (relative roster strength) descending, with
+  // Rank both lists by 模型权重 (relative roster strength) descending, with
   // deterministic tie-breakers so equal-strength rows are stably ordered.
   const byStrength = (x: AnalyticsEntity, y: AnalyticsEntity): number =>
     y.strength - x.strength ||

--- a/web/tests/analyticsRelationships.spec.js
+++ b/web/tests/analyticsRelationships.spec.js
@@ -76,6 +76,31 @@ async function addFilter(page, placeholder, value) {
 
 const HERO_PLACEHOLDER = '输入武将名或拼音...';
 const SKILL_PLACEHOLDER = '输入战法名或拼音...';
+const PAGE_SIZE = 40;
+
+async function expectUnfilteredPage(page, family, requestedLimit = PAGE_SIZE) {
+  const relationshipPanel = panel(page);
+  const total = rankedFeatures(family).length;
+  const visible = Math.min(total, requestedLimit);
+  const remaining = total - visible;
+
+  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(visible);
+  await expect(relationshipPanel.getByRole('status')).toContainText(
+    `当前显示 ${visible} / ${total}`
+  );
+
+  if (remaining > 0) {
+    await expect(
+      relationshipPanel.getByRole('button', {
+        name: `显示更多${MODE_FOR_FAMILY[family]}关系：再显示 ${Math.min(PAGE_SIZE, remaining)} 条`,
+      })
+    ).toBeVisible();
+  } else {
+    await expect(relationshipPanel.getByTestId('relationship-show-more')).toHaveCount(0);
+  }
+
+  return { total, visible };
+}
 
 test('unified relationship panel renders all six independent families with exact semantics', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 1000 });
@@ -260,33 +285,29 @@ test('all relationship filters preserve full-list ranks and ignore inapplicable 
 test('relationship rows progressively disclose after filtering and reset per query', async ({ page }) => {
   await page.goto('/analytics');
   const relationshipPanel = panel(page);
-  const hpCount = rankedFeatures('HP').length;
 
   await activateFamily(page, 'HP');
-  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(40);
-  await expect(relationshipPanel.getByRole('status')).toContainText(`当前显示 40 / ${hpCount}`);
-  const more = relationshipPanel.getByRole('button', {
-    name: '显示更多两人同队关系：再显示 40 条',
-  });
-  await expect(more).toBeVisible();
-  await more.click();
-  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(80);
-  await expect(relationshipPanel.getByRole('status')).toContainText(`当前显示 80 / ${hpCount}`);
+  const { total: hpCount, visible: hpInitialCount } = await expectUnfilteredPage(page, 'HP');
+  if (hpCount > hpInitialCount) {
+    await relationshipPanel.getByTestId('relationship-show-more').click();
+    await expectUnfilteredPage(page, 'HP', PAGE_SIZE * 2);
+  }
 
   for (const family of ['HT', 'B', 'M']) {
     await activateFamily(page, family);
-    await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(
-      rankedFeatures(family).length
-    );
-    await expect(relationshipPanel.getByTestId('relationship-show-more')).toHaveCount(0);
+    await expectUnfilteredPage(page, family);
   }
 
   await activateFamily(page, 'HP');
-  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(40);
-  await relationshipPanel.getByTestId('relationship-show-more').click();
-  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(80);
+  await expectUnfilteredPage(page, 'HP');
+  if (hpCount > hpInitialCount) {
+    await relationshipPanel.getByTestId('relationship-show-more').click();
+    await expectUnfilteredPage(page, 'HP', PAGE_SIZE * 2);
+  }
   await addFilter(page, SKILL_PLACEHOLDER, '折冲御侮');
-  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(40);
+  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(
+    hpInitialCount
+  );
   await expect(relationshipPanel.getByRole('status')).toContainText(
     '战法筛选不适用于此关系类型，未应用'
   );
@@ -335,7 +356,17 @@ test('negative fitted relationships remain reachable', async ({ page }) => {
 
   await page.goto('/analytics');
   await activateFamily(page, 'M');
-  const row = panel(page).getByTestId('relationship-ranking-row').nth(negativeIndex);
+  const rows = panel(page).getByTestId('relationship-ranking-row');
+  const requiredAdditionalPages = Math.floor(negativeIndex / PAGE_SIZE);
+  for (let pageIndex = 0; pageIndex < requiredAdditionalPages; pageIndex += 1) {
+    const more = panel(page).getByTestId('relationship-show-more');
+    await expect(more).toBeVisible();
+    await more.click();
+    await expect(rows).toHaveCount(
+      Math.min(mechanics.length, (pageIndex + 2) * PAGE_SIZE)
+    );
+  }
+  const row = rows.nth(negativeIndex);
   await expect(row.locator('td').first()).toHaveText(String(negativeIndex + 1));
   await expect(row.locator('td').nth(2)).toContainText('−');
 });
@@ -373,12 +404,14 @@ test('two-level selectors work by keyboard and the ranking stays compact at 320p
   });
   await expect(tableRegion).toHaveAttribute('tabindex', '0');
   await expect(tableRegion.getByRole('columnheader')).toHaveCount(4);
-  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(40);
-  const more = relationshipPanel.getByRole('button', {
-    name: '显示更多队内战法关系：再显示 40 条',
-  });
-  await expect(more).toBeVisible();
-  await expect(more).toHaveAttribute('aria-controls', 'relationship-ranking-table');
+  const { total: thsCount, visible: thsInitialCount } = await expectUnfilteredPage(
+    page,
+    'THS'
+  );
+  const more = relationshipPanel.getByTestId('relationship-show-more');
+  if (thsCount > thsInitialCount) {
+    await expect(more).toHaveAttribute('aria-controls', 'relationship-ranking-table');
+  }
   await expect(relationshipPanel).not.toContainText('队友携带');
 
   const geometry = await page.evaluate(() => {
@@ -389,12 +422,12 @@ test('two-level selectors work by keyboard and the ranking stays compact at 320p
       bodyOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
       cardRight: card?.getBoundingClientRect().right ?? Infinity,
       regionRight: region?.getBoundingClientRect().right ?? Infinity,
-      moreRight: moreButton?.getBoundingClientRect().right ?? Infinity,
+      moreRight: moreButton?.getBoundingClientRect().right ?? null,
       viewport: window.innerWidth,
     };
   });
   expect(geometry.bodyOverflow).toBeLessThanOrEqual(1);
   expect(geometry.cardRight).toBeLessThanOrEqual(geometry.viewport + 1);
   expect(geometry.regionRight).toBeLessThanOrEqual(geometry.viewport + 1);
-  expect(geometry.moreRight).toBeLessThanOrEqual(geometry.viewport + 1);
+  expect(geometry.moreRight === null || geometry.moreRight <= geometry.viewport + 1).toBe(true);
 });

--- a/web/tests/analyticsRelationships.spec.js
+++ b/web/tests/analyticsRelationships.spec.js
@@ -1,0 +1,400 @@
+const { test, expect } = require('@playwright/test');
+const recommendationData = require('../src/recommendation_data.json');
+
+const panel = (page) => page.getByTestId('relationship-ranking-panel');
+
+const GROUP_FOR_FAMILY = {
+  HP: '武将搭配',
+  HT: '武将搭配',
+  HS: '战法搭配',
+  THS: '战法搭配',
+  B: '特殊加成',
+  M: '特殊加成',
+};
+const MODE_FOR_FAMILY = {
+  HP: '两人同队',
+  HT: '三人同队',
+  HS: '自己携带',
+  THS: '队内战法',
+  B: '缘分',
+  M: '机制联动',
+};
+const RELATION_LABELS = {
+  benefits_from: '受益于',
+  requires: '需要',
+  consumes: '消耗',
+};
+
+function rankedFeatures(family) {
+  return Object.entries(recommendationData.model.weights)
+    .filter(([featureId]) => featureId.startsWith(`${family}|`))
+    .sort(([leftId, leftWeight], [rightId, rightWeight]) =>
+      rightWeight - leftWeight || (leftId < rightId ? -1 : leftId > rightId ? 1 : 0)
+    );
+}
+
+async function activateFamily(page, family) {
+  const relationshipPanel = panel(page);
+  const group = relationshipPanel.getByRole('button', {
+    name: GROUP_FOR_FAMILY[family],
+    exact: true,
+  });
+  await group.click();
+  const mode = relationshipPanel.getByRole('button', {
+    name: MODE_FOR_FAMILY[family],
+    exact: true,
+  });
+  await mode.click();
+  await expect(mode).toHaveAttribute('aria-pressed', 'true');
+  await expect(
+    relationshipPanel.getByRole('region', {
+      name: `${MODE_FOR_FAMILY[family]}关系排名表格，可滚动`,
+    })
+  ).toBeVisible();
+}
+
+async function activeRows(page) {
+  const rows = panel(page).getByTestId('relationship-ranking-row');
+  const count = await rows.count();
+  const result = [];
+  for (let index = 0; index < count; index += 1) {
+    const current = rows.nth(index);
+    result.push({
+      rank: Number((await current.locator('td').nth(0).innerText()).trim()),
+      label: (await current.locator('td').nth(1).innerText()).trim(),
+    });
+  }
+  return result;
+}
+
+async function addFilter(page, placeholder, value) {
+  const input = page.getByPlaceholder(placeholder);
+  await input.click();
+  await input.fill(value);
+  await page.getByRole('option').filter({ hasText: value }).first().click();
+}
+
+const HERO_PLACEHOLDER = '输入武将名或拼音...';
+const SKILL_PLACEHOLDER = '输入战法名或拼音...';
+
+test('unified relationship panel renders all six independent families with exact semantics', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 1000 });
+  await page.goto('/analytics');
+
+  const relationshipPanel = panel(page);
+  await expect(
+    relationshipPanel.getByRole('heading', { name: '关系搭配排名', exact: true })
+  ).toBeVisible();
+  await expect(
+    relationshipPanel.getByRole('button', { name: '武将搭配', exact: true })
+  ).toBeVisible();
+  await expect(
+    relationshipPanel.getByRole('button', { name: '战法搭配', exact: true })
+  ).toBeVisible();
+  await expect(
+    relationshipPanel.getByRole('button', { name: '特殊加成', exact: true })
+  ).toBeVisible();
+  await expect(page.getByText('最搭的武将组合', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('最搭的武将与战法', { exact: true })).toHaveCount(0);
+
+  const exposedFamilies = new Set();
+  for (const group of ['武将搭配', '战法搭配', '特殊加成']) {
+    await relationshipPanel.getByRole('button', { name: group, exact: true }).click();
+    const values = await relationshipPanel
+      .locator('[data-relationship-family]')
+      .evaluateAll((elements) => elements.map((element) => element.getAttribute('data-relationship-family')));
+    values.forEach((value) => exposedFamilies.add(value));
+  }
+  expect([...exposedFamilies].sort()).toEqual(['B', 'HP', 'HS', 'HT', 'M', 'THS']);
+  for (const excluded of ['HC', 'SP', 'TSP', 'TS3']) {
+    expect(exposedFamilies.has(excluded)).toBe(false);
+  }
+
+  await activateFamily(page, 'HP');
+  const hpId = rankedFeatures('HP')[0][0];
+  const hpNames = hpId.split('|').slice(1);
+  let firstRow = relationshipPanel.getByTestId('relationship-ranking-row').first();
+  await expect(firstRow).toContainText('同队');
+  await expect(firstRow.getByTestId('relationship-hero')).toHaveText(hpNames);
+
+  await activateFamily(page, 'HT');
+  const htNames = rankedFeatures('HT')[0][0].split('|').slice(1);
+  firstRow = relationshipPanel.getByTestId('relationship-ranking-row').first();
+  await expect(firstRow).toContainText('三人同队');
+  await expect(firstRow.getByTestId('relationship-hero')).toHaveText(htNames);
+
+  await activateFamily(page, 'HS');
+  const [, hsHero, hsSkill] = rankedFeatures('HS')[0][0].split('|');
+  firstRow = relationshipPanel.getByTestId('relationship-ranking-row').first();
+  await expect(firstRow).toContainText('携带');
+  await expect(firstRow.getByTestId('relationship-hero')).toHaveText([hsHero]);
+  await expect(firstRow.getByTestId('relationship-skill')).toHaveText([hsSkill]);
+
+  await activateFamily(page, 'THS');
+  const [, thsHero, thsSkill] = rankedFeatures('THS')[0][0].split('|');
+  firstRow = relationshipPanel.getByTestId('relationship-ranking-row').first();
+  await expect(firstRow).toContainText('队内存在');
+  await expect(firstRow).not.toContainText('队友携带');
+  await expect(firstRow.getByTestId('relationship-hero')).toHaveText([thsHero]);
+  await expect(firstRow.getByTestId('relationship-skill')).toHaveText([thsSkill]);
+  await expect(relationshipPanel).not.toContainText('队友携带');
+
+  await activateFamily(page, 'B');
+  const bondName = rankedFeatures('B')[0][0].split('|')[1];
+  const bond = recommendationData.catalog.relationships.bonds.find(
+    (candidate) => candidate.name === bondName
+  );
+  expect(bond).toBeTruthy();
+  firstRow = relationshipPanel.getByTestId('relationship-ranking-row').first();
+  await expect(firstRow).toContainText(bond.name);
+  await expect(firstRow).toContainText(`需要 ${bond.required_members} 名成员激活`);
+  const memberDisclosure = firstRow.locator('summary');
+  await expect(memberDisclosure).toHaveAttribute(
+    'aria-label',
+    `查看缘分成员：${bond.members.join('、')}`
+  );
+  await memberDisclosure.click();
+  await expect(firstRow.getByTestId('relationship-hero')).toHaveText(bond.members);
+
+  await activateFamily(page, 'M');
+  const [, mechanicId, relation, side] = rankedFeatures('M')[0][0].split('|');
+  const mechanicName = recommendationData.catalog.mechanics.mechanic_names[mechanicId];
+  firstRow = relationshipPanel.getByTestId('relationship-ranking-row').first();
+  await expect(firstRow).toContainText(mechanicName);
+  await expect(firstRow).toContainText(`联动方式：${RELATION_LABELS[relation]}`);
+  await expect(firstRow).toContainText(`作用侧：${side === 'enemy' ? '敌方' : '友方'}`);
+  await expect(firstRow).toContainText('汇总机制关系');
+  await expect(firstRow).toContainText('该组合分不属于任何一对具体战法');
+  await expect(firstRow).not.toContainText(mechanicId);
+  await expect(firstRow.getByTestId('relationship-skill')).toHaveCount(0);
+
+  const headers = await relationshipPanel.getByRole('columnheader').allInnerTexts();
+  expect(headers.map((header) => header.trim())).toEqual([
+    '排名',
+    '搭配',
+    '组合分',
+    '参考场次',
+  ]);
+});
+
+test('all relationship filters preserve full-list ranks and ignore inapplicable identities', async ({ page }) => {
+  const cases = [
+    { family: 'HP', filter: 'hero' },
+    { family: 'HT', filter: 'hero' },
+    { family: 'HS', filter: 'hero' },
+    { family: 'THS', filter: 'skill' },
+    { family: 'B', filter: 'bond-member' },
+  ];
+
+  for (const { family, filter } of cases) {
+    await page.goto('/analytics');
+    await activateFamily(page, family);
+    const before = await activeRows(page);
+    expect(before.length).toBeGreaterThan(4);
+    before.forEach(({ rank }, index) => expect(rank).toBe(index + 1));
+    const targetIndex = 4;
+    const familyFeatures = rankedFeatures(family);
+    const featureId = familyFeatures[targetIndex][0];
+    const parts = featureId.split('|').slice(1);
+    let filterValue;
+
+    if (filter === 'hero') {
+      filterValue = parts[0];
+      await addFilter(page, HERO_PLACEHOLDER, filterValue);
+    } else if (filter === 'skill') {
+      filterValue = parts[1];
+      await addFilter(page, SKILL_PLACEHOLDER, filterValue);
+    } else {
+      const bond = recommendationData.catalog.relationships.bonds.find(
+        (candidate) => candidate.name === parts[0]
+      );
+      filterValue = bond.members[0];
+      await addFilter(page, HERO_PLACEHOLDER, filterValue);
+    }
+
+    const expectedRanks = familyFeatures
+      .map(([candidateId], index) => ({
+        rank: index + 1,
+        parts: candidateId.split('|').slice(1),
+      }))
+      .filter(({ parts: candidateParts }) => {
+        if (filter === 'hero') {
+          return family === 'HP' || family === 'HT'
+            ? candidateParts.includes(filterValue)
+            : candidateParts[0] === filterValue;
+        }
+        if (filter === 'skill') return candidateParts[1] === filterValue;
+        const bond = recommendationData.catalog.relationships.bonds.find(
+          (candidate) => candidate.name === candidateParts[0]
+        );
+        return bond.members.includes(filterValue);
+      })
+      .slice(0, 40)
+      .map(({ rank }) => rank);
+    const after = await activeRows(page);
+    expect(after.map(({ rank }) => rank)).toEqual(expectedRanks);
+    expect(after.some(({ rank }) => rank === targetIndex + 1)).toBe(true);
+  }
+
+  // A skill has no precise meaning for HP and must neither filter nor be described as applied.
+  await page.goto('/analytics');
+  await activateFamily(page, 'HP');
+  const hpBefore = await activeRows(page);
+  await addFilter(page, SKILL_PLACEHOLDER, '折冲御侮');
+  expect(await activeRows(page)).toEqual(hpBefore);
+  await expect(panel(page).getByRole('status')).toContainText('战法筛选不适用于此关系类型');
+  await expect(panel(page).getByRole('status')).not.toContainText('已按');
+
+  // M is an aggregate relationship, so both global filters leave its full ranking unchanged.
+  await page.goto('/analytics');
+  await activateFamily(page, 'M');
+  const mechanicBefore = await activeRows(page);
+  await addFilter(page, HERO_PLACEHOLDER, '祝融');
+  await addFilter(page, SKILL_PLACEHOLDER, '折冲御侮');
+  expect(await activeRows(page)).toEqual(mechanicBefore);
+  await expect(panel(page).getByRole('status')).toContainText(
+    '武将和战法筛选不适用于此榜，未应用；当前显示'
+  );
+});
+
+test('relationship rows progressively disclose after filtering and reset per query', async ({ page }) => {
+  await page.goto('/analytics');
+  const relationshipPanel = panel(page);
+  const hpCount = rankedFeatures('HP').length;
+
+  await activateFamily(page, 'HP');
+  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(40);
+  await expect(relationshipPanel.getByRole('status')).toContainText(`当前显示 40 / ${hpCount}`);
+  const more = relationshipPanel.getByRole('button', {
+    name: '显示更多两人同队关系：再显示 40 条',
+  });
+  await expect(more).toBeVisible();
+  await more.click();
+  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(80);
+  await expect(relationshipPanel.getByRole('status')).toContainText(`当前显示 80 / ${hpCount}`);
+
+  for (const family of ['HT', 'B', 'M']) {
+    await activateFamily(page, family);
+    await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(
+      rankedFeatures(family).length
+    );
+    await expect(relationshipPanel.getByTestId('relationship-show-more')).toHaveCount(0);
+  }
+
+  await activateFamily(page, 'HP');
+  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(40);
+  await relationshipPanel.getByTestId('relationship-show-more').click();
+  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(80);
+  await addFilter(page, SKILL_PLACEHOLDER, '折冲御侮');
+  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(40);
+  await expect(relationshipPanel.getByRole('status')).toContainText(
+    '战法筛选不适用于此关系类型，未应用'
+  );
+});
+
+test('filtering can surface a globally lower-ranked relationship immediately', async ({ page }) => {
+  const features = rankedFeatures('HP');
+  let target = null;
+  for (let index = 40; index < features.length && !target; index += 1) {
+    const heroes = features[index][0].split('|').slice(1);
+    for (const hero of heroes) {
+      const priorMatches = features
+        .slice(0, index)
+        .filter(([featureId]) => featureId.split('|').slice(1).includes(hero)).length;
+      if (priorMatches < 40) {
+        target = { hero, rank: index + 1 };
+        break;
+      }
+    }
+  }
+  expect(target).toBeTruthy();
+
+  await page.goto('/analytics');
+  await activateFamily(page, 'HP');
+  await addFilter(page, HERO_PLACEHOLDER, target.hero);
+
+  const matchingRanks = features
+    .map(([featureId], index) => ({
+      rank: index + 1,
+      matches: featureId.split('|').slice(1).includes(target.hero),
+    }))
+    .filter(({ matches }) => matches)
+    .map(({ rank }) => rank);
+  const rendered = await activeRows(page);
+  expect(rendered.map(({ rank }) => rank)).toEqual(matchingRanks.slice(0, 40));
+  expect(rendered.some(({ rank }) => rank === target.rank)).toBe(true);
+  await expect(panel(page).getByRole('status')).toContainText(
+    `所选武将匹配 ${matchingRanks.length} / ${features.length} 条全榜关系`
+  );
+});
+
+test('negative fitted relationships remain reachable', async ({ page }) => {
+  const mechanics = rankedFeatures('M');
+  const negativeIndex = mechanics.findIndex(([, weight]) => weight < 0);
+  expect(negativeIndex).toBeGreaterThanOrEqual(0);
+
+  await page.goto('/analytics');
+  await activateFamily(page, 'M');
+  const row = panel(page).getByTestId('relationship-ranking-row').nth(negativeIndex);
+  await expect(row.locator('td').first()).toHaveText(String(negativeIndex + 1));
+  await expect(row.locator('td').nth(2)).toContainText('−');
+});
+
+test('two-level selectors work by keyboard and the ranking stays compact at 320px', async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 800 });
+  await page.goto('/analytics');
+
+  const relationshipPanel = panel(page);
+  const skillsGroup = relationshipPanel.getByRole('button', {
+    name: '战法搭配',
+    exact: true,
+  });
+  await skillsGroup.focus();
+  await page.keyboard.press('Enter');
+  await expect(skillsGroup).toHaveAttribute('aria-pressed', 'true');
+  await expect(
+    relationshipPanel.getByRole('button', { name: '自己携带', exact: true })
+  ).toBeVisible();
+  await expect(
+    relationshipPanel.getByRole('button', { name: '队内战法', exact: true })
+  ).toBeVisible();
+
+  const teamSkillMode = relationshipPanel.getByRole('button', {
+    name: '队内战法',
+    exact: true,
+  });
+  await teamSkillMode.focus();
+  await page.keyboard.press('Space');
+  await expect(teamSkillMode).toHaveAttribute('aria-pressed', 'true');
+  await expect(teamSkillMode).toHaveAttribute('aria-controls', 'relationship-ranking-table');
+
+  const tableRegion = relationshipPanel.getByRole('region', {
+    name: '队内战法关系排名表格，可滚动',
+  });
+  await expect(tableRegion).toHaveAttribute('tabindex', '0');
+  await expect(tableRegion.getByRole('columnheader')).toHaveCount(4);
+  await expect(relationshipPanel.getByTestId('relationship-ranking-row')).toHaveCount(40);
+  const more = relationshipPanel.getByRole('button', {
+    name: '显示更多队内战法关系：再显示 40 条',
+  });
+  await expect(more).toBeVisible();
+  await expect(more).toHaveAttribute('aria-controls', 'relationship-ranking-table');
+  await expect(relationshipPanel).not.toContainText('队友携带');
+
+  const geometry = await page.evaluate(() => {
+    const card = document.querySelector('[data-testid="relationship-ranking-panel"]');
+    const region = document.querySelector('#relationship-ranking-table');
+    const moreButton = document.querySelector('[data-testid="relationship-show-more"]');
+    return {
+      bodyOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      cardRight: card?.getBoundingClientRect().right ?? Infinity,
+      regionRight: region?.getBoundingClientRect().right ?? Infinity,
+      moreRight: moreButton?.getBoundingClientRect().right ?? Infinity,
+      viewport: window.innerWidth,
+    };
+  });
+  expect(geometry.bodyOverflow).toBeLessThanOrEqual(1);
+  expect(geometry.cardRight).toBeLessThanOrEqual(geometry.viewport + 1);
+  expect(geometry.regionRight).toBeLessThanOrEqual(geometry.viewport + 1);
+  expect(geometry.moreRight).toBeLessThanOrEqual(geometry.viewport + 1);
+});

--- a/web/tests/analyticsSearchKeepsTrueRank.spec.js
+++ b/web/tests/analyticsSearchKeepsTrueRank.spec.js
@@ -9,8 +9,10 @@ const database = require('../public/game-data/database.json');
 // ordering, so a filtered row keeps its true position. This spec exercises all
 // six 排名 tables — for each it (1) records the full-list rank of every row, then
 // (2) applies a filter and asserts each surviving row still shows its true rank
-// (never renumbered to 1..n). It also captures screenshots in Playwright's
-// per-test output directory for visual review.
+// (never renumbered to 1..n). The individual and usage tables retain their
+// original contract; the unified relationship panel is checked in representative
+// HP and HS modes here and all six modes in analyticsRelationships.spec.js.
+// Screenshots remain in Playwright's per-test output directory for visual review.
 
 // Locate a ranking table by its ScrollableAnalyticsTable aria-label region.
 const region = (page, label) =>
@@ -39,9 +41,9 @@ const pairKey = async (row) => {
   return names.map((s) => s.trim()).join(' + ');
 };
 const heroSkillKey = async (row) => {
-  const hero = (await row.locator('td').nth(1).innerText()).trim();
-  const skill = (await row.locator('td').nth(2).innerText()).trim();
-  return `${hero} · ${skill}`;
+  const chips = row.locator('td').nth(1).locator('.MuiChip-label');
+  const [hero, skill] = await chips.allInnerTexts();
+  return `${hero.trim()} · ${skill.trim()}`;
 };
 
 async function addFilter(page, placeholder, typed, optionText) {
@@ -53,6 +55,23 @@ async function addFilter(page, placeholder, typed, optionText) {
 
 const HERO_PH = '输入武将名或拼音...';
 const SKILL_PH = '输入战法名或拼音...';
+
+function relationshipRankMap(family, keyOfFeature) {
+  return new Map(
+    Object.entries(recommendationData.model.weights)
+      .filter(([featureId]) => featureId.startsWith(`${family}|`))
+      .sort(([leftId, leftWeight], [rightId, rightWeight]) =>
+        rightWeight - leftWeight || (leftId < rightId ? -1 : leftId > rightId ? 1 : 0)
+      )
+      .map(([featureId], index) => [keyOfFeature(featureId.split('|').slice(1)), index + 1])
+  );
+}
+
+const heroPairRanks = relationshipRankMap('HP', (parts) => parts.join(' + '));
+const heroSkillRanks = relationshipRankMap(
+  'HS',
+  ([hero, skill]) => `${hero} · ${skill}`
+);
 
 function expectedModelRanking(family, prefix) {
   return recommendationData.analytics[family]
@@ -160,8 +179,16 @@ test('全部武将 / 全部战法 show model weights from high to low without wi
 // For a table: read the full ordering, pick a target row whose true rank > 1,
 // apply the given filter, then assert every surviving row keeps its full-list
 // rank (and specifically that the target's true rank is shown, not 1).
-async function verifyTableKeepsTrueRank(page, testInfo, { label, keyOf, filter, screenshot }) {
+async function verifyTableKeepsTrueRank(page, testInfo, {
+  label,
+  keyOf,
+  filter,
+  screenshot,
+  prepare,
+  rankOf,
+}) {
   await page.goto('/analytics');
+  if (prepare) await prepare(page);
   await expect(region(page, label)).toBeVisible();
 
   const full = await readRows(page, label, keyOf);
@@ -180,7 +207,8 @@ async function verifyTableKeepsTrueRank(page, testInfo, { label, keyOf, filter, 
   expect(filtered.length).toBeGreaterThan(0);
   // The fix: each surviving row shows its true (full-list) rank, not a 1..n restart.
   for (const r of filtered) {
-    expect(r.rank, `row ${r.key} in ${label}`).toBe(fullRank.get(r.key));
+    const expectedRank = fullRank.get(r.key) ?? rankOf?.(r.key);
+    expect(r.rank, `row ${r.key} in ${label}`).toBe(expectedRank);
   }
   // The target survived and shows its real rank (which is > 1) — the exact regression.
   const shown = filtered.find((r) => r.key === target.key);
@@ -229,25 +257,31 @@ test('武将使用排行 / 战法使用排行 keep true 排名 under a search fi
   });
 });
 
-test('最强武将配对 / 最强武将战法组合 keep true 排名 under a search filter', async ({ page }, testInfo) => {
-  // Pairs: filter by one hero of the target pair; all surviving pairs keep true rank.
+test('unified HP / HS relationship modes keep true 排名 under a search filter', async ({ page }, testInfo) => {
+  // HP: filter by one hero of the target pair; surviving rows retain full-list ranks.
   await verifyTableKeepsTrueRank(page, testInfo, {
-    label: '最强武将配对',
+    label: '两人同队关系排名',
     keyOf: pairKey,
     filter: (p, t) => {
       const hero = t.key.split(' + ')[0];
       return addFilter(p, HERO_PH, hero, hero);
     },
+    rankOf: (key) => heroPairRanks.get(key),
     screenshot: 'analytics-rank-hero-pairs.png',
   });
-  // Hero+skill combos: filter by the target's hero.
+  // HS: enter 战法搭配, then filter by the target's encoded hero.
   await verifyTableKeepsTrueRank(page, testInfo, {
-    label: '最强武将战法组合',
+    label: '自己携带关系排名',
     keyOf: heroSkillKey,
+    prepare: (p) => p
+      .getByTestId('relationship-ranking-panel')
+      .getByRole('button', { name: '战法搭配', exact: true })
+      .click(),
     filter: (p, t) => {
       const hero = t.key.split(' · ')[0];
       return addFilter(p, HERO_PH, hero, hero);
     },
+    rankOf: (key) => heroSkillRanks.get(key),
     screenshot: 'analytics-rank-hero-skills.png',
   });
 });


### PR DESCRIPTION
## Intent

Create one clear, responsive Analytics relationship-ranking experience that replaces the separate 最搭的武将组合 and 最搭的武将与战法 cards. It must expose six independently ranked, player-readable feature families: HP 两人同队 and HT 三人同队 under 武将搭配; HS 自己携带 and THS 队内战法 under 战法搭配, with THS accurately described as the tactic existing anywhere in the exact team including on the named hero; and catalog-backed B 缘分 plus aggregate M 机制联动 under 特殊加成, without attributing an M weight to one concrete skill pair. Deliberately exclude HC, SP, TSP, and disabled TS3. Preserve scoring, training, telemetry, model weights, support thresholds, and recommendation_data.json. Keep every fitted relationship, including negative weights, available for querying; filter the complete family before limiting presentation; preserve immutable global ranks; initially render at most 40 matches and reveal additional matches in accessible batches of 40 with honest matching and full-family counts. Keep inapplicable-filter behavior explicit, bond activation/member details visible on demand, MECH labels fail-closed and human-readable, all existing Analytics content intact, and desktop, keyboard, screen-reader, and 320px mobile behavior covered.

## What Changed
- Replace the two legacy synergy cards with one responsive, two-level Analytics panel exposing independent HP/HT, HS/THS, and B/M rankings while excluding HC, SP, TSP, and TS3.
- Return every fitted relationship, including negative weights, with immutable global ranks, family-aware filtering before accessible 40-row batches, explicit counts, exact-team THS wording, expandable bond details, and fail-closed human-readable mechanic labels.
- Add unit, render, and Playwright coverage for ranking, filtering, pagination, accessibility, and 320px mobile behavior, and document the unified dashboard contract.

## Risk Assessment

✅ Low: The change is well-bounded to Analytics presentation and querying, preserves scoring artifacts and model behavior, and the prior pagination-test issue is correctly resolved without introducing a source-verifiable defect.

## Testing

No baseline test results were supplied. Focused Analytics component, labeling, real-artifact integration, filtering, pagination, keyboard, screen-reader, and end-to-end browser scenarios succeeded; manual desktop and 320px Chromium evidence confirmed the rendered THS, bond, MECH, immutable-rank, negative-weight, and responsive behavior. An initial evidence-harness invocation issue was corrected before the successful capture, and no product failures were found.

- Evidence: Desktop THS ranking showing exact-team wording, including that the named hero may carry the tactic, the full-family count, and 40-row disclosure (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0XZBMCSAXSBAQ078PQZV0HG/analytics-ths-desktop.png</code>)
- Evidence: Expanded catalog-backed bond activation and member details (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0XZBMCSAXSBAQ078PQZV0HG/analytics-bond-details-desktop.png</code>)
- Evidence: Human-readable aggregate MECH ranking without concrete skill-pair attribution (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0XZBMCSAXSBAQ078PQZV0HG/analytics-mechanic-aggregate-desktop.png</code>)
- Evidence: Filtered HP ranking preserving global ranks and surfacing negative fitted relationships (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0XZBMCSAXSBAQ078PQZV0HG/analytics-filtered-hp-global-ranks.png</code>)
- Evidence: 320px mobile THS ranking with compact controls, readable table, honest count, and show-more control (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M0XZBMCSAXSBAQ078PQZV0HG/analytics-ths-mobile-320.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8cb3e1050f7ff74860c7f45125335c15b32224ce","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `web/tests/analyticsRelationships.spec.js:276` - This E2E test assumes the generated HT, B, and M families always contain at most 40 rows, and the negative-M check at line 338 likewise assumes its target is initially rendered. Routine recommendation-data rebuilds can increase these fitted-family sizes without changing UI behavior, causing false CI failures. Assert `Math.min(count, 40)`, conditionally expect the show-more control, and page to any negative target before asserting it.

🔧 Fix: Make relationship pagination tests data-driven
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd web && pnpm exec vitest run src/components/analytics/__tests__/RelationshipRankingPanel.test.ts src/components/analytics/__tests__/RelationshipRankingPanel.render.test.tsx src/services/__tests__/featureLabels.test.ts`
- `cd web && pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t 'getAnalytics — unified relationship rankings|getAnalytics returns rankings'`
- `cd web && pnpm exec playwright test tests/analyticsRelationships.spec.js tests/analyticsSearchKeepsTrueRank.spec.js`
- <code>Queried the real generated recommendation artifact with `cd web &amp;&amp; node` to verify all six fitted families contain complete rankings and negative coefficients.</code>
- <code>Ran `pnpm exec vite --host 127.0.0.1 --port 3011` with headless Chromium to capture desktop THS semantics, expanded bond details, aggregate MECH wording, filtered immutable HP ranks, and the responsive 320px surface; the mobile browser observation had zero document overflow, 40 initially visible rows, a keyboard-focusable table region, and the full-family `40 / 3202` status.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
