### PR TITLE
fix(web): align Team Builder cards and clarify relationship scores

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -247,7 +247,8 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   contributions, not win probabilities. Hover, keyboard focus, tap selection,
   and drag show one signed four-decimal aggregate on each other directly related
   item for eligible HP/HS/SP features. Each compact value is prefixed with its
-  plain-language relationship: `同队` for HP, `携带` for HS, and `同将` for SP.
+  plain-language relationship: `同队` for HP, `携带` for HS, `同将` for SP, and
+  `三人组` for HT.
   HS never substitutes the team-wide meaning of THS. SP appears only for a
   concrete current assignment or concrete prospective drag-over placement.
   Eligibility requires an enabled, present feature at its family support floor
@@ -259,7 +260,7 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   and placement-ambiguous contexts show no HT. Permanent evidence rows remain
   HP/HS/SP-only, so this transient control is HT's sole presentation. This does
   not restore the old multiline team-header relationship summary.
-  Activating an item or HT score opens an opaque, portal-backed breakdown
+  Activating a displayed score opens an opaque, portal-backed breakdown
   containing every deterministically ordered displayed component with its
   relationship label, signed four-decimal weight, and support count; no
   strongest-only slice or +N summary hides eligible displayed evidence. Opening

--- a/web/README.md
+++ b/web/README.md
@@ -228,8 +228,10 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   pointer/touch drag-and-drop plus keyboard and tap-to-place movement. Each
   assignment card is a whole-card hero drag and drop surface while its row,
   tactic, score, and removal controls retain their own interactions. It reserves
-  a 142px portrait lane and a 164px control lane, so its row selector, text-only
-  tactic names, and remove actions stay complete; narrow screens expose the
+  a 142px portrait lane and a 164px control lane. The portrait is cropped into
+  the same 144px body height as the row selector and two tactic slots, so the
+  second tactic never leaves an unexplained blank strip below it. Tactic names
+  and remove actions stay complete; narrow screens expose the
   326px cards through a contained horizontal scroller without document-level
   overflow. On mobile, each intentional
   three-hero scroller has a visible swipe hint. Every enabled model family still
@@ -241,8 +243,11 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   exact concrete hero trio (HT). THS, TSP, M, HC, and B remain scoring-only and
   are absent from permanent evidence labels and every transient aggregate,
   breakdown, tooltip, and accessibility announcement.
-  Hover, keyboard focus, tap selection, and drag show one signed four-decimal
-  aggregate on each other directly related item for eligible HP/HS/SP features.
+  An always-visible legend explains that relationship values are relative-score
+  contributions, not win probabilities. Hover, keyboard focus, tap selection,
+  and drag show one signed four-decimal aggregate on each other directly related
+  item for eligible HP/HS/SP features. Each compact value is prefixed with its
+  plain-language relationship: `同队` for HP, `携带` for HS, and `同将` for SP.
   HS never substitutes the team-wide meaning of THS. SP appears only for a
   concrete current assignment or concrete prospective drag-over placement.
   Eligibility requires an enabled, present feature at its family support floor
@@ -272,7 +277,7 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   contained
   within a 320px-wide viewport without altering card layout or causing page
   overflow. The source receives a clear outline; unrelated cards are not faded.
-  Scores use only a subtle 150ms opacity and 2px transform transition, retain outgoing
+  Scores use only a subtle 240ms opacity and 3px transform transition, retain outgoing
   content for the exit, disable pointer ownership immediately, and disable
   motion under `prefers-reduced-motion`. Score and detail controls cannot start
   a drag, and the score lane permits safe drop-through hit-testing. Physical

