### PR TITLE
test(web): decouple Team Builder layout checks from warning copy

### DIFF
--- a/web/src/services/__tests__/teamBuilderMessaging.test.ts
+++ b/web/src/services/__tests__/teamBuilderMessaging.test.ts
@@ -41,6 +41,15 @@ describe('summarizeTeamBuilderRecommendation', () => {
     });
   });
 
+  test('names heroes specifically when only hero slots remain unfilled', () => {
+    expect(
+      summarizeTeamBuilderRecommendation([team(2, 3), team(3), team(3)])
+    ).toEqual({
+      successMessage: '已编入 2 支完整队伍',
+      warningMessage: '部分武将未通过证据量门槛，已保留空位。',
+    });
+  });
+
   test('names skills specifically when only skill slots remain unfilled', () => {
     expect(
       summarizeTeamBuilderRecommendation([team(3, 1), team(3), team(3)])

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -2015,12 +2015,6 @@ test.describe('Team Builder mobile placement', () => {
     await expect
       .poll(() => poolHeroButtons.count(), { timeout: 30000 })
       .toBeGreaterThanOrEqual(8);
-    await expect(page.getByTestId('recommendation-warning')).toHaveText(
-      '部分武将或战法未通过证据量门槛，已保留空位。'
-    );
-    await expect(page.getByTestId('recommendation-warning')).toHaveClass(
-      /MuiAlert-standardWarning/
-    );
     await skillRepository.scrollIntoViewIfNeeded();
 
     const [heroRepositoryBox, lastHeroBox, skillRepositoryBox] =


### PR DESCRIPTION
## Intent

修复 PR #117 合并后由 recommendation_data.json 重建触发的 Web E2E 失败。移动端 Team Builder 仓库布局测试只应验证卡片边界与页面溢出，不应硬编码当前生成模型导致的警告分类文案；武将缺失、战法缺失和两者缺失的精确文案继续由 teamBuilderMessaging 单元测试覆盖。保持产品逻辑、生成数据和其他测试不变，让未来战报或模型数据更新不会再次误报这个布局测试。

## What Changed

- Remove model-dependent warning text and style assertions from the mobile Team Builder repository layout test.
- Add focused unit coverage for the hero-only empty-slot warning, complementing existing skill-only and combined warning cases.

## Risk Assessment

✅ Low: The test-only change cleanly removes a model-data-dependent assertion from a layout E2E test and adds direct behavioral coverage for the previously uncovered hero-only message without changing product logic or generated data.

## Testing

No prior baseline results were supplied. Focused Vitest exercised the exact hero-only, skill-only, and combined warning messages; focused Playwright exercised the narrow-screen repository layout. A browser-level evidence probe reproduced the original stale assertion mismatch—the rebuilt data renders the skill-only warning—then confirmed eight visible warehouse cards remain contained, repositories do not overlap, and both repository and page widths have no horizontal overflow. After correcting an initial probe-only assumption that the current warning would be hero-only, the evidence run completed successfully.

- Evidence: Rendered Team Builder warning from rebuilt recommendation data (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M16H9HWA0AND8CKJGZTB6Z03/team-builder-current-warning.png</code>)
- Evidence: Mobile Team Builder hero and skill repositories at 521×667 (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M16H9HWA0AND8CKJGZTB6Z03/team-builder-mobile-repositories-viewport.png</code>)
<details>
<summary>Evidence: Rendered warning mismatch reproduction and measured layout/overflow checks</summary>

```text
{
  "viewport": {
    "width": 521,
    "height": 667
  },
  "renderedWarning": "部分战法未通过证据量门槛，已保留空位。",
  "renderedWarningClass": "MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard mui-6xgqj-MuiPaper-root-MuiAlert-root",
  "staleExpectedWarning": "部分武将或战法未通过证据量门槛，已保留空位。",
  "staleExpectationMatches": false,
  "reproducedBaselineFailure": "Expected values to be strictly equal:\n+ actual - expected\n\n+ '部分战法未通过证据量门槛，已保留空位。'\n- '部分武将或战法未通过证据量门槛，已保留空位。'\n     ^\n",
  "heroButtonCount": 8,
  "layoutChecks": {
    "lastHeroInsideRepository": true,
    "repositoriesDoNotOverlap": true,
    "repositoryHasNoHorizontalOverflow": true,
    "pageHasNoHorizontalOverflow": true
  },
  "horizontalMetrics": {
    "scrollWidth": 469,
    "clientWidth": 469,
    "contained": true
  },
  "documentMetrics": {
    "scrollWidth": 521,
    "clientWidth": 521,
    "noHorizontalPageOverflow": true
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"80bda4c415d9a978071238bbe15ff67ead46659f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `web/src/services/__tests__/teamBuilderMessaging.test.ts:35` - 意图要求“武将缺失、战法缺失和两者缺失的精确文案继续由 teamBuilderMessaging 单元测试覆盖”，但本次变更仅删除了布局 E2E 的警告断言；这里的武将缺失用例仍断言“两者缺失”文案。现有单测只精确覆盖“部分武将或战法…”和“部分战法…”，未覆盖实现中的武将单独缺失文案“部分武将未通过证据量门槛，已保留空位。”。请补充直接命中该分支的单测，或请用户明确撤销三分类覆盖要求。

🔧 Fix: Cover hero-only Team Builder warning
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd web && pnpm exec vitest run src/services/__tests__/teamBuilderMessaging.test.ts`
- `cd web && pnpm exec playwright test tests/buildATeam.spec.js --grep "keeps every hero card inside its repository on a narrow screen"`
- <code>`cd web &amp;&amp; pnpm start --host 127.0.0.1` with `NODE_PATH=&#34;$PWD/node_modules&#34; node .../capture-team-builder-evidence.cjs` to reproduce the stale warning assertion against the rendered UI, verify repository/card boundaries and horizontal overflow, and capture screenshots</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
