### PR TITLE
fix(web): clarify round snapshot sharing for WeChat

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -185,9 +185,10 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
 - **GameBoard**: Main game container managing the draft rounds. On wide desktop
   the option workspace and current roster share one two-column viewport; on
   mobile the roster is a disclosure below the option workspace. Once all three
-  candidate groups are complete, `复制选项与阵容图片` renders a controls-free,
-  fixed-1200px-wide PNG entirely in the browser, independent of the responsive
-  page layout. The image includes the round and season, every candidate group,
+  candidate groups are complete, the secondary green chat-bubbles action
+  `复制给微信好友` renders a controls-free, fixed-1200px-wide PNG entirely in the
+  browser, independent of the responsive page layout. The image includes the
+  round and season, every candidate group,
   current roster score, all acquired hero and tactic cards, guide rankings, and
   support markers. It is copied through the binary Clipboard API when allowed;
   otherwise a preview offers native file sharing when supported, download, and

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Container, Box, Button, Alert, CircularProgress, Typography, Paper, Snackbar } from "@mui/material";
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import ImageIcon from '@mui/icons-material/Image';
+import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import { useGame } from "../../context/GameContext";
 import { api } from "../../services/api";
 import { getRoundType, getItemsPerSet, TOTAL_ROUNDS } from "../../services/gameLogic";
@@ -803,7 +803,6 @@ const GameBoard = () => {
               </Button>
               <Button
                 variant="outlined"
-                color="primary"
                 size="small"
                 onClick={handleCopyRoundImage}
                 disabled={!allSetsComplete || shareImageBusy}
@@ -811,11 +810,20 @@ const GameBoard = () => {
                   shareImageBusy ? (
                     <CircularProgress size={16} color="inherit" />
                   ) : (
-                    <ImageIcon fontSize="small" />
+                    <ForumOutlinedIcon fontSize="small" />
                   )
                 }
+                sx={{
+                  color: '#067A3D',
+                  borderColor: '#067A3D',
+                  '&:hover': {
+                    color: '#046B35',
+                    borderColor: '#046B35',
+                    backgroundColor: 'rgba(7, 193, 96, 0.08)',
+                  },
+                }}
               >
-                复制选项与阵容图片
+                复制给微信好友
               </Button>
             </>
           }

