### PR TITLE
feat(web): add WeChat-ready round snapshot sharing

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -184,7 +184,14 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
 
 - **GameBoard**: Main game container managing the draft rounds. On wide desktop
   the option workspace and current roster share one two-column viewport; on
-  mobile the roster is a disclosure below the option workspace.
+  mobile the roster is a disclosure below the option workspace. Once all three
+  candidate groups are complete, `复制选项与阵容图片` renders a controls-free,
+  fixed-1200px-wide PNG entirely in the browser, independent of the responsive
+  page layout. The image includes the round and season, every candidate group,
+  current roster score, all acquired hero and tactic cards, guide rankings, and
+  support markers. It is copied through the binary Clipboard API when allowed;
+  otherwise a preview offers native file sharing when supported, download, and
+  mobile long-press/save guidance for sending it to WeChat.
 - **RoundInfo**: Display current round information with an accessible ten-round
   campaign-plaque progress rail
 - **CurrentTeam**: Keep 当前阵容, its roster 评分/score, the edit control, and season

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -33,6 +33,25 @@ interface QualificationInterstitialProps {
   children: ReactNode;
 }
 
+interface SharePreview {
+  blob: Blob;
+  file: File | null;
+  url: string;
+  downloadFilename: string;
+  nativeShareTitle: string;
+}
+
+interface GameBoardShellProps {
+  children: ReactNode;
+  snackbarMessage: string | null;
+  sharePreview: SharePreview | null;
+  canNativeShare: boolean;
+  onSnackbarClose: () => void;
+  onCloseSharePreview: () => void;
+  onDownloadShareImage: () => void;
+  onNativeShare: () => void;
+}
+
 const canShareFile = (file: File | null): boolean => {
   if (
     !file ||
@@ -48,6 +67,36 @@ const canShareFile = (file: File | null): boolean => {
     return false;
   }
 };
+
+const GameBoardShell = ({
+  children,
+  snackbarMessage,
+  sharePreview,
+  canNativeShare,
+  onSnackbarClose,
+  onCloseSharePreview,
+  onDownloadShareImage,
+  onNativeShare,
+}: GameBoardShellProps) => (
+  <>
+    {children}
+    <Snackbar
+      open={Boolean(snackbarMessage)}
+      autoHideDuration={2000}
+      onClose={onSnackbarClose}
+      message={snackbarMessage}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    />
+    <RoundShareDialog
+      open={sharePreview !== null}
+      previewUrl={sharePreview?.url ?? null}
+      canNativeShare={canNativeShare}
+      onClose={onCloseSharePreview}
+      onDownload={onDownloadShareImage}
+      onNativeShare={onNativeShare}
+    />
+  </>
+);
 
 const QualificationInterstitial = ({
   roundNumber,
@@ -108,14 +157,10 @@ const GameBoard = () => {
   const [error, setError] = useState<string | null>(null);
   const [snackbarMessage, setSnackbarMessage] = useState<string | null>(null);
   const [shareImageBusy, setShareImageBusy] = useState(false);
-  const [sharePreview, setSharePreview] = useState<{
-    blob: Blob;
-    file: File | null;
-    url: string;
-    downloadFilename: string;
-    nativeShareTitle: string;
-  } | null>(null);
+  const [sharePreview, setSharePreview] = useState<SharePreview | null>(null);
   const sharePreviewUrlRef = useRef<string | null>(null);
+  const shareExportSequenceRef = useRef(0);
+  const mountedRef = useRef(false);
 
   const {
     gameState,
@@ -205,14 +250,17 @@ const GameBoard = () => {
     pendingRecommendationRequestRef.current = null;
   }, []);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      shareExportSequenceRef.current += 1;
       if (sharePreviewUrlRef.current) {
         URL.revokeObjectURL(sharePreviewUrlRef.current);
+        sharePreviewUrlRef.current = null;
       }
-    },
-    []
-  );
+    };
+  }, []);
 
   useEffect(
     () =>
@@ -303,6 +351,86 @@ const GameBoard = () => {
     dispatch({ type: "UPDATE_TEAM", heroes, skills });
   };
 
+  const closeSharePreview = () => {
+    if (sharePreviewUrlRef.current) {
+      URL.revokeObjectURL(sharePreviewUrlRef.current);
+      sharePreviewUrlRef.current = null;
+    }
+    setSharePreview(null);
+  };
+
+  const openSharePreview = (
+    blob: Blob,
+    metadata: {
+      downloadFilename: string;
+      nativeShareTitle: string;
+    },
+    exportId: number
+  ) => {
+    if (!mountedRef.current || shareExportSequenceRef.current !== exportId) return;
+
+    const url = URL.createObjectURL(blob);
+    if (!mountedRef.current || shareExportSequenceRef.current !== exportId) {
+      URL.revokeObjectURL(url);
+      return;
+    }
+
+    if (sharePreviewUrlRef.current) {
+      URL.revokeObjectURL(sharePreviewUrlRef.current);
+    }
+    sharePreviewUrlRef.current = url;
+    let file: File | null = null;
+    try {
+      file = new File([blob], metadata.downloadFilename, {
+        type: 'image/png',
+      });
+    } catch {
+      // Older embedded browsers can still preview and download the Blob.
+    }
+    setSharePreview({ blob, file, url, ...metadata });
+  };
+
+  const canNativeShare = canShareFile(sharePreview?.file ?? null);
+
+  const handleNativeShare = async () => {
+    if (
+      !sharePreview?.file ||
+      typeof navigator === 'undefined' ||
+      typeof navigator.share !== 'function'
+    ) return;
+    try {
+      await navigator.share({
+        files: [sharePreview.file],
+        title: sharePreview.nativeShareTitle,
+      });
+    } catch (shareError) {
+      if ((shareError as DOMException).name !== 'AbortError') {
+        setError('分享图片失败：' + (shareError as Error).message);
+      }
+    }
+  };
+
+  const handleDownloadShareImage = () => {
+    if (!sharePreview) return;
+    const link = document.createElement('a');
+    link.href = sharePreview.url;
+    link.download = sharePreview.downloadFilename;
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  };
+
+  const shellProps: Omit<GameBoardShellProps, 'children'> = {
+    snackbarMessage,
+    sharePreview,
+    canNativeShare,
+    onSnackbarClose: () => setSnackbarMessage(null),
+    onCloseSharePreview: closeSharePreview,
+    onDownloadShareImage: handleDownloadShareImage,
+    onNativeShare: handleNativeShare,
+  };
+
   const qualificationRound =
     roundNumber === 7 && !gameState.round7_interstitial_dismissed
       ? 7
@@ -312,69 +440,73 @@ const GameBoard = () => {
 
   if (qualificationRound) {
     return (
-      <QualificationInterstitial
-        roundNumber={qualificationRound}
-        onContinue={() =>
-          dispatch({
-            type: "DISMISS_ROUND_INTERSTITIAL",
-            roundNumber: qualificationRound,
-          })
-        }
-      >
-        <CurrentTeam
-          heroes={gameState.current_heroes}
-          skills={gameState.current_skills}
-          availableHeroes={availableHeroes}
-          heroMetadata={heroMetadata}
-          skillMetadata={skillMetadata}
-          availableSkills={regularSkills}
-          onUpdateTeam={handleUpdateTeam}
-          editable={true}
-          supportHero={supportHero}
-          supportSkills={supportSkillsList}
-        />
-      </QualificationInterstitial>
+      <GameBoardShell {...shellProps}>
+        <QualificationInterstitial
+          roundNumber={qualificationRound}
+          onContinue={() =>
+            dispatch({
+              type: "DISMISS_ROUND_INTERSTITIAL",
+              roundNumber: qualificationRound,
+            })
+          }
+        >
+          <CurrentTeam
+            heroes={gameState.current_heroes}
+            skills={gameState.current_skills}
+            availableHeroes={availableHeroes}
+            heroMetadata={heroMetadata}
+            skillMetadata={skillMetadata}
+            availableSkills={regularSkills}
+            onUpdateTeam={handleUpdateTeam}
+            editable={true}
+            supportHero={supportHero}
+            supportSkills={supportSkillsList}
+          />
+        </QualificationInterstitial>
+      </GameBoardShell>
     );
   }
 
   // Check if game is complete
   if (roundNumber > TOTAL_ROUNDS) {
     return (
-      <Container maxWidth="xl" disableGutters>
-        <Box>
-          <Alert severity="success" sx={{ mb: 3 }}>
-            <Typography component="h1" variant="h4" gutterBottom>
-              对局完成
-            </Typography>
-            <Typography variant="body1">
-              你已完成全部 {TOTAL_ROUNDS} 轮。可查看最终队伍配置。
-            </Typography>
-            <Typography
-              component="p"
-              variant="h6"
-              sx={{ mt: 1.25, mb: 0, fontWeight: 800, color: "success.dark" }}
+      <GameBoardShell {...shellProps}>
+        <Container maxWidth="xl" disableGutters>
+          <Box>
+            <Alert severity="success" sx={{ mb: 3 }}>
+              <Typography component="h1" variant="h4" gutterBottom>
+                对局完成
+              </Typography>
+              <Typography variant="body1">
+                你已完成全部 {TOTAL_ROUNDS} 轮。可查看最终队伍配置。
+              </Typography>
+              <Typography
+                component="p"
+                variant="h6"
+                sx={{ mt: 1.25, mb: 0, fontWeight: 800, color: "success.dark" }}
+              >
+                祝你夺冠 🏆
+              </Typography>
+            </Alert>
+
+            <CurrentTeam
+              heroes={gameState.current_heroes}
+              skills={gameState.current_skills}
+              editable={false}
+              supportHero={supportHero}
+              supportSkills={supportSkillsList}
+            />
+
+            <Button
+              variant="outlined"
+              fullWidth
+              onClick={() => dispatch({ type: "RESET_GAME" })}
             >
-              祝你夺冠 🏆
-            </Typography>
-          </Alert>
-
-          <CurrentTeam
-            heroes={gameState.current_heroes}
-            skills={gameState.current_skills}
-            editable={false}
-            supportHero={supportHero}
-            supportSkills={supportSkillsList}
-          />
-
-          <Button
-            variant="outlined"
-            fullWidth
-            onClick={() => dispatch({ type: "RESET_GAME" })}
-          >
-            开始新对局
-          </Button>
-        </Box>
-      </Container>
+              开始新对局
+            </Button>
+          </Box>
+        </Container>
+      </GameBoardShell>
     );
   }
 
@@ -502,38 +634,8 @@ const GameBoard = () => {
     }
   };
 
-  const closeSharePreview = () => {
-    if (sharePreviewUrlRef.current) {
-      URL.revokeObjectURL(sharePreviewUrlRef.current);
-      sharePreviewUrlRef.current = null;
-    }
-    setSharePreview(null);
-  };
-
-  const openSharePreview = (
-    blob: Blob,
-    metadata: {
-      downloadFilename: string;
-      nativeShareTitle: string;
-    }
-  ) => {
-    if (sharePreviewUrlRef.current) {
-      URL.revokeObjectURL(sharePreviewUrlRef.current);
-    }
-    const url = URL.createObjectURL(blob);
-    sharePreviewUrlRef.current = url;
-    let file: File | null = null;
-    try {
-      file = new File([blob], metadata.downloadFilename, {
-        type: 'image/png',
-      });
-    } catch {
-      // Older embedded browsers can still preview and download the Blob.
-    }
-    setSharePreview({ blob, file, url, ...metadata });
-  };
-
   const handleCopyRoundImage = async () => {
+    const exportId = ++shareExportSequenceRef.current;
     setShareImageBusy(true);
     setError(null);
     const shareMetadata = {
@@ -573,47 +675,21 @@ const GameBoard = () => {
     try {
       const copied = await copyImageToClipboard(pngPromise);
       if (copied) {
+        if (!mountedRef.current || shareExportSequenceRef.current !== exportId) return;
         setSnackbarMessage('图片已复制，可粘贴到微信');
       } else {
-        openSharePreview(await pngPromise, shareMetadata);
+        const blob = await pngPromise;
+        openSharePreview(blob, shareMetadata, exportId);
       }
     } catch (shareError) {
+      if (!mountedRef.current || shareExportSequenceRef.current !== exportId) return;
       setError('生成分享图片失败：' + (shareError as Error).message);
       console.error(shareError);
     } finally {
-      setShareImageBusy(false);
-    }
-  };
-
-  const canNativeShare = canShareFile(sharePreview?.file ?? null);
-
-  const handleNativeShare = async () => {
-    if (
-      !sharePreview?.file ||
-      typeof navigator === 'undefined' ||
-      typeof navigator.share !== 'function'
-    ) return;
-    try {
-      await navigator.share({
-        files: [sharePreview.file],
-        title: sharePreview.nativeShareTitle,
-      });
-    } catch (shareError) {
-      if ((shareError as DOMException).name !== 'AbortError') {
-        setError('分享图片失败：' + (shareError as Error).message);
+      if (mountedRef.current && shareExportSequenceRef.current === exportId) {
+        setShareImageBusy(false);
       }
     }
-  };
-
-  const handleDownloadShareImage = () => {
-    if (!sharePreview) return;
-    const link = document.createElement('a');
-    link.href = sharePreview.url;
-    link.download = sharePreview.downloadFilename;
-    link.style.display = 'none';
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
   };
 
   const allSetsComplete =
@@ -622,7 +698,8 @@ const GameBoard = () => {
     currentRoundInputs.set3?.length === itemsPerSet;
 
   return (
-    <Container maxWidth="xl" disableGutters>
+    <GameBoardShell {...shellProps}>
+      <Container maxWidth="xl" disableGutters>
       <Box>
         <RoundInfo roundNumber={roundNumber} />
 
@@ -727,23 +804,6 @@ const GameBoard = () => {
           }
         />
 
-        <Snackbar
-          open={Boolean(snackbarMessage)}
-          autoHideDuration={2000}
-          onClose={() => setSnackbarMessage(null)}
-          message={snackbarMessage}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-        />
-
-        <RoundShareDialog
-          open={sharePreview !== null}
-          previewUrl={sharePreview?.url ?? null}
-          canNativeShare={canNativeShare}
-          onClose={closeSharePreview}
-          onDownload={handleDownloadShareImage}
-          onNativeShare={handleNativeShare}
-        />
-
         {currentRecommendation && (
           <>
             <KnownStrongTeams
@@ -798,7 +858,8 @@ const GameBoard = () => {
           </Box>
         </Box>
       </Box>
-    </Container>
+      </Container>
+    </GameBoardShell>
   );
 };
 

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Container, Box, Button, Alert, CircularProgress, Typography, Paper, Snackbar } from "@mui/material";
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ImageIcon from '@mui/icons-material/Image';
 import { useGame } from "../../context/GameContext";
 import { api } from "../../services/api";
 import { getRoundType, getItemsPerSet, TOTAL_ROUNDS } from "../../services/gameLogic";
@@ -10,11 +11,14 @@ import CurrentTeam from "./CurrentTeam";
 import RecommendationPanel from "./RecommendationPanel";
 import AnalysisGrid from "./AnalysisGrid";
 import KnownStrongTeams from "./KnownStrongTeams";
+import RoundShareDialog from "./RoundShareDialog";
 import ResponsiveDisclosure from "../common/ResponsiveDisclosure";
-import { copyToClipboard } from "../../utils/clipboard";
+import { copyImageToClipboard, copyToClipboard } from "../../utils/clipboard";
+import { renderRoundShareImage } from "../../utils/roundShareImage";
 import type { GameState, RoundType, SetName } from "../../types/game";
-import type { OptionAnalysis } from "../../services/recommendationEngine";
+import { currentRosterScore, type OptionAnalysis } from "../../services/recommendationEngine";
 import type { PreferencePrediction } from "../../types/telemetryData";
+import { recommendationData } from "../../data";
 import { recordRoundTelemetry } from "../../services/telemetry";
 import { recordSuccessfulPromptCopy } from "../../services/googleAnalytics";
 import {
@@ -28,6 +32,22 @@ interface QualificationInterstitialProps {
   onContinue: () => void;
   children: ReactNode;
 }
+
+const canShareFile = (file: File | null): boolean => {
+  if (
+    !file ||
+    typeof navigator === 'undefined' ||
+    typeof navigator.share !== 'function' ||
+    typeof navigator.canShare !== 'function'
+  ) {
+    return false;
+  }
+  try {
+    return navigator.canShare({ files: [file] });
+  } catch {
+    return false;
+  }
+};
 
 const QualificationInterstitial = ({
   roundNumber,
@@ -86,7 +106,14 @@ const GameBoard = () => {
   const { state, dispatch } = useGame();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState<string | null>(null);
+  const [shareImageBusy, setShareImageBusy] = useState(false);
+  const [sharePreview, setSharePreview] = useState<{
+    blob: Blob;
+    file: File | null;
+    url: string;
+  } | null>(null);
+  const sharePreviewUrlRef = useRef<string | null>(null);
 
   const {
     gameState,
@@ -175,6 +202,15 @@ const GameBoard = () => {
   useEffect(() => () => {
     pendingRecommendationRequestRef.current = null;
   }, []);
+
+  useEffect(
+    () => () => {
+      if (sharePreviewUrlRef.current) {
+        URL.revokeObjectURL(sharePreviewUrlRef.current);
+      }
+    },
+    []
+  );
 
   useEffect(
     () =>
@@ -457,11 +493,115 @@ const GameBoard = () => {
       });
       const copied = await copyToClipboard(prompt);
       if (copied) recordSuccessfulPromptCopy('roundAnalysis');
-      setSnackbarOpen(true);
+      setSnackbarMessage('提示词已复制到剪贴板');
     } catch (err) {
       setError('生成提示词失败：' + (err as Error).message);
       console.error(err);
     }
+  };
+
+  const closeSharePreview = () => {
+    if (sharePreviewUrlRef.current) {
+      URL.revokeObjectURL(sharePreviewUrlRef.current);
+      sharePreviewUrlRef.current = null;
+    }
+    setSharePreview(null);
+  };
+
+  const openSharePreview = (blob: Blob) => {
+    if (sharePreviewUrlRef.current) {
+      URL.revokeObjectURL(sharePreviewUrlRef.current);
+    }
+    const url = URL.createObjectURL(blob);
+    sharePreviewUrlRef.current = url;
+    let file: File | null = null;
+    try {
+      file = new File([blob], `sanmou-round-${roundNumber}.png`, {
+        type: 'image/png',
+      });
+    } catch {
+      // Older embedded browsers can still preview and download the Blob.
+    }
+    setSharePreview({ blob, file, url });
+  };
+
+  const handleCopyRoundImage = async () => {
+    setShareImageBusy(true);
+    setError(null);
+    const heroesWithSupport = [
+      ...(gameState.current_heroes || []),
+      ...(supportHero ? [supportHero] : []),
+    ];
+    const skillsWithSupport = [
+      ...(gameState.current_skills || []),
+      ...supportSkillsList,
+    ];
+    const pngPromise = renderRoundShareImage({
+      roundNumber,
+      roundType,
+      season: state.selectedSeason,
+      sets: [
+        [...(currentRoundInputs.set1 || [])],
+        [...(currentRoundInputs.set2 || [])],
+        [...(currentRoundInputs.set3 || [])],
+      ],
+      heroes: [...(gameState.current_heroes || [])],
+      skills: [...(gameState.current_skills || [])],
+      supportHero,
+      supportSkills: [...supportSkillsList],
+      rosterScore: currentRosterScore(
+        heroesWithSupport,
+        skillsWithSupport,
+        recommendationData
+      ),
+      heroMetadata,
+      skillMetadata,
+    });
+
+    try {
+      const copied = await copyImageToClipboard(pngPromise);
+      if (copied) {
+        setSnackbarMessage('图片已复制，可粘贴到微信');
+      } else {
+        openSharePreview(await pngPromise);
+      }
+    } catch (shareError) {
+      setError('生成分享图片失败：' + (shareError as Error).message);
+      console.error(shareError);
+    } finally {
+      setShareImageBusy(false);
+    }
+  };
+
+  const canNativeShare = canShareFile(sharePreview?.file ?? null);
+
+  const handleNativeShare = async () => {
+    if (
+      !sharePreview?.file ||
+      typeof navigator === 'undefined' ||
+      typeof navigator.share !== 'function'
+    ) return;
+    try {
+      await navigator.share({
+        files: [sharePreview.file],
+        title: `三谋演武第 ${roundNumber} 轮`,
+      });
+    } catch (shareError) {
+      if ((shareError as DOMException).name !== 'AbortError') {
+        setError('分享图片失败：' + (shareError as Error).message);
+      }
+    }
+  };
+
+  const handleDownloadShareImage = () => {
+    if (!sharePreview) return;
+    const link = document.createElement('a');
+    link.href = sharePreview.url;
+    link.download = `sanmou-round-${roundNumber}.png`;
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
   };
 
   const allSetsComplete =
@@ -555,16 +695,41 @@ const GameBoard = () => {
               >
                 复制 AI 分析提示词
               </Button>
+              <Button
+                variant="outlined"
+                color="primary"
+                size="small"
+                onClick={handleCopyRoundImage}
+                disabled={!allSetsComplete || shareImageBusy}
+                startIcon={
+                  shareImageBusy ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : (
+                    <ImageIcon fontSize="small" />
+                  )
+                }
+              >
+                复制选项与阵容图片
+              </Button>
             </>
           }
         />
 
         <Snackbar
-          open={snackbarOpen}
+          open={Boolean(snackbarMessage)}
           autoHideDuration={2000}
-          onClose={() => setSnackbarOpen(false)}
-          message="提示词已复制到剪贴板"
+          onClose={() => setSnackbarMessage(null)}
+          message={snackbarMessage}
           anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        />
+
+        <RoundShareDialog
+          open={sharePreview !== null}
+          previewUrl={sharePreview?.url ?? null}
+          canNativeShare={canNativeShare}
+          onClose={closeSharePreview}
+          onDownload={handleDownloadShareImage}
+          onNativeShare={handleNativeShare}
         />
 
         {currentRecommendation && (

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -112,6 +112,8 @@ const GameBoard = () => {
     blob: Blob;
     file: File | null;
     url: string;
+    downloadFilename: string;
+    nativeShareTitle: string;
   } | null>(null);
   const sharePreviewUrlRef = useRef<string | null>(null);
 
@@ -508,7 +510,13 @@ const GameBoard = () => {
     setSharePreview(null);
   };
 
-  const openSharePreview = (blob: Blob) => {
+  const openSharePreview = (
+    blob: Blob,
+    metadata: {
+      downloadFilename: string;
+      nativeShareTitle: string;
+    }
+  ) => {
     if (sharePreviewUrlRef.current) {
       URL.revokeObjectURL(sharePreviewUrlRef.current);
     }
@@ -516,18 +524,22 @@ const GameBoard = () => {
     sharePreviewUrlRef.current = url;
     let file: File | null = null;
     try {
-      file = new File([blob], `sanmou-round-${roundNumber}.png`, {
+      file = new File([blob], metadata.downloadFilename, {
         type: 'image/png',
       });
     } catch {
       // Older embedded browsers can still preview and download the Blob.
     }
-    setSharePreview({ blob, file, url });
+    setSharePreview({ blob, file, url, ...metadata });
   };
 
   const handleCopyRoundImage = async () => {
     setShareImageBusy(true);
     setError(null);
+    const shareMetadata = {
+      downloadFilename: `sanmou-round-${roundNumber}.png`,
+      nativeShareTitle: `三谋演武第 ${roundNumber} 轮`,
+    };
     const heroesWithSupport = [
       ...(gameState.current_heroes || []),
       ...(supportHero ? [supportHero] : []),
@@ -563,7 +575,7 @@ const GameBoard = () => {
       if (copied) {
         setSnackbarMessage('图片已复制，可粘贴到微信');
       } else {
-        openSharePreview(await pngPromise);
+        openSharePreview(await pngPromise, shareMetadata);
       }
     } catch (shareError) {
       setError('生成分享图片失败：' + (shareError as Error).message);
@@ -584,7 +596,7 @@ const GameBoard = () => {
     try {
       await navigator.share({
         files: [sharePreview.file],
-        title: `三谋演武第 ${roundNumber} 轮`,
+        title: sharePreview.nativeShareTitle,
       });
     } catch (shareError) {
       if ((shareError as DOMException).name !== 'AbortError') {
@@ -597,7 +609,7 @@ const GameBoard = () => {
     if (!sharePreview) return;
     const link = document.createElement('a');
     link.href = sharePreview.url;
-    link.download = `sanmou-round-${roundNumber}.png`;
+    link.download = sharePreview.downloadFilename;
     link.style.display = 'none';
     document.body.appendChild(link);
     link.click();

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -44,9 +44,11 @@ interface SharePreview {
 interface GameBoardShellProps {
   children: ReactNode;
   snackbarMessage: string | null;
+  shareError: string | null;
   sharePreview: SharePreview | null;
   canNativeShare: boolean;
   onSnackbarClose: () => void;
+  onShareErrorClose: () => void;
   onCloseSharePreview: () => void;
   onDownloadShareImage: () => void;
   onNativeShare: () => void;
@@ -71,9 +73,11 @@ const canShareFile = (file: File | null): boolean => {
 const GameBoardShell = ({
   children,
   snackbarMessage,
+  shareError,
   sharePreview,
   canNativeShare,
   onSnackbarClose,
+  onShareErrorClose,
   onCloseSharePreview,
   onDownloadShareImage,
   onNativeShare,
@@ -87,6 +91,14 @@ const GameBoardShell = ({
       message={snackbarMessage}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
     />
+    <Snackbar
+      open={Boolean(shareError)}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+    >
+      <Alert severity="error" onClose={onShareErrorClose} sx={{ width: '100%' }}>
+        {shareError}
+      </Alert>
+    </Snackbar>
     <RoundShareDialog
       open={sharePreview !== null}
       previewUrl={sharePreview?.url ?? null}
@@ -156,6 +168,7 @@ const GameBoard = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [snackbarMessage, setSnackbarMessage] = useState<string | null>(null);
+  const [shareError, setShareError] = useState<string | null>(null);
   const [shareImageBusy, setShareImageBusy] = useState(false);
   const [sharePreview, setSharePreview] = useState<SharePreview | null>(null);
   const sharePreviewUrlRef = useRef<string | null>(null);
@@ -398,14 +411,15 @@ const GameBoard = () => {
       typeof navigator === 'undefined' ||
       typeof navigator.share !== 'function'
     ) return;
+    setShareError(null);
     try {
       await navigator.share({
         files: [sharePreview.file],
         title: sharePreview.nativeShareTitle,
       });
-    } catch (shareError) {
-      if ((shareError as DOMException).name !== 'AbortError') {
-        setError('分享图片失败：' + (shareError as Error).message);
+    } catch (nativeShareError) {
+      if ((nativeShareError as DOMException).name !== 'AbortError') {
+        setShareError('分享图片失败：' + (nativeShareError as Error).message);
       }
     }
   };
@@ -423,9 +437,11 @@ const GameBoard = () => {
 
   const shellProps: Omit<GameBoardShellProps, 'children'> = {
     snackbarMessage,
+    shareError,
     sharePreview,
     canNativeShare,
     onSnackbarClose: () => setSnackbarMessage(null),
+    onShareErrorClose: () => setShareError(null),
     onCloseSharePreview: closeSharePreview,
     onDownloadShareImage: handleDownloadShareImage,
     onNativeShare: handleNativeShare,
@@ -638,6 +654,7 @@ const GameBoard = () => {
     const exportId = ++shareExportSequenceRef.current;
     setShareImageBusy(true);
     setError(null);
+    setShareError(null);
     const shareMetadata = {
       downloadFilename: `sanmou-round-${roundNumber}.png`,
       nativeShareTitle: `三谋演武第 ${roundNumber} 轮`,
@@ -681,10 +698,10 @@ const GameBoard = () => {
         const blob = await pngPromise;
         openSharePreview(blob, shareMetadata, exportId);
       }
-    } catch (shareError) {
+    } catch (shareImageError) {
       if (!mountedRef.current || shareExportSequenceRef.current !== exportId) return;
-      setError('生成分享图片失败：' + (shareError as Error).message);
-      console.error(shareError);
+      setShareError('生成分享图片失败：' + (shareImageError as Error).message);
+      console.error(shareImageError);
     } finally {
       if (mountedRef.current && shareExportSequenceRef.current === exportId) {
         setShareImageBusy(false);

--- a/web/src/components/game/RoundShareDialog.tsx
+++ b/web/src/components/game/RoundShareDialog.tsx
@@ -1,0 +1,68 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from '@mui/material';
+import DownloadIcon from '@mui/icons-material/Download';
+import ShareIcon from '@mui/icons-material/Share';
+
+interface RoundShareDialogProps {
+  open: boolean;
+  previewUrl: string | null;
+  canNativeShare: boolean;
+  onClose: () => void;
+  onDownload: () => void;
+  onNativeShare: () => void;
+}
+
+const RoundShareDialog = ({
+  open,
+  previewUrl,
+  canNativeShare,
+  onClose,
+  onDownload,
+  onNativeShare,
+}: RoundShareDialogProps) => (
+  <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+    <DialogTitle>发送到微信</DialogTitle>
+    <DialogContent>
+      <Alert severity="info" sx={{ mb: 2 }}>
+        浏览器未允许直接复制图片。可分享或下载图片；在手机上也可以长按预览图保存后发送到微信。
+      </Alert>
+      {previewUrl && (
+        <Box
+          component="img"
+          src={previewUrl}
+          alt="本轮候选组与当前阵容分享图片预览"
+          sx={{ display: 'block', width: '100%', height: 'auto', border: '1px solid', borderColor: 'divider' }}
+        />
+      )}
+    </DialogContent>
+    <DialogActions sx={{ px: 3, pb: 2, flexWrap: 'wrap' }}>
+      <Button onClick={onClose}>关闭</Button>
+      <Button
+        variant="outlined"
+        startIcon={<DownloadIcon />}
+        onClick={onDownload}
+        disabled={!previewUrl}
+      >
+        下载图片
+      </Button>
+      {canNativeShare && (
+        <Button
+          variant="contained"
+          startIcon={<ShareIcon />}
+          onClick={onNativeShare}
+        >
+          分享图片
+        </Button>
+      )}
+    </DialogActions>
+  </Dialog>
+);
+
+export default RoundShareDialog;

--- a/web/src/components/game/__tests__/GameBoard.test.tsx
+++ b/web/src/components/game/__tests__/GameBoard.test.tsx
@@ -105,6 +105,7 @@ const deferredRecommendation = () => {
 
 describe('GameBoard roster rescoring', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     Reflect.deleteProperty(URL, 'createObjectURL');
     Reflect.deleteProperty(URL, 'revokeObjectURL');
     Reflect.deleteProperty(navigator, 'share');
@@ -324,6 +325,110 @@ describe('GameBoard roster rescoring', () => {
       })
     );
     expect(await screen.findByText('图片已复制，可粘贴到微信')).toBeVisible();
+  });
+
+  test.each([
+    { roundNumber: 6, nextRound: 7, transition: 'qualification' },
+    { roundNumber: 10, nextRound: 11, transition: 'completion' },
+  ])(
+    'keeps the round $roundNumber fallback visible after the $transition transition',
+    async ({ roundNumber, nextRound, transition }) => {
+      mocks.state.gameState = {
+        ...mocks.state.gameState,
+        round_number: roundNumber,
+      };
+      mocks.copyImageToClipboard.mockResolvedValue(false);
+      let resolvePng!: (blob: Blob) => void;
+      const pngPromise = new Promise<Blob>((resolve) => {
+        resolvePng = resolve;
+      });
+      mocks.renderRoundShareImage.mockReturnValue(pngPromise);
+      const previewUrl = `blob:round-${roundNumber}`;
+      const createObjectURL = vi.fn(() => previewUrl);
+      const revokeObjectURL = vi.fn();
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: createObjectURL,
+      });
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: revokeObjectURL,
+      });
+      const { rerender, unmount } = render(<GameBoard />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: '复制选项与阵容图片' })
+      );
+      await waitFor(() =>
+        expect(mocks.copyImageToClipboard).toHaveBeenCalledTimes(1)
+      );
+
+      mocks.state.gameState = {
+        ...mocks.state.gameState,
+        round_number: nextRound,
+      };
+      rerender(<GameBoard />);
+      if (transition === 'qualification') {
+        expect(
+          screen.getAllByRole('button', { name: '我赢了，进入下一轮' })
+        ).not.toHaveLength(0);
+      } else {
+        expect(
+          screen.getByRole('heading', { name: '对局完成' })
+        ).toBeVisible();
+      }
+
+      await act(async () => {
+        resolvePng(new Blob(['png'], { type: 'image/png' }));
+        await pngPromise;
+      });
+
+      expect(
+        await screen.findByRole('dialog', { name: '发送到微信' })
+      ).toBeVisible();
+      expect(
+        screen.getByRole('img', { name: '本轮候选组与当前阵容分享图片预览' })
+      ).toHaveAttribute('src', previewUrl);
+
+      unmount();
+      expect(revokeObjectURL).toHaveBeenCalledWith(previewUrl);
+    }
+  );
+
+  test('does not publish a pending fallback after the game board unmounts', async () => {
+    mocks.copyImageToClipboard.mockResolvedValue(false);
+    let resolvePng!: (blob: Blob) => void;
+    const pngPromise = new Promise<Blob>((resolve) => {
+      resolvePng = resolve;
+    });
+    mocks.renderRoundShareImage.mockReturnValue(pngPromise);
+    const createObjectURL = vi.fn(() => 'blob:orphaned-round-share');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+    const { unmount } = render(<GameBoard />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: '复制选项与阵容图片' })
+    );
+    await waitFor(() =>
+      expect(mocks.copyImageToClipboard).toHaveBeenCalledTimes(1)
+    );
+    unmount();
+
+    await act(async () => {
+      resolvePng(new Blob(['png'], { type: 'image/png' }));
+      await pngPromise;
+    });
+
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(revokeObjectURL).not.toHaveBeenCalled();
   });
 
   test('keeps fallback labels tied to the exported round when the game advances', async () => {

--- a/web/src/components/game/__tests__/GameBoard.test.tsx
+++ b/web/src/components/game/__tests__/GameBoard.test.tsx
@@ -107,6 +107,8 @@ describe('GameBoard roster rescoring', () => {
   afterEach(() => {
     Reflect.deleteProperty(URL, 'createObjectURL');
     Reflect.deleteProperty(URL, 'revokeObjectURL');
+    Reflect.deleteProperty(navigator, 'share');
+    Reflect.deleteProperty(navigator, 'canShare');
   });
 
   beforeEach(() => {
@@ -118,6 +120,7 @@ describe('GameBoard roster rescoring', () => {
       ...mocks.state.gameState,
       support_hero: null,
       support_skills: [],
+      round_number: 1,
     };
     mocks.state.currentRecommendation = {
       recommended_set_index: 1,
@@ -323,10 +326,21 @@ describe('GameBoard roster rescoring', () => {
     expect(await screen.findByText('图片已复制，可粘贴到微信')).toBeVisible();
   });
 
-  test('opens the save/share preview when image clipboard access is unavailable', async () => {
+  test('keeps fallback labels tied to the exported round when the game advances', async () => {
     mocks.copyImageToClipboard.mockResolvedValue(false);
+    let resolvePng!: (blob: Blob) => void;
+    const pngPromise = new Promise<Blob>((resolve) => {
+      resolvePng = resolve;
+    });
+    mocks.renderRoundShareImage.mockReturnValue(pngPromise);
     const createObjectURL = vi.fn(() => 'blob:round-share');
     const revokeObjectURL = vi.fn();
+    const nativeShare = vi.fn(async () => undefined);
+    const canShare = vi.fn(() => true);
+    const clickedDownloads: string[] = [];
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function () {
+      clickedDownloads.push(this.download);
+    });
     Object.defineProperty(URL, 'createObjectURL', {
       configurable: true,
       value: createObjectURL,
@@ -335,16 +349,42 @@ describe('GameBoard roster rescoring', () => {
       configurable: true,
       value: revokeObjectURL,
     });
-    render(<GameBoard />);
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      value: nativeShare,
+    });
+    Object.defineProperty(navigator, 'canShare', {
+      configurable: true,
+      value: canShare,
+    });
+    const { rerender } = render(<GameBoard />);
 
     fireEvent.click(
       screen.getByRole('button', { name: '复制选项与阵容图片' })
     );
+    mocks.state.gameState = {
+      ...mocks.state.gameState,
+      round_number: 2,
+    };
+    rerender(<GameBoard />);
+    resolvePng(new Blob(['png'], { type: 'image/png' }));
 
     expect(await screen.findByRole('dialog', { name: '发送到微信' })).toBeVisible();
     expect(
       screen.getByRole('img', { name: '本轮候选组与当前阵容分享图片预览' })
     ).toHaveAttribute('src', 'blob:round-share');
+
+    fireEvent.click(screen.getByRole('button', { name: '下载图片' }));
+    expect(clickedDownloads).toEqual(['sanmou-round-1.png']);
+
+    fireEvent.click(screen.getByRole('button', { name: '分享图片' }));
+    await waitFor(() => {
+      expect(nativeShare).toHaveBeenCalledWith({
+        files: [expect.objectContaining({ name: 'sanmou-round-1.png' })],
+        title: '三谋演武第 1 轮',
+      });
+    });
+
     fireEvent.click(screen.getByRole('button', { name: '关闭' }));
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:round-share');
   });

--- a/web/src/components/game/__tests__/GameBoard.test.tsx
+++ b/web/src/components/game/__tests__/GameBoard.test.tsx
@@ -529,7 +529,9 @@ describe('GameBoard roster rescoring', () => {
     const nativeShare = vi.fn(async () => undefined);
     const canShare = vi.fn(() => true);
     const clickedDownloads: string[] = [];
-    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function () {
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement
+    ) {
       clickedDownloads.push(this.download);
     });
     Object.defineProperty(URL, 'createObjectURL', {

--- a/web/src/components/game/__tests__/GameBoard.test.tsx
+++ b/web/src/components/game/__tests__/GameBoard.test.tsx
@@ -395,6 +395,41 @@ describe('GameBoard roster rescoring', () => {
     }
   );
 
+  test('keeps image generation failures visible after a completion transition', async () => {
+    mocks.state.gameState = {
+      ...mocks.state.gameState,
+      round_number: 10,
+    };
+    mocks.copyImageToClipboard.mockResolvedValue(false);
+    let rejectPng!: (error: Error) => void;
+    const pngPromise = new Promise<Blob>((_resolve, reject) => {
+      rejectPng = reject;
+    });
+    mocks.renderRoundShareImage.mockReturnValue(pngPromise);
+    const { rerender } = render(<GameBoard />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: '复制选项与阵容图片' })
+    );
+    await waitFor(() =>
+      expect(mocks.copyImageToClipboard).toHaveBeenCalledTimes(1)
+    );
+
+    mocks.state.gameState = {
+      ...mocks.state.gameState,
+      round_number: 11,
+    };
+    rerender(<GameBoard />);
+    expect(screen.getByRole('heading', { name: '对局完成' })).toBeVisible();
+
+    await act(async () => {
+      rejectPng(new Error('画布导出失败'));
+      await pngPromise.catch(() => undefined);
+    });
+
+    expect(await screen.findByText('生成分享图片失败：画布导出失败')).toBeVisible();
+  });
+
   test('does not publish a pending fallback after the game board unmounts', async () => {
     mocks.copyImageToClipboard.mockResolvedValue(false);
     let resolvePng!: (blob: Blob) => void;
@@ -429,6 +464,57 @@ describe('GameBoard roster rescoring', () => {
 
     expect(createObjectURL).not.toHaveBeenCalled();
     expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  test('keeps native-share failures visible and retryable after completion', async () => {
+    mocks.state.gameState = {
+      ...mocks.state.gameState,
+      round_number: 10,
+    };
+    mocks.copyImageToClipboard.mockResolvedValue(false);
+    const previewUrl = 'blob:native-share-failure';
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => previewUrl),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    const nativeShare = vi.fn()
+      .mockRejectedValueOnce(new Error('微信分享不可用'))
+      .mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      value: nativeShare,
+    });
+    Object.defineProperty(navigator, 'canShare', {
+      configurable: true,
+      value: vi.fn(() => true),
+    });
+    const { rerender } = render(<GameBoard />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: '复制选项与阵容图片' })
+    );
+    expect(await screen.findByRole('dialog', { name: '发送到微信' })).toBeVisible();
+
+    mocks.state.gameState = {
+      ...mocks.state.gameState,
+      round_number: 11,
+    };
+    rerender(<GameBoard />);
+    expect(screen.getByText(/你已完成全部 10 轮/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '分享图片' }));
+    expect(await screen.findByText('分享图片失败：微信分享不可用')).toBeVisible();
+    expect(screen.getByRole('dialog', { name: '发送到微信' })).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: '分享图片' }));
+    await waitFor(() => expect(nativeShare).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.queryByText('分享图片失败：微信分享不可用')).not.toBeInTheDocument()
+    );
   });
 
   test('keeps fallback labels tied to the exported round when the game advances', async () => {

--- a/web/src/components/game/__tests__/GameBoard.test.tsx
+++ b/web/src/components/game/__tests__/GameBoard.test.tsx
@@ -44,6 +44,10 @@ const mocks = vi.hoisted(() => {
         preference: null,
       },
     })),
+    copyImageToClipboard: vi.fn(async () => true),
+    renderRoundShareImage: vi.fn(async () =>
+      new Blob(['png'], { type: 'image/png' })
+    ),
   };
 });
 
@@ -55,6 +59,13 @@ vi.mock('../../../services/api', () => ({
 }));
 vi.mock('../../../services/telemetry', () => ({
   recordRoundTelemetry: mocks.recordRoundTelemetry,
+}));
+vi.mock('../../../utils/clipboard', () => ({
+  copyToClipboard: vi.fn(async () => true),
+  copyImageToClipboard: mocks.copyImageToClipboard,
+}));
+vi.mock('../../../utils/roundShareImage', () => ({
+  renderRoundShareImage: mocks.renderRoundShareImage,
 }));
 vi.mock('../RoundInfo', () => ({ default: () => <div /> }));
 vi.mock('../CurrentTeam', () => ({ default: () => <div /> }));
@@ -93,6 +104,11 @@ const deferredRecommendation = () => {
 };
 
 describe('GameBoard roster rescoring', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(URL, 'createObjectURL');
+    Reflect.deleteProperty(URL, 'revokeObjectURL');
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getRecommendation.mockImplementation(async () =>
@@ -109,6 +125,10 @@ describe('GameBoard roster rescoring', () => {
     };
     mocks.state.rosterRevision = 0;
     mocks.state.recommendationRosterRevision = 0;
+    mocks.copyImageToClipboard.mockResolvedValue(true);
+    mocks.renderRoundShareImage.mockResolvedValue(
+      new Blob(['png'], { type: 'image/png' })
+    );
   });
 
   test('preserves offered sets and automatically recalculates after the roster changes', async () => {
@@ -274,5 +294,58 @@ describe('GameBoard roster rescoring', () => {
       });
     });
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  test('copies a complete candidate-and-roster PNG with the current round state', async () => {
+    render(<GameBoard />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: '复制选项与阵容图片' })
+    );
+
+    await waitFor(() => expect(mocks.copyImageToClipboard).toHaveBeenCalledTimes(1));
+    expect(mocks.renderRoundShareImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roundNumber: 1,
+        roundType: 'hero',
+        season: 1,
+        sets: [
+          ['曹操', '孙权', '袁绍'],
+          ['周瑜', '陆逊', '吕蒙'],
+          ['诸葛亮', '庞统', '黄忠'],
+        ],
+        heroes: ['刘备', '关羽', '张飞', '赵云'],
+        skills: ['战法甲'],
+        supportHero: null,
+        supportSkills: [],
+      })
+    );
+    expect(await screen.findByText('图片已复制，可粘贴到微信')).toBeVisible();
+  });
+
+  test('opens the save/share preview when image clipboard access is unavailable', async () => {
+    mocks.copyImageToClipboard.mockResolvedValue(false);
+    const createObjectURL = vi.fn(() => 'blob:round-share');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+    render(<GameBoard />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: '复制选项与阵容图片' })
+    );
+
+    expect(await screen.findByRole('dialog', { name: '发送到微信' })).toBeVisible();
+    expect(
+      screen.getByRole('img', { name: '本轮候选组与当前阵容分享图片预览' })
+    ).toHaveAttribute('src', 'blob:round-share');
+    fireEvent.click(screen.getByRole('button', { name: '关闭' }));
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:round-share');
   });
 });

--- a/web/src/utils/__tests__/clipboard.test.ts
+++ b/web/src/utils/__tests__/clipboard.test.ts
@@ -1,7 +1,7 @@
-import { copyToClipboard } from '../clipboard';
+import { copyImageToClipboard, copyToClipboard } from '../clipboard';
 
 const setClipboard = (
-  value: { writeText: (text: string) => Promise<void> } | undefined
+  value: Partial<Clipboard> | undefined
 ) => {
   Object.defineProperty(navigator, 'clipboard', {
     configurable: true,
@@ -19,6 +19,7 @@ const setExecCommand = (implementation: () => boolean) => {
 describe('copyToClipboard', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     Reflect.deleteProperty(navigator, 'clipboard');
     Reflect.deleteProperty(document, 'execCommand');
     document.body.innerHTML = '';
@@ -51,5 +52,39 @@ describe('copyToClipboard', () => {
 
     await expect(copyToClipboard('备用复制')).resolves.toBe(true);
     expect(document.querySelector('textarea')).toBeNull();
+  });
+
+  test('copies a promised PNG through the binary Clipboard API', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ write });
+    const clipboardItems: Array<Record<string, Blob | Promise<Blob>>> = [];
+    vi.stubGlobal(
+      'ClipboardItem',
+      class ClipboardItemMock {
+        constructor(data: Record<string, Blob | Promise<Blob>>) {
+          clipboardItems.push(data);
+        }
+      }
+    );
+    const png = new Blob(['png'], { type: 'image/png' });
+
+    await expect(copyImageToClipboard(Promise.resolve(png))).resolves.toBe(true);
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(await clipboardItems[0]['image/png']).toBe(png);
+  });
+
+  test('returns false when binary clipboard support is unavailable or rejects', async () => {
+    setClipboard(undefined);
+    await expect(
+      copyImageToClipboard(new Blob(['png'], { type: 'image/png' }))
+    ).resolves.toBe(false);
+
+    const write = vi.fn().mockRejectedValue(new DOMException('denied'));
+    setClipboard({ write });
+    vi.stubGlobal('ClipboardItem', class ClipboardItemMock {});
+    await expect(
+      copyImageToClipboard(new Blob(['png'], { type: 'image/png' }))
+    ).resolves.toBe(false);
   });
 });

--- a/web/src/utils/__tests__/roundShareImage.test.ts
+++ b/web/src/utils/__tests__/roundShareImage.test.ts
@@ -1,0 +1,33 @@
+import { getRoundShareImageLayout } from '../roundShareImage';
+
+describe('getRoundShareImageLayout', () => {
+  test('keeps an early-round pool to one row per item type', () => {
+    const layout = getRoundShareImageLayout({
+      heroes: ['刘备', '关羽', '张飞', '赵云'],
+      skills: Array.from({ length: 8 }, (_, index) => `战法${index}`),
+      supportHero: null,
+      supportSkills: [],
+    });
+
+    expect(layout.heroRows).toBe(1);
+    expect(layout.skillRows).toBe(1);
+    expect(layout.height).toBeGreaterThan(900);
+  });
+
+  test('grows for a complete late-round pool and de-duplicates support entries', () => {
+    const early = getRoundShareImageLayout({
+      heroes: Array.from({ length: 4 }, (_, index) => `武将${index}`),
+      skills: Array.from({ length: 8 }, (_, index) => `战法${index}`),
+    });
+    const late = getRoundShareImageLayout({
+      heroes: Array.from({ length: 15 }, (_, index) => `武将${index}`),
+      skills: Array.from({ length: 28 }, (_, index) => `战法${index}`),
+      supportHero: '武将0',
+      supportSkills: ['战法0', '战法1'],
+    });
+
+    expect(late.heroRows).toBe(2);
+    expect(late.skillRows).toBe(3);
+    expect(late.height).toBeGreaterThan(early.height);
+  });
+});

--- a/web/src/utils/clipboard.ts
+++ b/web/src/utils/clipboard.ts
@@ -30,3 +30,29 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     textarea?.remove();
   }
 }
+
+/**
+ * Copy a PNG to the system clipboard. Accepting a promise lets callers start
+ * the Clipboard API write during the user gesture while card artwork is still
+ * being rendered. Browsers without binary clipboard support return false so
+ * the caller can offer a visible share/download fallback.
+ */
+export async function copyImageToClipboard(
+  png: Blob | Promise<Blob>
+): Promise<boolean> {
+  if (
+    typeof navigator === 'undefined' ||
+    !navigator.clipboard?.write ||
+    typeof ClipboardItem === 'undefined'
+  ) {
+    return false;
+  }
+
+  try {
+    const item = new ClipboardItem({ 'image/png': Promise.resolve(png) });
+    await navigator.clipboard.write([item]);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/web/src/utils/roundShareImage.ts
+++ b/web/src/utils/roundShareImage.ts
@@ -1,0 +1,515 @@
+import { getGameAsset, type GameAssetKind, type GameAssetQuality } from '../gameAssets';
+import type { HeroMeta, RoundType, SkillMeta } from '../types/game';
+import { formatHeroRanking, formatSkillRanking } from './itemMetadata';
+
+const IMAGE_WIDTH = 1200;
+const OUTER_PADDING = 40;
+const CONTENT_WIDTH = IMAGE_WIDTH - OUTER_PADDING * 2;
+const GROUP_GAP = 16;
+const GROUP_CARD_GAP = 8;
+const GROUP_PADDING = 14;
+const GROUP_TITLE_HEIGHT = 42;
+const GROUP_CARD_WIDTH =
+  (CONTENT_WIDTH - GROUP_GAP * 2) / 3;
+const CANDIDATE_CARD_WIDTH =
+  (GROUP_CARD_WIDTH - GROUP_PADDING * 2 - GROUP_CARD_GAP * 2) / 3;
+const CANDIDATE_ART_HEIGHT = CANDIDATE_CARD_WIDTH * (248 / 160);
+const CANDIDATE_META_HEIGHT = 27;
+const CANDIDATE_GROUP_HEIGHT =
+  GROUP_TITLE_HEIGHT + CANDIDATE_ART_HEIGHT + CANDIDATE_META_HEIGHT + 24;
+
+const POOL_COLUMNS = 10;
+const POOL_GAP = 10;
+const POOL_CARD_WIDTH =
+  (CONTENT_WIDTH - POOL_GAP * (POOL_COLUMNS - 1)) / POOL_COLUMNS;
+const POOL_ART_HEIGHT = POOL_CARD_WIDTH * (248 / 160);
+const POOL_META_HEIGHT = 28;
+const POOL_CARD_HEIGHT = POOL_ART_HEIGHT + POOL_META_HEIGHT;
+
+const COLORS = {
+  background: '#f4efe4',
+  paper: '#fffdf7',
+  primary: '#315b50',
+  secondary: '#886b35',
+  text: '#222720',
+  muted: '#6f756c',
+  divider: '#d6cdbb',
+  support: '#a8392f',
+  orange: '#9a7228',
+  purple: '#7956a6',
+};
+
+const UI_FONT = '"PingFang SC", "Microsoft YaHei", sans-serif';
+const TITLE_FONT = '"Songti SC", STSong, serif';
+
+export interface RoundShareImageInput {
+  roundNumber: number;
+  roundType: RoundType;
+  season: number | null;
+  sets: [string[], string[], string[]];
+  heroes: string[];
+  skills: string[];
+  supportHero?: string | null;
+  supportSkills?: string[];
+  rosterScore: number;
+  heroMetadata?: Record<string, HeroMeta> | null;
+  skillMetadata?: Record<string, SkillMeta> | null;
+}
+
+interface ShareCard {
+  name: string;
+  kind: GameAssetKind;
+  ranking: string;
+  support: boolean;
+  quality: GameAssetQuality | null;
+  assetPath: string | null;
+}
+
+interface RoundShareLayout {
+  height: number;
+  heroRows: number;
+  skillRows: number;
+}
+
+const uniqueItems = (items: string[]): string[] => [...new Set(items)];
+
+const poolRows = (count: number): number => Math.max(1, Math.ceil(count / POOL_COLUMNS));
+
+/** Exported for deterministic layout tests without requiring a browser canvas. */
+export const getRoundShareImageLayout = (
+  input: Pick<RoundShareImageInput, 'heroes' | 'skills' | 'supportHero' | 'supportSkills'>
+): RoundShareLayout => {
+  const heroCount = uniqueItems([
+    ...(input.supportHero ? [input.supportHero] : []),
+    ...input.heroes,
+  ]).length;
+  const skillCount = uniqueItems([
+    ...(input.supportSkills ?? []),
+    ...input.skills,
+  ]).length;
+  const heroRows = poolRows(heroCount);
+  const skillRows = poolRows(skillCount);
+  const height = Math.ceil(
+    40 + // top padding
+      78 + // title and badges
+      46 + // candidate section title
+      CANDIDATE_GROUP_HEIGHT +
+      42 + // gap before roster
+      50 + // roster title
+      38 + // hero title
+      heroRows * POOL_CARD_HEIGHT +
+      (heroRows - 1) * POOL_GAP +
+      30 + // hero/skill gap
+      38 + // skill title
+      skillRows * POOL_CARD_HEIGHT +
+      (skillRows - 1) * POOL_GAP +
+      44 // bottom padding
+  );
+  return { height, heroRows, skillRows };
+};
+
+const makeShareCard = (
+  name: string,
+  kind: GameAssetKind,
+  ranking: string,
+  support: boolean
+): ShareCard => {
+  const asset = getGameAsset(name, kind);
+  return {
+    name,
+    kind,
+    ranking,
+    support,
+    quality: asset?.quality ?? null,
+    assetPath: asset?.path ?? null,
+  };
+};
+
+const roundedRect = (
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+) => {
+  const safeRadius = Math.min(radius, width / 2, height / 2);
+  context.beginPath();
+  context.moveTo(x + safeRadius, y);
+  context.lineTo(x + width - safeRadius, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + safeRadius);
+  context.lineTo(x + width, y + height - safeRadius);
+  context.quadraticCurveTo(
+    x + width,
+    y + height,
+    x + width - safeRadius,
+    y + height
+  );
+  context.lineTo(x + safeRadius, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - safeRadius);
+  context.lineTo(x, y + safeRadius);
+  context.quadraticCurveTo(x, y, x + safeRadius, y);
+  context.closePath();
+};
+
+const fitText = (
+  context: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number
+): string => {
+  if (context.measureText(text).width <= maxWidth) return text;
+  let fitted = text;
+  while (fitted.length > 1 && context.measureText(`${fitted}…`).width > maxWidth) {
+    fitted = fitted.slice(0, -1);
+  }
+  return `${fitted}…`;
+};
+
+const drawBadge = (
+  context: CanvasRenderingContext2D,
+  label: string,
+  x: number,
+  y: number,
+  fill: string,
+  color = '#fff'
+): number => {
+  context.save();
+  context.font = `700 20px ${UI_FONT}`;
+  const width = Math.ceil(context.measureText(label).width + 28);
+  roundedRect(context, x, y, width, 38, 19);
+  context.fillStyle = fill;
+  context.fill();
+  context.fillStyle = color;
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.fillText(label, x + width / 2, y + 19);
+  context.restore();
+  return width;
+};
+
+const loadImage = (path: string): Promise<HTMLImageElement | null> =>
+  new Promise((resolve) => {
+    const image = new Image();
+    image.decoding = 'async';
+    image.onload = () => resolve(image);
+    image.onerror = () => resolve(null);
+    image.src = path;
+  });
+
+const loadCardImages = async (
+  cards: ShareCard[]
+): Promise<Map<string, HTMLImageElement | null>> => {
+  const paths = uniqueItems(
+    cards.flatMap((card) => (card.assetPath ? [card.assetPath] : []))
+  );
+  const entries = await Promise.all(
+    paths.map(async (path) => [path, await loadImage(path)] as const)
+  );
+  return new Map(entries);
+};
+
+const drawCoverImage = (
+  context: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  x: number,
+  y: number,
+  width: number,
+  height: number
+) => {
+  const scale = Math.max(width / image.naturalWidth, height / image.naturalHeight);
+  const sourceWidth = width / scale;
+  const sourceHeight = height / scale;
+  const sourceX = (image.naturalWidth - sourceWidth) / 2;
+  const sourceY = (image.naturalHeight - sourceHeight) / 2;
+  context.drawImage(
+    image,
+    sourceX,
+    sourceY,
+    sourceWidth,
+    sourceHeight,
+    x,
+    y,
+    width,
+    height
+  );
+};
+
+const drawShareCard = (
+  context: CanvasRenderingContext2D,
+  card: ShareCard,
+  image: HTMLImageElement | null,
+  x: number,
+  y: number,
+  width: number,
+  artHeight: number,
+  metaHeight: number,
+  nameFontSize: number
+) => {
+  context.save();
+  roundedRect(context, x, y, width, artHeight, 7);
+  context.clip();
+
+  if (image) {
+    drawCoverImage(context, image, x, y, width, artHeight);
+  } else {
+    const missingGradient = context.createLinearGradient(x, y, x, y + artHeight);
+    missingGradient.addColorStop(0, '#ede1c7');
+    missingGradient.addColorStop(1, '#bba67d');
+    context.fillStyle = missingGradient;
+    context.fillRect(x, y, width, artHeight);
+  }
+
+  const nameGradient = context.createLinearGradient(x, y + artHeight * 0.48, x, y + artHeight);
+  nameGradient.addColorStop(0, 'rgba(8, 13, 12, 0)');
+  nameGradient.addColorStop(1, 'rgba(7, 11, 10, 0.96)');
+  context.fillStyle = nameGradient;
+  context.fillRect(x, y + artHeight * 0.45, width, artHeight * 0.55);
+
+  context.fillStyle = '#fff8e8';
+  context.font = `900 ${nameFontSize}px ${TITLE_FONT}`;
+  context.textAlign = 'center';
+  context.textBaseline = 'alphabetic';
+  context.shadowColor = '#000';
+  context.shadowBlur = 3;
+  context.fillText(
+    fitText(context, card.name, width - 10),
+    x + width / 2,
+    y + artHeight - 10
+  );
+  context.shadowBlur = 0;
+
+  if (card.support) {
+    context.font = `800 ${Math.max(14, nameFontSize - 2)}px ${UI_FONT}`;
+    const label = '★ 支援';
+    const badgeWidth = context.measureText(label).width + 18;
+    context.fillStyle = COLORS.support;
+    context.fillRect(x + 5, y + 5, badgeWidth, 27);
+    context.fillStyle = '#fff';
+    context.textAlign = 'left';
+    context.textBaseline = 'middle';
+    context.fillText(label, x + 14, y + 18.5);
+  }
+  context.restore();
+
+  context.save();
+  roundedRect(context, x, y, width, artHeight, 7);
+  context.strokeStyle =
+    card.quality === 'purple' ? COLORS.purple : COLORS.orange;
+  context.lineWidth = 2;
+  context.stroke();
+  context.fillStyle = COLORS.muted;
+  context.font = `600 ${Math.max(14, nameFontSize - 3)}px ${UI_FONT}`;
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.fillText(
+    fitText(context, card.ranking || (card.kind === 'hero' ? '武将' : '战法'), width),
+    x + width / 2,
+    y + artHeight + metaHeight / 2
+  );
+  context.restore();
+};
+
+const drawPoolGrid = (
+  context: CanvasRenderingContext2D,
+  cards: ShareCard[],
+  images: Map<string, HTMLImageElement | null>,
+  y: number
+) => {
+  cards.forEach((card, index) => {
+    const row = Math.floor(index / POOL_COLUMNS);
+    const column = index % POOL_COLUMNS;
+    drawShareCard(
+      context,
+      card,
+      card.assetPath ? (images.get(card.assetPath) ?? null) : null,
+      OUTER_PADDING + column * (POOL_CARD_WIDTH + POOL_GAP),
+      y + row * (POOL_CARD_HEIGHT + POOL_GAP),
+      POOL_CARD_WIDTH,
+      POOL_ART_HEIGHT,
+      POOL_META_HEIGHT,
+      18
+    );
+  });
+};
+
+const canvasToPng = (canvas: HTMLCanvasElement): Promise<Blob> =>
+  new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error('浏览器无法生成分享图片'));
+    }, 'image/png');
+  });
+
+/**
+ * Render a stable, controls-free PNG containing all candidate sets and the
+ * complete current pool, independent of the responsive disclosure state.
+ */
+export async function renderRoundShareImage(
+  input: RoundShareImageInput
+): Promise<Blob> {
+  const supportSkills = new Set(input.supportSkills ?? []);
+  const candidateCards = input.sets.flatMap((set) =>
+    set.map((name) =>
+      makeShareCard(
+        name,
+        input.roundType === 'hero' ? 'hero' : 'tactic',
+        input.roundType === 'hero'
+          ? formatHeroRanking(input.heroMetadata?.[name])
+          : formatSkillRanking(input.skillMetadata?.[name]),
+        false
+      )
+    )
+  );
+  const heroCards = uniqueItems([
+    ...(input.supportHero ? [input.supportHero] : []),
+    ...input.heroes,
+  ]).map((name) =>
+    makeShareCard(
+      name,
+      'hero',
+      formatHeroRanking(input.heroMetadata?.[name]),
+      name === input.supportHero
+    )
+  );
+  const skillCards = uniqueItems([
+    ...(input.supportSkills ?? []),
+    ...input.skills,
+  ]).map((name) =>
+    makeShareCard(
+      name,
+      'tactic',
+      formatSkillRanking(input.skillMetadata?.[name]),
+      supportSkills.has(name)
+    )
+  );
+  const allCards = [...candidateCards, ...heroCards, ...skillCards];
+  const [images] = await Promise.all([
+    loadCardImages(allCards),
+    typeof document !== 'undefined' && document.fonts
+      ? document.fonts.ready
+      : Promise.resolve(),
+  ]);
+
+  const layout = getRoundShareImageLayout(input);
+  const canvas = document.createElement('canvas');
+  canvas.width = IMAGE_WIDTH;
+  canvas.height = layout.height;
+  const context = canvas.getContext('2d');
+  if (!context) throw new Error('浏览器不支持图片生成');
+  context.imageSmoothingEnabled = true;
+  context.imageSmoothingQuality = 'high';
+
+  context.fillStyle = COLORS.background;
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  context.strokeStyle = 'rgba(125, 105, 68, 0.055)';
+  context.lineWidth = 1;
+  for (let lineY = 10; lineY < canvas.height; lineY += 8) {
+    context.beginPath();
+    context.moveTo(0, lineY);
+    context.lineTo(canvas.width, lineY);
+    context.stroke();
+  }
+
+  let y = 40;
+  context.fillStyle = COLORS.text;
+  context.font = `800 42px ${TITLE_FONT}`;
+  context.textAlign = 'left';
+  context.textBaseline = 'top';
+  context.fillText('三谋演武 · 本轮选择', OUTER_PADDING, y);
+  const typeLabel = input.roundType === 'hero' ? '武将候选' : '战法候选';
+  const roundBadgeWidth = drawBadge(
+    context,
+    `第 ${input.roundNumber} 轮 · ${typeLabel}`,
+    OUTER_PADDING,
+    y + 52,
+    COLORS.primary
+  );
+  if (input.season !== null) {
+    drawBadge(
+      context,
+      `S${input.season}`,
+      OUTER_PADDING + roundBadgeWidth + 10,
+      y + 52,
+      COLORS.secondary
+    );
+  }
+
+  y += 118;
+  context.fillStyle = COLORS.text;
+  context.font = `800 27px ${UI_FONT}`;
+  context.textBaseline = 'top';
+  context.fillText('候选组', OUTER_PADDING, y);
+  y += 46;
+
+  input.sets.forEach((set, groupIndex) => {
+    const groupX = OUTER_PADDING + groupIndex * (GROUP_CARD_WIDTH + GROUP_GAP);
+    const candidateOffset = input.sets
+      .slice(0, groupIndex)
+      .reduce((total, group) => total + group.length, 0);
+    const groupItemsWidth =
+      set.length * CANDIDATE_CARD_WIDTH +
+      Math.max(0, set.length - 1) * GROUP_CARD_GAP;
+    const groupItemsX = groupX + (GROUP_CARD_WIDTH - groupItemsWidth) / 2;
+    context.save();
+    roundedRect(context, groupX, y, GROUP_CARD_WIDTH, CANDIDATE_GROUP_HEIGHT, 10);
+    context.fillStyle = COLORS.paper;
+    context.fill();
+    context.strokeStyle = COLORS.divider;
+    context.lineWidth = 2;
+    context.stroke();
+    context.fillStyle = COLORS.text;
+    context.font = `800 23px ${TITLE_FONT}`;
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    context.fillText(
+      `第 ${groupIndex + 1} 组  (${set.length}/${set.length})`,
+      groupX + GROUP_CARD_WIDTH / 2,
+      y + GROUP_TITLE_HEIGHT / 2 + 3
+    );
+    context.restore();
+
+    set.forEach((name, itemIndex) => {
+      const card = candidateCards[candidateOffset + itemIndex];
+      drawShareCard(
+        context,
+        card,
+        card.assetPath ? (images.get(card.assetPath) ?? null) : null,
+        groupItemsX + itemIndex * (CANDIDATE_CARD_WIDTH + GROUP_CARD_GAP),
+        y + GROUP_TITLE_HEIGHT,
+        CANDIDATE_CARD_WIDTH,
+        CANDIDATE_ART_HEIGHT,
+        CANDIDATE_META_HEIGHT,
+        18
+      );
+    });
+  });
+
+  y += CANDIDATE_GROUP_HEIGHT + 42;
+  context.fillStyle = COLORS.text;
+  context.font = `800 30px ${UI_FONT}`;
+  context.textAlign = 'left';
+  context.textBaseline = 'top';
+  context.fillText('当前阵容', OUTER_PADDING, y);
+  context.fillStyle = COLORS.primary;
+  context.font = `800 24px ${UI_FONT}`;
+  context.fillText(`评分 ${input.rosterScore.toFixed(1)}`, OUTER_PADDING + 150, y + 3);
+  y += 50;
+
+  context.fillStyle = COLORS.text;
+  context.font = `800 22px ${UI_FONT}`;
+  context.fillText(`武将 (${heroCards.length})`, OUTER_PADDING, y);
+  y += 38;
+  drawPoolGrid(context, heroCards, images, y);
+  y +=
+    layout.heroRows * POOL_CARD_HEIGHT +
+    (layout.heroRows - 1) * POOL_GAP +
+    30;
+
+  context.fillStyle = COLORS.text;
+  context.font = `800 22px ${UI_FONT}`;
+  context.fillText(`战法 (${skillCards.length})`, OUTER_PADDING, y);
+  y += 38;
+  drawPoolGrid(context, skillCards, images, y);
+
+  return canvasToPng(canvas);
+}

--- a/web/tests/gameCardVisuals.spec.js
+++ b/web/tests/gameCardVisuals.spec.js
@@ -69,7 +69,14 @@ test.describe('local game-card presentation', () => {
     });
 
     await page.setViewportSize({ width: 1280, height: 900 });
-    await seedGame(page, roundState(), roundInputs());
+    await seedGame(
+      page,
+      {
+        ...roundState(),
+        current_skills: Object.keys(manifest.tactics).slice(0, 18),
+      },
+      roundInputs()
+    );
     await page.getByRole('button', { name: '获取 AI 推荐' }).click();
 
     const groups = page.getByTestId('analysis-set-card');
@@ -97,6 +104,74 @@ test.describe('local game-card presentation', () => {
     );
     expect(groupBoxes[1].top).toBeGreaterThanOrEqual(groupBoxes[0].bottom);
     expect(groupBoxes[2].top).toBeGreaterThanOrEqual(groupBoxes[1].bottom);
+  });
+
+  test('copies a complete round PNG and offers a mobile preview when image clipboard access is blocked', async ({ page }, testInfo) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          write: async (items) => {
+            const blob = await items[0].getType('image/png');
+            const bitmap = await createImageBitmap(blob);
+            window.__roundShareCopy = {
+              type: blob.type,
+              size: blob.size,
+              width: bitmap.width,
+              height: bitmap.height,
+            };
+            bitmap.close();
+          },
+        },
+      });
+    });
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await seedGame(
+      page,
+      {
+        ...roundState(),
+        current_skills: Object.keys(manifest.tactics).slice(0, 18),
+      },
+      roundInputs()
+    );
+
+    await page.getByRole('button', { name: '复制选项与阵容图片' }).click();
+    await expect(page.getByText('图片已复制，可粘贴到微信')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__roundShareCopy)).toMatchObject({
+      type: 'image/png',
+      width: 1200,
+    });
+    const copied = await page.evaluate(() => window.__roundShareCopy);
+    expect(copied.size).toBeGreaterThan(10_000);
+    expect(copied.height).toBeGreaterThan(1_000);
+    await expect(page.getByRole('dialog', { name: '发送到微信' })).toHaveCount(0);
+
+    await page.evaluate(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: undefined,
+      });
+    });
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.getByRole('button', { name: '复制选项与阵容图片' }).click();
+
+    const dialog = page.getByRole('dialog', { name: '发送到微信' });
+    await expect(dialog).toBeVisible();
+    const preview = dialog.getByRole('img', {
+      name: '本轮候选组与当前阵容分享图片预览',
+    });
+    await expect(preview).toBeVisible();
+    await expect.poll(() => preview.evaluate((image) => image.naturalWidth)).toBe(1200);
+    const downloadButton = dialog.getByRole('button', { name: '下载图片' });
+    await expect(downloadButton).toBeEnabled();
+    const downloadPromise = page.waitForEvent('download');
+    await downloadButton.click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toBe('sanmou-round-7.png');
+    await download.saveAs(testInfo.outputPath('round-share.png'));
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth)
+    ).toBeLessThanOrEqual(1);
   });
 
   test('preserves the selected group and offers while a support change finishes rescoring', async ({ page }) => {


### PR DESCRIPTION
## Intent

Develop a feature on the round-selection screen where a player can copy the complete candidate sets and existing pool as a screenshot for pasting into WeChat. Export a controls-free, fixed-layout 1200px PNG containing the round and season, all three candidate groups, current roster score, heroes, tactics, rankings, and support markers, entirely client-side. Copy the PNG through the binary Clipboard API when supported; otherwise show a preview with native file sharing when available, download, and long-press/save guidance. Preserve existing editing, recommendation, and game behavior, and keep the action usable at desktop, tablet, and mobile sizes.

## What Changed
- Add a round-selection action that renders a controls-free, fixed-width 1200px PNG with the round, season, all candidate groups, roster score, heroes, tactics, rankings, and support markers.
- Copy the PNG through the binary Clipboard API, with a preview fallback offering native file sharing, download, and mobile long-press guidance while retaining exported-round metadata across transitions.
- Add unit and Playwright coverage for image layout, clipboard fallbacks, transition and error handling, and desktop/mobile export behavior, plus document the sharing workflow.

## Risk Assessment

✅ Low: The client-side export and fallback flow is well-bounded, preserves immutable round metadata across asynchronous transitions, and cleans up generated object URLs safely.

## Testing

After correcting initial pnpm invocations to run inside `web/`, targeted Vitest and Playwright checks passed. End-to-end browser verification exercised binary clipboard copying, preview/download/native-share fallbacks, support rescoring preservation, maximum active-pool rendering, and desktop/tablet/mobile usability; the generated PNGs were visually inspected and responsive checks found no browser errors or horizontal overflow.

- Evidence: Maximum Round 10 controls-free 1200px PNG with all candidate groups, maximum active roster, rankings, score, and support markers (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1B73P01HXFT74ZD76TYAAVY/wechat-round-10-max-active-pool.png</code>)
- Evidence: Round 7 generated PNG with support hero and support tactics (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1B73P01HXFT74ZD76TYAAVY/wechat-round-7-with-support.png</code>)
- Evidence: Desktop round-selection share action (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1B73P01HXFT74ZD76TYAAVY/desktop-round-share-action.png</code>)
- Evidence: Tablet round-selection share action (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1B73P01HXFT74ZD76TYAAVY/tablet-round-share-action.png</code>)
- Evidence: Mobile round-selection share action (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1B73P01HXFT74ZD76TYAAVY/mobile-round-share-action.png</code>)
- Evidence: Desktop fallback preview and download dialog (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1B73P01HXFT74ZD76TYAAVY/desktop-round-share-fallback.png</code>)
- Evidence: Tablet fallback preview and download dialog (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1B73P01HXFT74ZD76TYAAVY/tablet-round-share-fallback.png</code>)
- Evidence: Mobile fallback preview, guidance, and download dialog (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1B73P01HXFT74ZD76TYAAVY/mobile-round-share-fallback.png</code>)
- Evidence: Mobile fallback with native file-sharing action available (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1B73P01HXFT74ZD76TYAAVY/mobile-round-share-native-share.png</code>)
<details>
<summary>Evidence: Responsive browser verification report</summary>

```text
{
  "scenario": "Round 7 with three two-hero candidate groups, 9 current heroes, 18 current tactics, one support hero, and two support tactics",
  "selectedSeason": 16,
  "generatedPng": {
    "path": "/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1B73P01HXFT74ZD76TYAAVY/wechat-round-7-with-support.png",
    "bytes": 1464992
  },
  "results": [
    {
      "viewport": "desktop",
      "dimensions": {
        "width": 1280,
        "height": 900
      },
      "actionBox": {
        "x": 750.0625,
        "y": 222.265625,
        "width": 181.9375,
        "height": 40
      },
      "preview": {
        "naturalWidth": 1200,
        "naturalHeight": 1237
      },
      "horizontalOverflow": 0,
      "guidanceVisible": true,
      "downloadVisible": true,
      "browserErrors": []
    },
    {
      "viewport": "tablet",
      "dimensions": {
        "width": 768,
        "height": 1024
      },
      "actionBox": {
        "x": 562.0625,
        "y": 288.265625,
        "width": 181.9375,
        "height": 40
      },
      "preview": {
        "naturalWidth": 1200,
        "naturalHeight": 1237
      },
      "horizontalOverflow": 0,
      "guidanceVisible": true,
      "downloadVisible": true,
      "browserErrors": []
    },
    {
      "viewport": "mobile",
      "dimensions": {
        "width": 390,
        "height": 844
      },
      "actionBox": {
        "x": 16,
        "y": 408.375,
        "width": 181.9375,
        "height": 40
      },
      "preview": {
        "naturalWidth": 1200,
        "naturalHeight": 1237
      },
      "horizontalOverflow": 0,
      "guidanceVisible": true,
      "downloadVisible": true,
      "browserErrors": []
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Maximum active-pool PNG verification report</summary>

```text
{
  "scenario": "Round 10 maximum active pool",
  "season": 16,
  "candidateGroups": [
    3,
    3,
    3
  ],
  "currentHeroes": 14,
  "supportHeroes": 1,
  "currentTactics": 23,
  "supportTactics": 2,
  "dimensions": {
    "width": 1200,
    "height": 1632
  },
  "bytes": 1975750,
  "filename": "sanmou-round-10.png",
  "browserErrors": []
}
```
</details>
<details>
<summary>Evidence: Native file-sharing payload verification</summary>

```text
{
  "title": "三谋演武第 7 轮",
  "name": "sanmou-round-7.png",
  "type": "image/png",
  "size": 1464992
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"56abd7d36df749fec53c884fc439855a40764f8f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ `web/src/components/game/GameBoard.tsx:600` - The fallback download filename and native-share title read the live `roundNumber`, not the round captured by the asynchronous export. If a player starts an export and confirms the choice before image rendering finishes, the preview contains round N while download labels it round N+1 and native sharing uses an N+1 title. Capture the round-derived filename/title in `sharePreview` when the export starts and use that snapshot in both handlers.

🔧 Fix: Snapshot round metadata for image sharing fallbacks
2 warnings still open:
- ⚠️ `web/src/components/game/GameBoard.tsx:738` - The required “otherwise show a preview with native file sharing when available, download, and long-press/save guidance” fallback is mounted only in the normal-round return. If binary clipboard access is unavailable and a player confirms round 6, 8, or especially round 10 before rendering finishes, `openSharePreview` stores the image after the component has switched to an earlier qualification/completion return, so the fallback is hidden (permanently after round 10). Render the share surface from a GameBoard shell shared by normal, qualification, and completion states.
- ⚠️ `web/src/components/game/GameBoard.tsx:523` - A pending fallback export can create its object URL after GameBoard unmounts via the available route navigation. The cleanup has already run while the ref is null, React ignores the later state update, and the generated PNG URL remains unrecoverable until page unload. Guard pending export completion with mounted/export ownership or create the URL from a mounted effect.

🔧 Fix: Preserve share fallbacks and clean up exports
1 warning still open:
- ⚠️ `web/src/components/game/GameBoard.tsx:686` - Share failures are written to `error`, but the error Alert exists only in the normal-round body and is absent from the shared shell. If a round 6, 8, or 10 export fails after the player confirms the choice, the qualification/completion view silently hides the failure and the cleared candidate sets prevent retrying that round; native-share rejection has the same problem. Render share errors through `GameBoardShell` or inside the share dialog.

🔧 Fix: Keep share failures visible across round transitions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd web && pnpm exec vitest run src/components/game/__tests__/GameBoard.test.tsx src/utils/__tests__/clipboard.test.ts src/utils/__tests__/roundShareImage.test.ts`
- `cd web && pnpm exec playwright test tests/gameCardVisuals.spec.js --grep "copies a complete round PNG and offers a mobile preview" --workers=1`
- `cd web && pnpm exec playwright test tests/gameCardVisuals.spec.js --grep "preserves the selected group and offers while a support change finishes rescoring" --workers=1`
- <code>`cd web &amp;&amp; pnpm start --host 127.0.0.1` with a Playwright browser check at 1280×900, 768×1024, and 390×844: forced binary clipboard fallback, opened the share dialog, verified the 1200px preview, long-press guidance, download action, zero horizontal overflow, and captured screenshots.</code>
- `Playwright manual Round 7 check with three candidate groups, 9 current heroes, 18 current tactics, one support hero, and two support tactics; downloaded and visually inspected the generated PNG.`
- <code>Playwright manual native-share check with `navigator.canShare` and `navigator.share`: verified the shared file was `sanmou-round-7.png`, `image/png`, with the expected title and nontrivial binary content.</code>
- `Playwright manual maximum active-pool check for Round 10: rendered three 3-tactic groups, 15 heroes including support, and 25 tactics including support into a downloaded 1200×1632 PNG.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