--- a/web/scripts/capture-visual-audit.mjs
+++ b/web/scripts/capture-visual-audit.mjs
@@ -243,6 +243,34 @@ try {
   });
 
   await capture(browser, {
+    name: 'desktop--team-builder-relationship-detail',
+    route: '/team-builder',
+    viewport: viewports.desktop,
+    seed: progress({
+      ...lateState,
+      current_heroes: [qualityHero],
+      current_skills: qualitySkills,
+    }),
+    teamBuilderLayout: {
+      heroes: [qualityHero],
+      skills: qualitySkills,
+      layout: qualityLayout,
+    },
+    prepare: async (page) => {
+      await page.getByTestId('skill-slot-0-0-0').hover({ position: { x: 12, y: 22 } });
+      const relationshipScore = page
+        .getByTestId('skill-slot-0-0-1')
+        .locator('..')
+        .getByTestId('relationship-score');
+      await relationshipScore.waitFor();
+      await page.waitForTimeout(260);
+      await relationshipScore.click();
+      await page.getByRole('dialog').waitFor();
+      await page.waitForTimeout(250);
+    },
+  });
+
+  await capture(browser, {
     name: 'mobile-320--team-builder-tactic-swap',
     route: '/team-builder',
     viewport: { width: 320, height: 844 },

--- a/web/src/components/common/GameCardArt.tsx
+++ b/web/src/components/common/GameCardArt.tsx
@@ -84,8 +84,8 @@ const GameCardArt = ({
           inset: 0,
           width: '100%',
           height: '100%',
-          // Source cards vary slightly in aspect ratio. A tiny edge crop keeps
-          // the complete card frame visually full without exposing black bars.
+          // Cover fills the requested frame despite source aspect-ratio drift;
+          // callers can choose a deliberate portrait crop with imagePosition.
           objectFit: fallback ? 'contain' : 'cover',
           objectPosition: imagePosition,
         }}

--- a/web/src/components/common/GameCardArt.tsx
+++ b/web/src/components/common/GameCardArt.tsx
@@ -14,6 +14,7 @@ interface GameCardArtProps {
   ranking?: string | null;
   onRemove?: () => void;
   artOnly?: boolean;
+  imagePosition?: string;
   sx?: SxProps<Theme>;
 }
 
@@ -31,6 +32,7 @@ const GameCardArt = ({
   ranking,
   onRemove,
   artOnly = false,
+  imagePosition = 'center',
   sx,
 }: GameCardArtProps) => {
   const entry = getGameAsset(name, kind);
@@ -85,7 +87,7 @@ const GameCardArt = ({
           // Source cards vary slightly in aspect ratio. A tiny edge crop keeps
           // the complete card frame visually full without exposing black bars.
           objectFit: fallback ? 'contain' : 'cover',
-          objectPosition: 'center',
+          objectPosition: imagePosition,
         }}
       />
       {showTextOverlay && <Box

--- a/web/src/components/teamBuilder/FormationWorkbench.tsx
+++ b/web/src/components/teamBuilder/FormationWorkbench.tsx
@@ -141,8 +141,9 @@ const PRIMARY_PREVIEW_SURFACE_HEIGHT =
 const HERO_ASSIGNMENT_CARD_MIN_WIDTH = 326;
 const HERO_ASSIGNMENT_ART_WIDTH = 142;
 const HERO_ASSIGNMENT_CONTROLS_MIN_WIDTH = 164;
+const HERO_ASSIGNMENT_BODY_HEIGHT = 144;
 const SKILL_DROP_HIGHLIGHT_COLOR = '#174c42';
-const RELATIONSHIP_TRANSITION_MS = 150;
+const RELATIONSHIP_TRANSITION_MS = 240;
 const TEAM_EVIDENCE_LIMIT = 3;
 const TEAM_EVIDENCE_FAMILIES = new Set(['HP', 'HS', 'SP']);
 
@@ -408,6 +409,7 @@ export const RelationshipAggregateScore = ({
   const [anchor, setAnchor] = useState<HTMLButtonElement | null>(null);
   const titleId = useId();
   const detailId = useId();
+  const explainerId = useId();
   const closeRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
@@ -489,8 +491,8 @@ export const RelationshipAggregateScore = ({
         pointerEvents: 'none',
         opacity: renderedPhase === 'visible' ? 1 : 0,
         transform:
-          renderedPhase === 'visible' ? 'translateY(0)' : 'translateY(2px)',
-        transition: `opacity ${RELATIONSHIP_TRANSITION_MS}ms ease, transform ${RELATIONSHIP_TRANSITION_MS}ms ease`,
+          renderedPhase === 'visible' ? 'translateY(0)' : 'translateY(3px)',
+        transition: `opacity ${RELATIONSHIP_TRANSITION_MS}ms cubic-bezier(0.2, 0, 0, 1), transform ${RELATIONSHIP_TRANSITION_MS}ms cubic-bezier(0.2, 0, 0, 1)`,
         '@media (prefers-reduced-motion: reduce)': {
           transition: 'none',
           transform: 'none',
@@ -519,23 +521,23 @@ export const RelationshipAggregateScore = ({
           position: 'absolute',
           right: rightOffset,
           top: 0,
-          minWidth: 68,
+          minWidth: 64,
           pointerEvents: interactive ? 'auto' : 'none',
           height: RELATIONSHIP_RAIL_HEIGHT,
           minHeight: RELATIONSHIP_RAIL_HEIGHT,
           px: 0.75,
           border: '1px solid',
-          borderColor: positive ? 'success.dark' : 'error.main',
+          borderColor: positive ? 'success.main' : 'error.main',
           borderRadius: 0.75,
-          bgcolor: positive
-            ? alpha('#183522', 0.98)
-            : alpha('#3c211d', 0.98),
-          color: '#fffdf7',
+          bgcolor: positive ? 'success.light' : 'error.light',
+          color: positive ? 'success.dark' : 'error.dark',
           fontSize: 11,
           fontWeight: 900,
           lineHeight: 1,
           fontVariantNumeric: 'tabular-nums',
           whiteSpace: 'nowrap',
+          flexDirection: 'column',
+          gap: 0.25,
           '&:focus-visible': {
             outline: '2px solid',
             outlineColor: 'info.main',
@@ -543,8 +545,14 @@ export const RelationshipAggregateScore = ({
           },
         }}
       >
-        {shown.compactLabel ? `${shown.compactLabel} ` : ''}
-        {formatRelationshipPreviewWeight(shown.total)}
+        {shown.compactLabel && (
+          <Box component="span" sx={{ fontSize: 10, lineHeight: 1 }}>
+            {shown.compactLabel}
+          </Box>
+        )}
+        <Box component="span" sx={{ lineHeight: 1 }}>
+          {formatRelationshipPreviewWeight(shown.total)}
+        </Box>
       </ButtonBase>
       <Popover
         open={Boolean(anchor) && interactive}
@@ -573,6 +581,7 @@ export const RelationshipAggregateScore = ({
           id={detailId}
           role="dialog"
           aria-labelledby={titleId}
+          aria-describedby={explainerId}
           data-team-builder-relationship-detail="true"
           data-team-builder-drop-exclusion="true"
           sx={{ position: 'relative', p: 1.25, pr: 6.5 }}
@@ -595,8 +604,26 @@ export const RelationshipAggregateScore = ({
             <CloseIcon fontSize="small" />
           </IconButton>
           <Typography id={titleId} component="h2" variant="subtitle2" fontWeight={900}>
-            {shown.detailHeading ?? `${shown.target.name} × ${shown.source.name}`}{' '}
-            {formatRelationshipPreviewWeight(shown.total)}
+            {shown.detailHeading ?? `${shown.target.name} × ${shown.source.name}`}
+          </Typography>
+          <Typography
+            id={explainerId}
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: 'block', mt: 0.25, lineHeight: 1.55 }}
+          >
+            {shown.compactLabel ?? '关系'}影响{' '}
+            <Box
+              component="span"
+              sx={{
+                color: positive ? 'success.dark' : 'error.dark',
+                fontWeight: 900,
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {formatRelationshipPreviewWeight(shown.total)}
+            </Box>
+            {' · '}正值提高相对评分，负值降低；不是胜率。
           </Typography>
           <Stack
             component="ul"
@@ -1519,14 +1546,21 @@ const HeroAssignmentCard = ({
         sx={{
           display: 'grid',
           gridTemplateColumns: `${HERO_ASSIGNMENT_ART_WIDTH}px minmax(${HERO_ASSIGNMENT_CONTROLS_MIN_WIDTH}px, 1fr)`,
-          gap: 0.75,
-          p: 0.75,
+          gap: 1,
+          p: 0.5,
           alignItems: 'stretch',
+          height: HERO_ASSIGNMENT_BODY_HEIGHT + 8,
+          boxSizing: 'border-box',
         }}
       >
         <Box
           data-testid={`hero-art-${teamIndex}-${heroIndex}`}
-          sx={{ minWidth: 0, minHeight: 0, display: 'flex' }}
+          sx={{
+            minWidth: 0,
+            minHeight: 0,
+            height: HERO_ASSIGNMENT_BODY_HEIGHT,
+            display: 'flex',
+          }}
         >
           {slot.hero ? (
             <GameCardArt
@@ -1534,11 +1568,12 @@ const HeroAssignmentCard = ({
               kind="hero"
               size="compact"
               artOnly
+              imagePosition="center 28%"
               sx={{
                 width: '100%',
                 height: '100%',
                 minHeight: 0,
-                aspectRatio: '160 / 248',
+                aspectRatio: 'auto',
                 bgcolor: 'background.default',
                 boxShadow: 'none',
               }}
@@ -1567,8 +1602,8 @@ const HeroAssignmentCard = ({
         <Stack
           data-testid={`hero-controls-${teamIndex}-${heroIndex}`}
           data-team-builder-hero-interaction-exclusion="true"
-          spacing={0.6}
-          sx={{ minWidth: 0 }}
+          spacing={0.5}
+          sx={{ minWidth: 0, height: HERO_ASSIGNMENT_BODY_HEIGHT }}
         >
           <ToggleButtonGroup
             data-team-builder-preview-exclusion="true"
@@ -2122,12 +2157,32 @@ const FormationWorkbench = ({
                 我的比赛阵容
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                拖动武将与战法；触屏也可先点选，再点亮目标位置。
+                拖动武将与战法；触屏也可先点选，再点亮目标位置。悬停或聚焦项目可查看关系影响。
               </Typography>
             </Box>
             {actions && (
               <Box sx={{ ml: 'auto', maxWidth: '100%' }}>{actions}</Box>
             )}
+          </Stack>
+          <Stack
+            component="aside"
+            aria-label="关系影响说明"
+            data-testid="relationship-preview-legend"
+            direction="row"
+            alignItems="baseline"
+            spacing={0.75}
+            useFlexGap
+            flexWrap="wrap"
+          >
+            <Typography
+              variant="caption"
+              sx={{ color: 'primary.dark', fontWeight: 900 }}
+            >
+              关系影响
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              同队、携带、同将会显示带符号的相对评分影响：“+”提高，“−”降低；不是胜率。
+            </Typography>
           </Stack>
           {selected && (
             <Alert
@@ -2176,6 +2231,7 @@ const FormationWorkbench = ({
                   borderLeft: '4px solid',
                   borderLeftColor: teamAccent[teamIndex],
                   bgcolor: alpha('#fbf8ef', 0.94),
+                  boxShadow: 'none',
                 }}
               >
                 <Stack

--- a/web/src/components/teamBuilder/FormationWorkbench.tsx
+++ b/web/src/components/teamBuilder/FormationWorkbench.tsx
@@ -2181,7 +2181,7 @@ const FormationWorkbench = ({
               关系影响
             </Typography>
             <Typography variant="caption" color="text.secondary">
-              同队、携带、同将会显示带符号的相对评分影响：“+”提高，“−”降低；不是胜率。
+              同队（两名武将）、携带（武将与战法）、同将（两战法由同一武将携带）、三人组（完整三人同队）会显示带符号的相对评分影响：“+”提高，“−”降低；不是胜率。
             </Typography>
           </Stack>
           {selected && (

--- a/web/src/components/teamBuilder/__tests__/FormationWorkbench.test.tsx
+++ b/web/src/components/teamBuilder/__tests__/FormationWorkbench.test.tsx
@@ -184,12 +184,25 @@ const aggregate = (
   components: PairRelationshipPreview[]
 ): PairRelationshipAggregatePreview => {
   const total = components.reduce((sum, component) => sum + component.weight, 0);
+  const labels = new Set(
+    components.map(({ family }) =>
+      family === 'HP'
+        ? '同队'
+        : family === 'HS'
+          ? '携带'
+          : family === 'SP'
+            ? '同将'
+            : '三人组'
+    )
+  );
+  const compactLabel = labels.size === 1 ? [...labels][0] : '关系';
   return {
     source: components[0].source,
     target: components[0].target,
     total,
     components,
-    accessibleLabel: `${components[0].target.name}与来源战法的关系总分 ${total >= 0 ? '+' : '−'}${Math.abs(total).toFixed(4)}，共 ${components.length} 项；查看完整明细`,
+    compactLabel,
+    accessibleLabel: `${components[0].target.name}与来源战法的${compactLabel}关系影响 ${total >= 0 ? '+' : '−'}${Math.abs(total).toFixed(4)}，共 ${components.length} 项；正值提高相对评分，负值降低，这不是胜率；查看完整明细`,
   };
 };
 
@@ -229,7 +242,13 @@ describe('FormationWorkbench card presentation', () => {
     expect(screen.queryByTestId('game-card-tactic-避其锐气')).not.toBeInTheDocument();
     expect(screen.queryByTestId('game-card-tactic-青囊急救')).not.toBeInTheDocument();
     expect(getComputedStyle(screen.getByTestId('hero-art-0-0')).alignItems).not.toBe('start');
+    expect(getComputedStyle(screen.getByTestId('hero-art-0-0')).height).toBe('144px');
+    expect(getComputedStyle(screen.getByTestId('hero-controls-0-0')).height).toBe('144px');
     expect(getComputedStyle(screen.getByTestId('game-card-hero-刘备')).height).toBe('100%');
+    expect(getComputedStyle(screen.getByTestId('game-card-hero-刘备')).aspectRatio).toBe('auto');
+    expect(screen.getByTestId('relationship-preview-legend')).toHaveTextContent(
+      '“+”提高，“−”降低；不是胜率'
+    );
     expect(
       getComputedStyle(screen.getByTestId('pool-hero-曹操-primary')).paddingTop
     ).toBe('4px');
@@ -775,10 +794,10 @@ describe('FormationWorkbench contextual presentation', () => {
       expect(within(team).getByTestId('team-strength')).toHaveTextContent(
         scoreBefore ?? ''
       );
-      expect(team).not.toHaveTextContent(/同队|战法搭配|机制|同阵营|缘分/);
+      expect(team).not.toHaveTextContent(/战法搭配|机制|同阵营|缘分/);
       for (const transientScore of screen.queryAllByTestId('relationship-score')) {
         expect(transientScore).not.toHaveAccessibleName(
-          /同队|战法搭配|机制|同阵营|缘分/
+          /战法搭配|机制|同阵营|缘分/
         );
       }
       expect(screen.queryByTestId('team-relationship-status')).not.toBeInTheDocument();
@@ -864,17 +883,20 @@ describe('RelationshipAggregateScore', () => {
       </div>
     );
 
-    const score = screen.getByRole('button', { name: /关系总分 \+0\.2000/ });
-    expect(score).toHaveTextContent('+0.2000');
+    const score = screen.getByRole('button', { name: /关系影响 \+0\.2000/ });
+    expect(score).toHaveTextContent('关系+0.2000');
     expect(getComputedStyle(score).height).toBe('44px');
     expect(getComputedStyle(score).minHeight).toBe('44px');
-    expect(getComputedStyle(score).minWidth).toBe('68px');
+    expect(getComputedStyle(score).minWidth).toBe('64px');
     expect(getComputedStyle(screen.getByTestId('relationship-score-lane')).height).toBe('44px');
     expect(screen.queryByRole('list', { name: '全部关系分项' })).not.toBeInTheDocument();
 
     act(() => score.focus());
     fireEvent.click(score);
-    expect(screen.getByRole('dialog')).toHaveTextContent('甲 × 来源战法 +0.2000');
+    expect(screen.getByRole('dialog')).toHaveTextContent('甲 × 来源战法');
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      '关系影响 +0.2000 · 正值提高相对评分，负值降低；不是胜率。'
+    );
     expect(screen.getAllByTestId('relationship-detail-row')).toHaveLength(4);
     expect(screen.getByText('+0.4000 · 参考 10 场')).toBeVisible();
     expect(screen.getByText('−0.3000 · 参考 10 场')).toBeVisible();
@@ -899,16 +921,19 @@ describe('RelationshipAggregateScore', () => {
     trio.compactLabel = '三人组';
     trio.detailHeading = '队伍 1 · 精确三人组 甲、乙、丙';
     trio.accessibleLabel =
-      '队伍 1，精确武将三人组甲、乙、丙，关系总分 +0.4000，共 1 项；查看完整明细';
+      '队伍 1，精确武将三人组甲、乙、丙，三人组关系影响 +0.4000，共 1 项；正值提高相对评分，负值降低，这不是胜率；查看完整明细';
     render(<RelationshipAggregateScore aggregate={trio} />);
 
     const score = screen.getByTestId('relationship-score');
-    expect(score).toHaveTextContent('三人组 +0.4000');
+    expect(score).toHaveTextContent('三人组+0.4000');
     expect(score).toHaveAccessibleName(/精确武将三人组甲、乙、丙/);
     fireEvent.click(score);
 
     expect(screen.getByRole('dialog')).toHaveTextContent(
-      '队伍 1 · 精确三人组 甲、乙、丙 +0.4000'
+      '队伍 1 · 精确三人组 甲、乙、丙'
+    );
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      '三人组影响 +0.4000 · 正值提高相对评分，负值降低；不是胜率。'
     );
     expect(screen.getAllByTestId('relationship-detail-row')).toHaveLength(1);
     expect(screen.getByText('+0.4000 · 参考 10 场')).toBeVisible();
@@ -917,7 +942,7 @@ describe('RelationshipAggregateScore', () => {
     );
   });
 
-  test('retains an outgoing score for 150ms without pointer ownership', () => {
+  test('retains an outgoing score for 240ms without pointer ownership', () => {
     vi.useFakeTimers();
     const preview = aggregate([relationship('HS', 0.4, '甲')]);
     const { rerender } = render(
@@ -933,7 +958,7 @@ describe('RelationshipAggregateScore', () => {
     expect(lane).toHaveAttribute('aria-hidden', 'true');
     expect(getComputedStyle(lane).pointerEvents).toBe('none');
 
-    act(() => vi.advanceTimersByTime(149));
+    act(() => vi.advanceTimersByTime(239));
     expect(screen.getByTestId('relationship-score-lane')).toBeInTheDocument();
     act(() => vi.advanceTimersByTime(1));
     expect(screen.queryByTestId('relationship-score-lane')).not.toBeInTheDocument();
@@ -960,7 +985,7 @@ describe('RelationshipAggregateScore', () => {
       /甲与来源战法/
     );
 
-    act(() => vi.advanceTimersByTime(149));
+    act(() => vi.advanceTimersByTime(239));
     expect(screen.getByTestId('relationship-score')).toHaveAccessibleName(
       /甲与来源战法/
     );

--- a/web/src/components/teamBuilder/__tests__/FormationWorkbench.test.tsx
+++ b/web/src/components/teamBuilder/__tests__/FormationWorkbench.test.tsx
@@ -247,7 +247,7 @@ describe('FormationWorkbench card presentation', () => {
     expect(getComputedStyle(screen.getByTestId('game-card-hero-刘备')).height).toBe('100%');
     expect(getComputedStyle(screen.getByTestId('game-card-hero-刘备')).aspectRatio).toBe('auto');
     expect(screen.getByTestId('relationship-preview-legend')).toHaveTextContent(
-      '“+”提高，“−”降低；不是胜率'
+      '同队（两名武将）、携带（武将与战法）、同将（两战法由同一武将携带）、三人组（完整三人同队）会显示带符号的相对评分影响：“+”提高，“−”降低；不是胜率。'
     );
     expect(
       getComputedStyle(screen.getByTestId('pool-hero-曹操-primary')).paddingTop

--- a/web/src/pages/TeamBuilder.tsx
+++ b/web/src/pages/TeamBuilder.tsx
@@ -588,7 +588,7 @@ const TeamBuilder = () => {
             <Button
               startIcon={<ArrowBackIcon />}
               onClick={() => navigate(-1)}
-              variant="contained"
+              variant="outlined"
               sx={{ flexShrink: 0 }}
             >
               返回

--- a/web/src/services/__tests__/relationshipPreview.test.ts
+++ b/web/src/services/__tests__/relationshipPreview.test.ts
@@ -375,10 +375,12 @@ describe('aggregate relationship previews', () => {
 
     expect(aggregate).toMatchObject({
       total: 0.25,
+      compactLabel: '携带',
       components: [{ family: 'HS', featureId: 'HS|A|x' }],
     });
     expect(aggregate?.components).toHaveLength(1);
     expect(aggregate?.accessibleLabel).toContain('共 1 项');
+    expect(aggregate?.accessibleLabel).toContain('正值提高相对评分，负值降低，这不是胜率');
     expect(aggregate?.components[0].accessibleLabel).toContain('直接携带');
   });
 });

--- a/web/src/services/relationshipPreview.ts
+++ b/web/src/services/relationshipPreview.ts
@@ -84,6 +84,15 @@ const DISPLAYED_FAMILIES = new Set<PairRelationshipFamily>([
 
 const RELATIONSHIP_PREVIEW_WEIGHT_DIGITS = 4;
 
+const COMPACT_RELATIONSHIP_LABELS: Readonly<
+  Record<PairRelationshipFamily, string>
+> = {
+  HP: '同队',
+  HS: '携带',
+  SP: '同将',
+  HT: '三人组',
+};
+
 export const formatRelationshipPreviewWeight = (weight: number): string =>
   formatSignedWeight(weight, RELATIONSHIP_PREVIEW_WEIGHT_DIGITS);
 
@@ -393,12 +402,18 @@ export function aggregateRelationshipTargetsFor(
     if (!hasVisibleRelationshipPreviewWeight(total)) continue;
     const target = distinct[0].target;
     const signed = formatRelationshipPreviewWeight(total);
+    const compactLabels = new Set(
+      distinct.map(({ family }) => COMPACT_RELATIONSHIP_LABELS[family])
+    );
+    const compactLabel =
+      compactLabels.size === 1 ? [...compactLabels][0] : '关系';
     aggregates.set(targetKey, {
       source,
       target,
       total,
       components: distinct,
-      accessibleLabel: `${target.name}与${source.name}的关系总分 ${signed}，共 ${distinct.length} 项；查看完整明细`,
+      compactLabel,
+      accessibleLabel: `${target.name}与${source.name}的${compactLabel}关系影响 ${signed}，共 ${distinct.length} 项；正值提高相对评分，负值降低，这不是胜率；查看完整明细`,
     });
   }
   return aggregates;
@@ -484,7 +499,7 @@ export function buildHeroTrioRelationshipPreviews(
         components: [component],
         compactLabel: '三人组',
         detailHeading: `队伍 ${teamIndex + 1} · 精确三人组 ${trioName}`,
-        accessibleLabel: `队伍 ${teamIndex + 1}，精确武将三人组${trioName}，关系总分 ${signed}，共 1 项；查看完整明细`,
+        accessibleLabel: `队伍 ${teamIndex + 1}，精确武将三人组${trioName}，三人组关系影响 ${signed}，共 1 项；正值提高相对评分，负值降低，这不是胜率；查看完整明细`,
       },
     ],
   ]);

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -2360,12 +2360,12 @@ test.describe('Team Builder best default', () => {
     await expect(
       page.getByText(/可信特征要求|高证据配合|加分不低于/)
     ).toHaveCount(0);
-    await expect(page.getByTestId('relationship-preview-legend')).toContainText(
-      '同队、携带、同将会显示带符号的相对评分影响',
+    const relationshipLegend = page.getByTestId('relationship-preview-legend');
+    await expect(relationshipLegend).toBeVisible();
+    await expect(relationshipLegend).toContainText(
+      '同队（两名武将）、携带（武将与战法）、同将（两战法由同一武将携带）、三人组（完整三人同队）会显示带符号的相对评分影响',
     );
-    await expect(page.getByTestId('relationship-preview-legend')).toContainText(
-      '不是胜率',
-    );
+    await expect(relationshipLegend).toContainText('不是胜率');
     await expect(page.getByText(/阵型和前后排由你确认/)).toHaveCount(0);
     await expect(page.getByText('最佳推荐', { exact: true })).toHaveCount(0);
     await expect(

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -22,9 +22,17 @@ function expectedModelFeature(featureId) {
   }
 
   const weight = weights[featureId];
+  const compactLabel = {
+    HP: '同队',
+    HS: '携带',
+    SP: '同将',
+    HT: '三人组',
+  }[featureId.split('|')[0]];
   return {
     featureId,
+    compactLabel,
     formattedWeight: `${weight < 0 ? '−' : '+'}${Math.abs(weight).toFixed(4)}`,
+    visibleLabel: `${compactLabel}${weight < 0 ? '−' : '+'}${Math.abs(weight).toFixed(4)}`,
     support: support[featureId],
   };
 }
@@ -467,7 +475,7 @@ async function expectAccessibleContrast(target) {
 
 async function expectRailContainedByShell(shell, primary, rail) {
   await expect(rail).toHaveAttribute('data-relationship-transition-state', 'visible');
-  await rail.page().waitForTimeout(170);
+  await rail.page().waitForTimeout(260);
   const [shellBox, primaryBox, railBox] = await Promise.all([
     shell.boundingBox(),
     primary.boundingBox(),
@@ -750,8 +758,8 @@ async function assertStationaryRelationshipActivation(page, {
   // Let every one-shot exit settle before checking that a stationary pointer
   // causes no further ownership or DOM oscillation. Several cards can hand off
   // at once, so a fixed delay can end between their independently scheduled
-  // passive effects even though each exit itself lasts only 150ms.
-  await page.waitForTimeout(180);
+  // passive effects even though each exit itself lasts only 240ms.
+  await page.waitForTimeout(280);
   await expect(
     page.locator(
       '[data-testid="relationship-score-lane"][data-relationship-count="0"]',
@@ -1189,8 +1197,7 @@ test.describe('Team Builder manual workshop', () => {
           (heroControlsBox.y + heroControlsBox.height),
       ),
     ).toBeLessThanOrEqual(1);
-    expect(heroArtBox.width / heroArtBox.height).toBeGreaterThanOrEqual(0.58);
-    expect(heroArtBox.width / heroArtBox.height).toBeLessThanOrEqual(0.68);
+    expect(heroArtBox.width / heroArtBox.height).toBeCloseTo(142 / 144, 2);
 
     await page.getByRole('combobox', { name: '阵型' }).first().click();
     await page.getByRole('option', { name: '锥形阵' }).click();
@@ -1423,16 +1430,19 @@ test.describe('Team Builder contextual relationship weights', () => {
 
     const zhangZhaoCard = page.getByTestId('hero-card-0-0');
     const zhangZhaoScore = zhangZhaoCard.getByTestId('relationship-score');
-    await expect(zhangZhaoScore).toHaveText(zhangZhaoFire.formattedWeight);
+    await expect(zhangZhaoScore).toHaveText(zhangZhaoFire.visibleLabel);
     await expect(zhangZhaoCard.getByTestId('relationship-score')).toHaveCount(1);
     await expect(zhangZhaoScore).toHaveAccessibleName(
-      `张昭与烈火张天的关系总分 ${zhangZhaoFire.formattedWeight}，共 1 项；查看完整明细`,
+      `张昭与烈火张天的携带关系影响 ${zhangZhaoFire.formattedWeight}，共 1 项；正值提高相对评分，负值降低，这不是胜率；查看完整明细`,
     );
     await zhangZhaoScore.focus();
     await zhangZhaoScore.press('Enter');
     const zhangBreakdown = page.getByRole('dialog');
     await expect(zhangBreakdown).toContainText(
-      `张昭 × 烈火张天 ${zhangZhaoFire.formattedWeight}`,
+      '张昭 × 烈火张天',
+    );
+    await expect(zhangBreakdown).toContainText(
+      `携带影响 ${zhangZhaoFire.formattedWeight} · 正值提高相对评分，负值降低；不是胜率。`,
     );
     await expect(zhangBreakdown.getByTestId('relationship-detail-row')).toHaveCount(1);
     await expect(zhangBreakdown).toContainText(
@@ -1473,14 +1483,14 @@ test.describe('Team Builder contextual relationship weights', () => {
 
     await page.getByTestId('hero-slot-0-0').hover();
     await expect(luXunCard.getByTestId('relationship-score')).toHaveText(
-      zhangZhaoLuXun.formattedWeight,
+      zhangZhaoLuXun.visibleLabel,
     );
     await expect(
       page.getByTestId('hero-card-0-2').getByTestId('relationship-score'),
-    ).toHaveText(zhangZhaoHuangGai.formattedWeight);
+    ).toHaveText(zhangZhaoHuangGai.visibleLabel);
     await expect(
       fire.locator('..').getByTestId('relationship-score'),
-    ).toHaveText(zhangZhaoFire.formattedWeight);
+    ).toHaveText(zhangZhaoFire.visibleLabel);
     await expect(
       page.getByTestId('pool-skill-胜敌益强').getByTestId('relationship-score'),
     ).toHaveCount(0);
@@ -1520,9 +1530,9 @@ test.describe('Team Builder contextual relationship weights', () => {
       };
     });
     expect(normalStyle).toEqual({
-      duration: '0.15s, 0.15s',
+      duration: '0.24s, 0.24s',
       property: 'opacity, transform',
-      timing: 'ease, ease',
+      timing: 'cubic-bezier(0.2, 0, 0, 1), cubic-bezier(0.2, 0, 0, 1)',
     });
 
     await page.getByRole('heading', { level: 1, name: '队伍策案' }).hover();
@@ -1552,12 +1562,12 @@ test.describe('Team Builder contextual relationship weights', () => {
         .flatMap(({ transforms }) => transforms)
         .some(
           (transform) =>
-            transform === 'translateY(2px)' ||
-            /matrix\([^)]*,\s*2\)$/.test(transform),
+            transform === 'translateY(3px)' ||
+            /matrix\([^)]*,\s*3\)$/.test(transform),
         ),
     ).toBe(true);
 
-    await page.waitForTimeout(170);
+    await page.waitForTimeout(260);
     await page.emulateMedia({ reducedMotion: 'reduce' });
     await source.hover();
     await expect(lane).toHaveAttribute(
@@ -1651,7 +1661,7 @@ test.describe('Team Builder contextual relationship weights', () => {
         });
         await page.evaluate(() => document.activeElement?.blur());
         await page.getByRole('heading', { level: 1, name: '队伍策案' }).hover();
-        await page.waitForTimeout(180);
+        await page.waitForTimeout(280);
       }
     }
   });
@@ -1682,7 +1692,7 @@ test.describe('Team Builder contextual relationship weights', () => {
       });
       await page.evaluate(() => document.activeElement?.blur());
       await page.getByRole('heading', { level: 1, name: '队伍策案' }).hover();
-      await page.waitForTimeout(180);
+      await page.waitForTimeout(280);
 
       const skillOwner = page.getByTestId('skill-slot-0-0-0').locator('..');
       const skillTargetPrimary = page.getByTestId('skill-slot-0-0-1');
@@ -1859,14 +1869,14 @@ test.describe('Team Builder contextual relationship weights', () => {
       );
       await expect(activeGroups.first()).toHaveCSS(
         'transition-duration',
-        '0.15s, 0.15s',
+        '0.24s, 0.24s',
       );
 
       await page.getByTestId('hero-slot-0-0').hover();
       const trioLane = page.getByTestId('team-relationship-score-lane-0');
       const trioScore = trioLane.getByTestId('relationship-score');
       await expect(trioScore).toHaveText(
-        `三人组 ${mengHuoTrio.formattedWeight}`,
+        `三人组${mengHuoTrio.formattedWeight}`,
       );
       await expect(trioScore).toHaveAccessibleName(
         /精确武将三人组孟获、木鹿大王、祝融/,
@@ -1881,7 +1891,7 @@ test.describe('Team Builder contextual relationship weights', () => {
       await page.evaluate(() => document.activeElement?.blur());
 
       await page.getByRole('heading', { level: 1, name: '队伍策案' }).hover();
-      await page.waitForTimeout(180);
+      await page.waitForTimeout(280);
       expect(await evidenceSnapshot()).toEqual(evidenceBefore);
       await expect(teamCard.getByTestId('team-strength')).toHaveText(scoreBefore);
       await expect(teamCard).not.toContainText(
@@ -1918,7 +1928,7 @@ test.describe('Team Builder contextual relationship weights', () => {
     await page.getByTestId('hero-slot-0-2').hover();
     const trioLane = page.getByTestId('team-relationship-score-lane-0');
     const trioScore = trioLane.getByTestId('relationship-score');
-    await expect(trioScore).toHaveText(`三人组 ${mengHuoTrio.formattedWeight}`);
+    await expect(trioScore).toHaveText(`三人组${mengHuoTrio.formattedWeight}`);
     await expect(trioLane.getByTestId('relationship-score-lane')).toHaveAttribute(
       'data-relationship-transition-state',
       'visible',
@@ -1939,7 +1949,10 @@ test.describe('Team Builder contextual relationship weights', () => {
     await page.mouse.up();
 
     await expect(page.getByRole('dialog')).toContainText(
-      `队伍 1 · 精确三人组 孟获、木鹿大王、祝融 ${mengHuoTrio.formattedWeight}`,
+      '队伍 1 · 精确三人组 孟获、木鹿大王、祝融',
+    );
+    await expect(page.getByRole('dialog')).toContainText(
+      `三人组影响 ${mengHuoTrio.formattedWeight} · 正值提高相对评分，负值降低；不是胜率。`,
     );
   });
 
@@ -1968,7 +1981,7 @@ test.describe('Team Builder contextual relationship weights', () => {
       .getByTestId('team-relationship-score-lane-0')
       .getByTestId('relationship-score');
     await expect(prospectiveTrio).toHaveText(
-      `三人组 ${diaoChanTrio.formattedWeight}`,
+      `三人组${diaoChanTrio.formattedWeight}`,
     );
     await expect(prospectiveTrio).toHaveAccessibleName(
       /精确武将三人组孟获、祝融、貂蝉/,
@@ -2010,22 +2023,22 @@ test.describe('Team Builder contextual relationship weights', () => {
 
     const hero = page.getByTestId('hero-slot-0-0');
     const removeHero = page.getByRole('button', { name: '移除武将 张昭' });
-    await hero.hover();
+    await hero.hover({ position: { x: 12, y: 22 } });
     await expect(hero).toHaveAttribute('data-preview-state', 'selected');
     await removeHero.hover();
     await expect(page.locator('[data-preview-state]')).toHaveCount(0);
-    await hero.hover();
+    await hero.hover({ position: { x: 12, y: 22 } });
     await expect(hero).toHaveAttribute('data-preview-state', 'selected');
 
     const skill = page.getByTestId('skill-slot-0-0-0');
     const removeSkill = page.getByRole('button', {
       name: '移除战法 烈火张天',
     });
-    await skill.hover();
+    await skill.hover({ position: { x: 12, y: 22 } });
     await expect(skill).toHaveAttribute('data-preview-state', 'selected');
     await removeSkill.hover();
     await expect(page.locator('[data-preview-state]')).toHaveCount(0);
-    await skill.hover();
+    await skill.hover({ position: { x: 12, y: 22 } });
     await expect(skill).toHaveAttribute('data-preview-state', 'selected');
   });
 
@@ -2060,7 +2073,7 @@ test.describe('Team Builder contextual relationship weights', () => {
       .getByTestId('skill-slot-0-1-0')
       .locator('..')
       .getByTestId('relationship-score');
-    await expect(skillScore).toHaveText(zhangZhaoFire.formattedWeight);
+    await expect(skillScore).toHaveText(zhangZhaoFire.visibleLabel);
     await movePointerTo(page, skillScore);
     await page.mouse.up();
 
@@ -2079,12 +2092,12 @@ test.describe('Team Builder contextual relationship weights', () => {
     const zhangZhaoScore = page
       .getByTestId('hero-card-0-0')
       .getByTestId('relationship-score');
-    await expect(zhangZhaoScore).toHaveText(zhangZhaoFire.formattedWeight);
+    await expect(zhangZhaoScore).toHaveText(zhangZhaoFire.visibleLabel);
     await zhangZhaoScore.focus();
     await zhangZhaoScore.press('Enter');
 
     await expect(page.getByRole('dialog')).toContainText(
-      `张昭 × 烈火张天 ${zhangZhaoFire.formattedWeight}`,
+      '张昭 × 烈火张天',
     );
     await expect(page.getByText('已选择：烈火张天')).toHaveCount(0);
     await expect(page.getByTestId('hero-slot-0-2')).toContainText('黄盖');
@@ -2121,7 +2134,7 @@ test.describe('Team Builder contextual relationship weights', () => {
       .getByTestId('hero-card-0-0')
       .getByTestId('relationship-score');
     await expect(focusedZhangZhaoScore).toHaveText(
-      zhangZhaoFire.formattedWeight,
+      zhangZhaoFire.visibleLabel,
     );
     await focusedZhangZhaoScore.focus();
     await focusedZhangZhaoScore.press('Enter');
@@ -2142,7 +2155,7 @@ test.describe('Team Builder contextual relationship weights', () => {
     await expect(fire).toHaveAttribute('data-preview-state', 'selected');
     await expect(
       page.getByTestId('hero-card-0-0').getByTestId('relationship-score'),
-    ).toHaveText(zhangZhaoFire.formattedWeight);
+    ).toHaveText(zhangZhaoFire.visibleLabel);
     await expectPermanentEvidenceUnchanged();
 
     await page.getByRole('button', { name: '取消' }).click();
@@ -2347,6 +2360,12 @@ test.describe('Team Builder best default', () => {
     await expect(
       page.getByText(/可信特征要求|高证据配合|加分不低于/)
     ).toHaveCount(0);
+    await expect(page.getByTestId('relationship-preview-legend')).toContainText(
+      '同队、携带、同将会显示带符号的相对评分影响',
+    );
+    await expect(page.getByTestId('relationship-preview-legend')).toContainText(
+      '不是胜率',
+    );
     await expect(page.getByText(/阵型和前后排由你确认/)).toHaveCount(0);
     await expect(page.getByText('最佳推荐', { exact: true })).toHaveCount(0);
     await expect(
@@ -2397,7 +2416,7 @@ test.describe('Team Builder best default', () => {
 
     const body = await page.locator('body').innerText();
     expect(body).not.toContain('总评分');
-    expect(body).not.toContain('胜率');
+    expect(body).not.toMatch(/胜率[：:]/);
     expect(body).toContain('加分');
     expect(body).toContain('参考');
     const seededFormations = await page
@@ -2533,13 +2552,15 @@ test.describe('Team Builder mobile placement', () => {
     });
     expect(geometry.card.width).toBeGreaterThanOrEqual(325);
     expect(geometry.art.width).toBeGreaterThanOrEqual(141);
-    expect(geometry.art.height).toBeGreaterThanOrEqual(220);
+    expect(Math.abs(geometry.art.height - 144)).toBeLessThanOrEqual(1);
     expect(geometry.controls.width).toBeGreaterThanOrEqual(163);
+    expect(Math.abs(geometry.controls.height - 144)).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.art.bottom - geometry.controls.bottom)).toBeLessThanOrEqual(1);
     expect(geometry.controls.left).toBeGreaterThanOrEqual(
       geometry.art.right + 5,
     );
     expect(geometry.controls.right).toBeLessThanOrEqual(
-      geometry.card.right - 5,
+      geometry.card.right - 3,
     );
     expect(geometry.controls.top).toBeGreaterThanOrEqual(geometry.card.top);
     expect(geometry.controls.bottom).toBeLessThanOrEqual(
@@ -2700,7 +2721,7 @@ test.describe('Team Builder mobile placement', () => {
     const poolZhouYuRail = poolZhouYu.getByTestId('relationship-score-lane');
     await expect(
       zhangZhaoRail.getByTestId('relationship-score'),
-    ).toHaveText(zhangZhaoFire.formattedWeight);
+    ).toHaveText(zhangZhaoFire.visibleLabel);
     await expect(poolZhouYuRail).toHaveCount(0);
     await expectRailContainedByShell(
       zhangZhaoHeader,
@@ -2712,7 +2733,7 @@ test.describe('Team Builder mobile placement', () => {
     await zhangZhaoRail.getByTestId('relationship-score').tap();
     const detail = page.getByRole('dialog');
     await expect(detail).toContainText(
-      `张昭 × 烈火张天 ${zhangZhaoFire.formattedWeight}`,
+      '张昭 × 烈火张天',
     );
     await expect(page.getByText('已选择：烈火张天')).toBeVisible();
     const detailBox = await detail.boundingBox();


### PR DESCRIPTION
## Intent

Improve the ./web UI using the principles in every skill from gnurio/refactoring-ui-plugin, with special focus on /team-builder. Eliminate the unexplained gap below the second allocated skill by matching a cropped hero portrait to the row selector and two skill slots. Make hover, focus, tap, and drag relationship weights self-explanatory with plain-language 同队, 携带, 同将, and 三人组 labels; an always-visible legend; a clear positive-versus-negative relative-score explanation that explicitly says the value is not win probability; lighter semantic colors; and a gentler 240ms reduced-motion-aware transition. Clarify button hierarchy, reduce nested elevation, preserve model scoring and displayed-family rules, and retain drag/drop, touch, keyboard, accessibility, responsive behavior, and all non-target behavior. Validate every route at desktop, tablet, and mobile. The user explicitly approved allowing telemetry-disabled no-mistakes to review and, if necessary, commit automated fixes to commit eec9ce3b; push branch codex/refactor-web-ui to github.com/liamqma/sanmou-yanwu; and create a PR targeting master.

## What Changed
- Crop assigned hero portraits to align with the 144px row-and-skill control stack, flatten nested team-card elevation, and demote back navigation to an outlined action.
- Add an always-visible relationship legend, plain-language 同队/携带/同将/三人组 labels, and accessible breakdowns explaining signed relative-score effects are not win probability.
- Use lighter positive/negative score surfaces and a reduced-motion-aware 240ms transition, with updated unit, end-to-end, visual-audit, and component documentation coverage.

## Risk Assessment

✅ Low: The change is a well-bounded presentation refactor that preserves scoring and relationship-family logic while satisfying the portrait, labeling, legend, semantic-color, motion, accessibility, and responsive requirements.

## Testing

No pre-supplied baseline results were available. After bypassing a stale unrelated dev server on port 3000, focused Vitest and browser tests exercised hover, focus, tap, keyboard, drag/drop, relationship-family labels, score explanations, 240ms/reduced-motion behavior, model-display filtering, and the cropped 144px hero/control layout successfully. The visual audit rendered all seven routes at desktop, tablet, and mobile plus representative Team Builder states, recording no page errors, horizontal overflow, or disallowed dark surfaces; reviewer-visible screenshots were manually inspected and transient worktree artifacts were cleaned.

- Evidence: Desktop Team Builder relationship detail showing the always-visible legend, cropped hero portrait, labeled score, and not-win-probability explanation (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1AWTNYZX183JN0S29GP60V3/visual-audit/desktop--team-builder-relationship-detail.png</code>)
- Evidence: 320px Team Builder tap/swap state showing aligned portrait, row selector, two tactic slots, and responsive legend (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1AWTNYZX183JN0S29GP60V3/visual-audit/mobile-320--team-builder-tactic-swap.png</code>)
- Evidence: Populated desktop Team Builder overview (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1AWTNYZX183JN0S29GP60V3/visual-audit/desktop--team-builder-populated.png</code>)
<details>
<summary>Evidence: Visual audit report covering every route at desktop, tablet, and mobile plus representative component states</summary>

```text
[
  {
    "name": "desktop--advisor",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:演武配将与战法推荐",
      "H2:初始武将 (0/4)还需 4 名",
      "H2:初始战法 (0/8)还需 8 个"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--analytics",
    "errors": [],
    "title": "三国谋定天下演武数据与武将战法排行｜演武参谋",
    "headings": [
      "H1:数据洞察",
      "H2:匿名选项统计",
      "H3:游戏最常提供",
      "H3:玩家最常选择",
      "H2:历史战报分析",
      "H3:三步看懂这些数字",
      "H3:只看我关心的武将和战法",
      "H3:先看谁更值得选",
      "H3:再看哪些搭配效果好",
      "H3:看看大家常用什么",
      "H3:数据与算法说明选看内容：了解这些推荐有多可靠，不影响日常挑人挑战法。"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--team-builder",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 0 名武将、0 个战法；支援选择也会进入仓库",
      "H2:还没有可编排的卡池"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--contribute",
    "errors": [],
    "title": "上传三国谋定天下演武战报｜演武参谋",
    "headings": [
      "H1:上传战报",
      "H2:四步完成上传",
      "H2:准备 DeepSeek 提示词",
      "H2:填写并确认战报",
      "H3:手动确认双方阵容",
      "H3:确认阵容 1",
      "H3:确认阵容 2"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--contributors",
    "errors": [],
    "title": "三国谋定天下演武战报贡献榜｜演武参谋",
    "headings": [
      "H1:战报贡献榜",
      "H2:贡献者排名"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--guide",
    "errors": [],
    "title": "三国谋定天下演武武将战法排行与强队攻略｜演武参谋",
    "headings": [
      "H1:三国谋定天下演武武将、战法与阵容指南",
      "H2:国家武将排行榜",
      "H3:魏国",
      "H3:蜀国",
      "H3:吴国",
      "H3:群雄",
      "H2:战法排行榜",
      "H3:兵刃",
      "H3:谋略",
      "H3:治疗",
      "H3:防御",
      "H3:辅助",
      "H3:文武",
      "H2:强队阵容",
      "H2:阵容克制查询",
      "H2:阵容解析",
      "H3:司马懿",
      "H3:祝融"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--not-found",
    "errors": [],
    "title": "页面未找到｜演武参谋",
    "headings": [
      "H1:页面未找到"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--advisor",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:演武配将与战法推荐",
      "H2:初始武将 (0/4)还需 4 名",
      "H2:初始战法 (0/8)还需 8 个"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--analytics",
    "errors": [],
    "title": "三国谋定天下演武数据与武将战法排行｜演武参谋",
    "headings": [
      "H1:数据洞察",
      "H2:匿名选项统计",
      "H3:游戏最常提供",
      "H3:玩家最常选择",
      "H2:历史战报分析",
      "H3:三步看懂这些数字",
      "H3:只看我关心的武将和战法",
      "H3:先看谁更值得选",
      "H3:再看哪些搭配效果好",
      "H3:看看大家常用什么",
      "H3:数据与算法说明选看内容：了解这些推荐有多可靠，不影响日常挑人挑战法。"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--team-builder",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 0 名武将、0 个战法；支援选择也会进入仓库",
      "H2:还没有可编排的卡池"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--contribute",
    "errors": [],
    "title": "上传三国谋定天下演武战报｜演武参谋",
    "headings": [
      "H1:上传战报",
      "H2:四步完成上传",
      "H2:准备 DeepSeek 提示词",
      "H2:填写并确认战报",
      "H3:手动确认双方阵容",
      "H3:确认阵容 1",
      "H3:确认阵容 2"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--contributors",
    "errors": [],
    "title": "三国谋定天下演武战报贡献榜｜演武参谋",
    "headings": [
      "H1:战报贡献榜",
      "H2:贡献者排名"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--guide",
    "errors": [],
    "title": "三国谋定天下演武武将战法排行与强队攻略｜演武参谋",
    "headings": [
      "H1:三国谋定天下演武武将、战法与阵容指南",
      "H2:国家武将排行榜",
      "H3:魏国",
      "H3:蜀国",
      "H3:吴国",
      "H3:群雄",
      "H2:战法排行榜",
      "H3:兵刃",
      "H3:谋略",
      "H3:治疗",
      "H3:防御",
      "H3:辅助",
      "H3:文武",
      "H2:强队阵容",
      "H2:阵容克制查询",
      "H2:阵容解析",
      "H3:司马懿",
      "H3:祝融"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--not-found",
    "errors": [],
    "title": "页面未找到｜演武参谋",
    "headings": [
      "H1:页面未找到"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--advisor",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:演武配将与战法推荐",
      "H2:初始武将 (0/4)还需 4 名",
      "H2:初始战法 (0/8)还需 8 个"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--analytics",
    "errors": [],
    "title": "三国谋定天下演武数据与武将战法排行｜演武参谋",
    "headings": [
      "H1:数据洞察",
      "H2:匿名选项统计",
      "H3:游戏最常提供",
      "H3:玩家最常选择",
      "H2:历史战报分析",
      "H3:三步看懂这些数字",
      "H3:只看我关心的武将和战法",
      "H3:先看谁更值得选",
      "H3:再看哪些搭配效果好",
      "H3:看看大家常用什么",
      "H3:数据与算法说明选看内容：了解这些推荐有多可靠，不影响日常挑人挑战法。"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--team-builder",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 0 名武将、0 个战法；支援选择也会进入仓库",
      "H2:还没有可编排的卡池"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--contribute",
    "errors": [],
    "title": "上传三国谋定天下演武战报｜演武参谋",
    "headings": [
      "H1:上传战报",
      "H2:四步完成上传",
      "H2:准备 DeepSeek 提示词",
      "H2:填写并确认战报",
      "H3:手动确认双方阵容",
      "H3:确认阵容 1",
      "H3:确认阵容 2"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--contributors",
    "errors": [],
    "title": "三国谋定天下演武战报贡献榜｜演武参谋",
    "headings": [
      "H1:战报贡献榜",
      "H2:贡献者排名"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--guide",
    "errors": [],
    "title": "三国谋定天下演武武将战法排行与强队攻略｜演武参谋",
    "headings": [
      "H1:三国谋定天下演武武将、战法与阵容指南",
      "H2:国家武将排行榜",
      "H3:魏国",
      "H3:蜀国",
      "H3:吴国",
      "H3:群雄",
      "H2:战法排行榜",
      "H3:兵刃",
      "H3:谋略",
      "H3:治疗",
      "H3:防御",
      "H3:辅助",
      "H3:文武",
      "H2:强队阵容",
      "H2:阵容克制查询",
      "H2:阵容解析",
      "H3:司马懿",
      "H3:祝融"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--not-found",
    "errors": [],
    "title": "页面未找到｜演武参谋",
    "headings": [
      "H1:页面未找到"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--round-recommendation",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:第 1 轮：选择武将",
      "H2:当前阵容",
      "H2:本轮选择",
      "H3:第 1 组 (3/3)",
      "H3:第 2 组 (3/3)",
      "H3:第 3 组 (3/3)",
      "H2:本轮阵容方向",
      "H2:AI 推荐"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--round-recommendation",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:第 1 轮：选择武将",
      "H2:本轮选择",
      "H3:第 1 组 (3/3)",
      "H3:第 2 组 (3/3)",
      "H3:第 3 组 (3/3)",
      "H2:本轮阵容方向",
      "H2:AI 推荐"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--round-roster-expanded",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:第 1 轮：选择武将",
      "H2:当前阵容",
      "H2:本轮选择",
      "H3:第 1 组 (3/3)",
      "H3:第 2 组 (3/3)",
      "H3:第 3 组 (3/3)",
      "H2:本轮阵容方向",
      "H2:AI 推荐"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--qualification-interstitial",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:第 7 轮：选择武将",
      "H2:整军再战",
      "H2:当前阵容"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--team-builder-populated",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 9 名武将、18 个战法；支援选择也会进入仓库",
      "H2:我的比赛阵容",
      "H3:队伍 1",
      "H3:队伍 2",
      "H3:队伍 3",
      "H2:卡池仓库",
      "H3:武将仓库",
      "H3:战法仓库"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--team-builder-tactic-quality",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 1 名武将、2 个战法；支援选择也会进入仓库",
      "H2:我的比赛阵容",
      "H3:队伍 1",
      "H3:队伍 2",
      "H3:队伍 3",
      "H2:卡池仓库",
      "H3:武将仓库",
      "H3:战法仓库"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--team-builder-relationship-detail",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 1 名武将、2 个战法；支援选择也会进入仓库",
      "H2:我的比赛阵容",
      "H3:队伍 1",
      "H3:队伍 2",
      "H3:队伍 3",
      "H2:卡池仓库",
      "H3:武将仓库",
      "H3:战法仓库",
      "H2:如沐春风 × 忘私相助"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile-320--team-builder-tactic-swap",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 1 名武将、2 个战法；支援选择也会进入仓库",
      "H2:我的比赛阵容",
      "H3:队伍 1",
      "H3:队伍 2",
      "H3:队伍 3",
      "H2:卡池仓库",
      "H3:武将仓库",
      "H3:战法仓库"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--team-builder-loading",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 9 名武将、18 个战法；支援选择也会进入仓库"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--completed-game",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:对局完成",
      "H2:当前阵容"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--discussion-dialog",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:演武配将与战法推荐",
      "H2:初始武将 (0/4)还需 4 名",
      "H2:初始战法 (0/8)还需 8 个",
      "H2:加演武讨论群"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--support-hero-dialog",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:第 1 轮：选择武将",
      "H2:当前阵容",
      "H2:本轮选择",
      "H3:第 1 组 (3/3)",
      "H3:第 2 组 (3/3)",
      "H3:第 3 组 (3/3)",
      "H2:推荐支援武将"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--leaderboard-loading",
    "errors": [],
    "title": "三国谋定天下演武战报贡献榜｜演武参谋",
    "headings": [
      "H1:战报贡献榜",
      "H2:贡献者排名"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--route-loading",
    "errors": [],
    "title": "三国谋定天下演武数据与武将战法排行｜演武参谋",
    "headings": [],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  }
]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ec44f9f3ac9433b5bcf59f9364ae37e6992fb32e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `web/src/components/teamBuilder/FormationWorkbench.tsx:2184` - The required always-visible relationship legend is incomplete: the intent explicitly enumerates 同队、携带、同将、三人组, but this legend says only “同队、携带、同将…”. Since HT previews still dynamically display 三人组, include that category in the persistent legend (and its meaning), or confirm that omitting it was intentional.

🔧 Fix: Complete relationship legend with trio explanation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd web && pnpm exec vitest run src/services/__tests__/relationshipPreview.test.ts src/components/teamBuilder/__tests__/FormationWorkbench.test.tsx`
- <code>`cd web &amp;&amp; pnpm exec playwright test tests/buildATeam.spec.js --grep &#39;whole hero and skill blocks drag|supports keyboard placement|shows one aggregate per target|executes relationship transitions|shows one exact HT for a concrete post-replacement hero drag|uses keyboard focus and tap selection|seeds exactly one evidence-only editable three-team formation|exposes complete hero controls and tactic names at 320px|keeps direct score breakdown and relation-free card taps usable at 320px&#39;` — initial attempt exposed a stale server on port 3000</code>
- <code>`cd web &amp;&amp; pnpm exec playwright test --config .playwright.no-mistakes.tmp.cjs tests/buildATeam.spec.js --grep &#39;whole hero and skill blocks drag|supports keyboard placement|shows one aggregate per target|executes relationship transitions|shows one exact HT for a concrete post-replacement hero drag|uses keyboard focus and tap selection|seeds exactly one evidence-only editable three-team formation|exposes complete hero controls and tactic names at 320px|keeps direct score breakdown and relation-free card taps usable at 320px&#39;` using an isolated Vite server on port 3100</code>
- `cd web && VISUAL_AUDIT_BASE_URL=http://127.0.0.1:3100 node scripts/capture-visual-audit.mjs /var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1AWTNYZX183JN0S29GP60V3/visual-audit`
- `Manually inspected the populated desktop Team Builder, relationship-detail popover, and 320px tap/swap screenshots for portrait cropping, control alignment, legend/copy placement, semantic colors, and responsive layout.`
- `Removed transient Playwright output and temporary configuration, then confirmed the worktree remained clean.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