--- a/web/src/components/game/__tests__/GameBoard.test.tsx
+++ b/web/src/components/game/__tests__/GameBoard.test.tsx
@@ -303,9 +303,11 @@ describe('GameBoard roster rescoring', () => {
   test('copies a complete candidate-and-roster PNG with the current round state', async () => {
     render(<GameBoard />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: '复制选项与阵容图片' })
-    );
+    const shareButton = screen.getByRole('button', { name: '复制给微信好友' });
+    expect(screen.getByTestId('ForumOutlinedIcon')).toBeVisible();
+    expect(shareButton).toHaveStyle({ color: '#067A3D', borderColor: '#067A3D' });
+
+    fireEvent.click(shareButton);
 
     await waitFor(() => expect(mocks.copyImageToClipboard).toHaveBeenCalledTimes(1));
     expect(mocks.renderRoundShareImage).toHaveBeenCalledWith(
@@ -357,7 +359,7 @@ describe('GameBoard roster rescoring', () => {
       const { rerender, unmount } = render(<GameBoard />);
 
       fireEvent.click(
-        screen.getByRole('button', { name: '复制选项与阵容图片' })
+        screen.getByRole('button', { name: '复制给微信好友' })
       );
       await waitFor(() =>
         expect(mocks.copyImageToClipboard).toHaveBeenCalledTimes(1)
@@ -409,7 +411,7 @@ describe('GameBoard roster rescoring', () => {
     const { rerender } = render(<GameBoard />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: '复制选项与阵容图片' })
+      screen.getByRole('button', { name: '复制给微信好友' })
     );
     await waitFor(() =>
       expect(mocks.copyImageToClipboard).toHaveBeenCalledTimes(1)
@@ -450,7 +452,7 @@ describe('GameBoard roster rescoring', () => {
     const { unmount } = render(<GameBoard />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: '复制选项与阵容图片' })
+      screen.getByRole('button', { name: '复制给微信好友' })
     );
     await waitFor(() =>
       expect(mocks.copyImageToClipboard).toHaveBeenCalledTimes(1)
@@ -495,7 +497,7 @@ describe('GameBoard roster rescoring', () => {
     const { rerender } = render(<GameBoard />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: '复制选项与阵容图片' })
+      screen.getByRole('button', { name: '复制给微信好友' })
     );
     expect(await screen.findByRole('dialog', { name: '发送到微信' })).toBeVisible();
 
@@ -553,7 +555,7 @@ describe('GameBoard roster rescoring', () => {
     const { rerender } = render(<GameBoard />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: '复制选项与阵容图片' })
+      screen.getByRole('button', { name: '复制给微信好友' })
     );
     mocks.state.gameState = {
       ...mocks.state.gameState,

--- a/web/tests/gameCardVisuals.spec.js
+++ b/web/tests/gameCardVisuals.spec.js
@@ -135,7 +135,20 @@ test.describe('local game-card presentation', () => {
       roundInputs()
     );
 
-    await page.getByRole('button', { name: '复制给微信好友' }).click();
+    const shareButton = page.getByRole('button', { name: '复制给微信好友' });
+    await expect(shareButton.locator('[data-testid="ForumOutlinedIcon"]')).toBeVisible();
+    await expect(shareButton).toHaveCSS('color', 'rgb(6, 122, 61)');
+    await expect(shareButton).toHaveCSS('border-color', 'rgb(6, 122, 61)');
+    await expect(shareButton).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+    await shareButton.hover();
+    await expect(shareButton).toHaveCSS('color', 'rgb(4, 107, 53)');
+    await expect(shareButton).toHaveCSS('border-color', 'rgb(4, 107, 53)');
+    await expect(shareButton).toHaveCSS(
+      'background-color',
+      'rgba(7, 193, 96, 0.08)'
+    );
+
+    await shareButton.click();
     await expect(page.getByText('图片已复制，可粘贴到微信')).toBeVisible();
     await expect.poll(() => page.evaluate(() => window.__roundShareCopy)).toMatchObject({
       type: 'image/png',

--- a/web/tests/gameCardVisuals.spec.js
+++ b/web/tests/gameCardVisuals.spec.js
@@ -135,7 +135,7 @@ test.describe('local game-card presentation', () => {
       roundInputs()
     );
 
-    await page.getByRole('button', { name: '复制选项与阵容图片' }).click();
+    await page.getByRole('button', { name: '复制给微信好友' }).click();
     await expect(page.getByText('图片已复制，可粘贴到微信')).toBeVisible();
     await expect.poll(() => page.evaluate(() => window.__roundShareCopy)).toMatchObject({
       type: 'image/png',
@@ -153,7 +153,7 @@ test.describe('local game-card presentation', () => {
       });
     });
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.getByRole('button', { name: '复制选项与阵容图片' }).click();
+    await page.getByRole('button', { name: '复制给微信好友' }).click();
 
     const dialog = page.getByRole('dialog', { name: '发送到微信' });
     await expect(dialog).toBeVisible();


### PR DESCRIPTION
## Intent

Make the round snapshot copy action clearly indicate that it is intended for sharing with WeChat friends. Change the button label from ‘复制选项与阵容图片’ to the user-approved shorter text ‘复制给微信好友’, replace the generic image glyph with the app's existing WeChat-style chat-bubbles icon, and give this secondary outlined action an accessible WeChat-green treatment without competing with the primary AI recommendation button. Use dark green text and border with a darker hover state and a subtle official WeChat-green hover tint because official #07C160 alone does not meet text contrast on white. Preserve all existing clipboard, fallback dialog, and sharing behavior, and update unit and end-to-end coverage for the new accessible name, icon, and styling.

## What Changed

- Rename the round snapshot action to `复制给微信好友` and replace the generic image glyph with the existing outlined chat-bubbles icon.
- Apply dark WeChat-green text and border styling with a darker hover state and subtle `#07C160` hover tint while retaining the existing clipboard and fallback sharing flow.
- Update web documentation, unit assertions, and Playwright coverage for the new accessible name, icon, and visual styling.

## Risk Assessment

🚨 High: The implementation is narrow and preserves the existing sharing handlers, but an explicit acceptance requirement for end-to-end icon and styling coverage remains unmet.

## Testing

No prior baseline results were supplied; after installing locked web dependencies and isolating Vite from an occupied port 3000, the focused GameBoard unit suite, the Playwright clipboard/fallback path with accessible-name/icon/style assertions, and desktop/mobile rendered and WCAG contrast checks all succeeded, producing action-state screenshots, a fallback-dialog screenshot, and the real 1200×1237 share PNG; broad suites, builds, and static checks were intentionally left to later phases.

- Evidence: Desktop WeChat share action beside the primary AI action (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1BAX02G5ERNC8XCG7G0F7VE/wechat-share-action-default.png</code>)
- Evidence: Desktop WeChat share action with official-green hover tint (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1BAX02G5ERNC8XCG7G0F7VE/wechat-share-action-hover.png</code>)
- Evidence: Mobile WeChat share action layout (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1BAX02G5ERNC8XCG7G0F7VE/wechat-share-action-mobile.png</code>)
- Evidence: Mobile blocked-clipboard fallback dialog (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1BAX02G5ERNC8XCG7G0F7VE/wechat-share-fallback-mobile.png</code>)
- Evidence: Actual generated round-share PNG (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1BAX02G5ERNC8XCG7G0F7VE/round-share.png</code>)
<details>
<summary>Evidence: Rendered share-action style and contrast diagnostics</summary>

`Accessible name: 复制给微信好友; visible 18×18 ForumOutlined icon; default color/border rgb(6,122,61), transparent background; hover color/border rgb(4,107,53), rgba(7,193,96,0.08) background; contrast ratios 5.44:1 default and 6.17:1 hover; zero horizontal overflow.`

```text
{
  "accessibleName": "复制给微信好友",
  "icon": {
    "visible": true,
    "width": 18,
    "height": 18
  },
  "defaultStyles": {
    "color": "rgb(6, 122, 61)",
    "borderColor": "rgb(6, 122, 61)",
    "backgroundColor": "rgba(0, 0, 0, 0)"
  },
  "hoverStyles": {
    "color": "rgb(4, 107, 53)",
    "borderColor": "rgb(4, 107, 53)",
    "backgroundColor": "rgba(7, 193, 96, 0.08)"
  },
  "primaryAiStyles": {
    "color": "rgb(255, 253, 248)",
    "borderColor": "rgb(255, 253, 248)",
    "backgroundColor": "rgb(69, 108, 95)"
  },
  "horizontalOverflow": 0,
  "contrastRatios": {
    "defaultTextOnWhite": 5.44,
    "hoverTextOnTint": 6.17,
    "officialWechatGreenOnWhite": 2.38,
    "wcagAaNormalTextMinimum": 4.5
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4638bfa34ff53d77225ad9950f61314107c43c35","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `web/tests/gameCardVisuals.spec.js:138` - The intent requires “update unit and end-to-end coverage for the new accessible name, icon, and styling,” but the changed E2E hunk only locates the renamed button and clicks it. It does not verify that the ForumOutlined icon is inside the button or that the normal and hovered computed text, border, and official-green tint styles are applied; the unit test also covers only the normal color and border. Add executable Playwright assertions for the icon and both normal and hovered computed styles.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd web &amp;&amp; pnpm install --frozen-lockfile` (dependency setup; generated dependencies were removed afterward)</code>
- `cd web && pnpm exec vitest run src/components/game/__tests__/GameBoard.test.tsx`
- <code>`cd web &amp;&amp; pnpm exec playwright test tests/gameCardVisuals.spec.js --grep &#34;copies a complete round PNG and offers a mobile preview when image clipboard access is blocked&#34;` (initial result discarded because configured port 3000 was occupied by a pre-existing Vite process)</code>
- <code>`cd web &amp;&amp; pnpm exec playwright test --config=&#39;/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1BAX02G5ERNC8XCG7G0F7VE/focused-playwright.config.cjs&#39; gameCardVisuals.spec.js --grep &#34;copies a complete round PNG and offers a mobile preview when image clipboard access is blocked&#34;` against the target worktree on isolated port 3100</code>
- <code>`pnpm exec vite --port 3100 --strictPort` with inline Playwright Chromium checks at desktop and mobile sizes: rendered the accessible label and chat-bubbles icon, captured default/hover action states, exercised blocked-clipboard fallback, verified the 1200px preview and zero horizontal overflow</code>
- `Browser-computed WCAG contrast check: default dark green on white 5.44:1 and hover dark green on the WeChat-green tint 6.17:1, both above the 4.5:1 normal-text threshold`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
