### PR TITLE
fix(web): simplify round share image exports

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -190,10 +190,11 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   browser, independent of the responsive page layout. The image includes the
   round and season, every candidate group with one clearly marked AI
   recommendation, current roster score, all acquired hero and tactic cards, and
-  support markers; presentation-tier labels are omitted. If the player has not
-  requested an on-screen analysis yet, copying runs the same recommendation
-  engine first so the exported image still identifies a recommended group. It
-  is copied through the binary Clipboard API when allowed; otherwise a preview
+  support markers. It omits the page title, candidate heading, completion
+  counts, and all guide-tier metadata strips. A recommendation that still
+  matches the roster is reused; otherwise copying runs the same deterministic
+  engine solely for the export, without selecting a group for the player. It is
+  copied through the binary Clipboard API when allowed; otherwise a preview
   offers native file sharing when supported, download, and mobile
   long-press/save guidance for sending it to WeChat.
 - **RoundInfo**: Display current round information with an accessible ten-round

--- a/web/README.md
+++ b/web/README.md
@@ -188,11 +188,14 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   candidate groups are complete, the secondary green chat-bubbles action
   `复制给微信好友` renders a controls-free, fixed-1200px-wide PNG entirely in the
   browser, independent of the responsive page layout. The image includes the
-  round and season, every candidate group,
-  current roster score, all acquired hero and tactic cards, guide rankings, and
-  support markers. It is copied through the binary Clipboard API when allowed;
-  otherwise a preview offers native file sharing when supported, download, and
-  mobile long-press/save guidance for sending it to WeChat.
+  round and season, every candidate group with one clearly marked AI
+  recommendation, current roster score, all acquired hero and tactic cards, and
+  support markers; presentation-tier labels are omitted. If the player has not
+  requested an on-screen analysis yet, copying runs the same recommendation
+  engine first so the exported image still identifies a recommended group. It
+  is copied through the binary Clipboard API when allowed; otherwise a preview
+  offers native file sharing when supported, download, and mobile
+  long-press/save guidance for sending it to WeChat.
 - **RoundInfo**: Display current round information with an accessible ten-round
   campaign-plaque progress rail
 - **CurrentTeam**: Keep 当前阵容, its roster 评分/score, the edit control, and season

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -667,29 +667,50 @@ const GameBoard = () => {
       ...(gameState.current_skills || []),
       ...supportSkillsList,
     ];
-    const pngPromise = renderRoundShareImage({
-      roundNumber,
-      roundType,
-      season: state.selectedSeason,
-      sets: [
-        [...(currentRoundInputs.set1 || [])],
-        [...(currentRoundInputs.set2 || [])],
-        [...(currentRoundInputs.set3 || [])],
-      ],
-      heroes: [...(gameState.current_heroes || [])],
-      skills: [...(gameState.current_skills || [])],
-      supportHero,
-      supportSkills: [...supportSkillsList],
-      rosterScore: currentRosterScore(
-        heroesWithSupport,
-        skillsWithSupport,
-        recommendationData
-      ),
-      heroMetadata,
-      skillMetadata,
-    });
+    const availableSets: [string[], string[], string[]] = [
+      [...(currentRoundInputs.set1 || [])],
+      [...(currentRoundInputs.set2 || [])],
+      [...(currentRoundInputs.set3 || [])],
+    ];
+    const isValidSetIndex = (value: unknown): value is number =>
+      typeof value === 'number' &&
+      Number.isInteger(value) &&
+      value >= 0 &&
+      value < availableSets.length;
 
     try {
+      const pngPromise = (async () => {
+        let recommendedSetIndex: unknown = recommendationIsCurrent
+          ? currentRecommendation?.recommended_set_index
+          : undefined;
+        if (!isValidSetIndex(recommendedSetIndex)) {
+          const response = await api.getRecommendation(roundType, availableSets, gameState);
+          recommendedSetIndex = response.recommendation.recommended_set_index;
+        }
+        if (!isValidSetIndex(recommendedSetIndex)) {
+          throw new Error('AI 推荐组无效');
+        }
+        if (!mountedRef.current || shareExportSequenceRef.current !== exportId) {
+          throw new Error('分享图片生成已取消');
+        }
+
+        return renderRoundShareImage({
+          roundNumber,
+          roundType,
+          season: state.selectedSeason,
+          sets: availableSets,
+          recommendedSetIndex,
+          heroes: [...(gameState.current_heroes || [])],
+          skills: [...(gameState.current_skills || [])],
+          supportHero,
+          supportSkills: [...supportSkillsList],
+          rosterScore: currentRosterScore(
+            heroesWithSupport,
+            skillsWithSupport,
+            recommendationData
+          ),
+        });
+      })();
       const copied = await copyImageToClipboard(pngPromise);
       if (copied) {
         if (!mountedRef.current || shareExportSequenceRef.current !== exportId) return;

--- a/web/src/components/game/__tests__/GameBoard.test.tsx
+++ b/web/src/components/game/__tests__/GameBoard.test.tsx
@@ -24,9 +24,9 @@ const mocks = vi.hoisted(() => {
       currentRecommendation: {
         recommended_set_index: 1,
         analysis: [],
-      },
+      } as { recommended_set_index: number; analysis: never[] } | null,
       rosterRevision: 0,
-      recommendationRosterRevision: 0,
+      recommendationRosterRevision: 0 as number | null,
       availableHeroes: [],
       heroMetadata: {},
       skillMetadata: {},
@@ -320,13 +320,49 @@ describe('GameBoard roster rescoring', () => {
           ['周瑜', '陆逊', '吕蒙'],
           ['诸葛亮', '庞统', '黄忠'],
         ],
+        recommendedSetIndex: 1,
         heroes: ['刘备', '关羽', '张飞', '赵云'],
         skills: ['战法甲'],
         supportHero: null,
         supportSkills: [],
       })
     );
+    expect(mocks.getRecommendation).not.toHaveBeenCalled();
     expect(await screen.findByText('图片已复制，可粘贴到微信')).toBeVisible();
+  });
+
+  test('automatically recommends a group before exporting when analysis has not run', async () => {
+    const recommendation = deferredRecommendation();
+    mocks.getRecommendation.mockImplementationOnce(() => recommendation.promise);
+    mocks.state.currentRecommendation = null;
+    mocks.state.recommendationRosterRevision = null;
+    render(<GameBoard />);
+
+    fireEvent.click(screen.getByRole('button', { name: '复制给微信好友' }));
+
+    await waitFor(() => {
+      expect(mocks.getRecommendation).toHaveBeenCalledWith(
+        'hero',
+        [
+          ['曹操', '孙权', '袁绍'],
+          ['周瑜', '陆逊', '吕蒙'],
+          ['诸葛亮', '庞统', '黄忠'],
+        ],
+        mocks.state.gameState
+      );
+    });
+    expect(mocks.copyImageToClipboard).toHaveBeenCalledTimes(1);
+    expect(mocks.renderRoundShareImage).not.toHaveBeenCalled();
+
+    await act(async () => {
+      recommendation.resolve(recommendationResponse(2));
+      await recommendation.promise;
+    });
+    await waitFor(() => {
+      expect(mocks.renderRoundShareImage).toHaveBeenCalledWith(
+        expect.objectContaining({ recommendedSetIndex: 2 })
+      );
+    });
   });
 
   test.each([

--- a/web/src/utils/__tests__/roundShareImage.test.ts
+++ b/web/src/utils/__tests__/roundShareImage.test.ts
@@ -1,4 +1,8 @@
-import { getRoundShareImageLayout } from '../roundShareImage';
+import {
+  getRoundShareGroupTitle,
+  getRoundShareImageLayout,
+  renderRoundShareImage,
+} from '../roundShareImage';
 
 describe('getRoundShareImageLayout', () => {
   test('keeps an early-round pool to one row per item type', () => {
@@ -11,7 +15,29 @@ describe('getRoundShareImageLayout', () => {
 
     expect(layout.heroRows).toBe(1);
     expect(layout.skillRows).toBe(1);
-    expect(layout.height).toBeGreaterThan(900);
+    expect(layout.height).toBeGreaterThan(800);
+    expect(layout.height).toBeLessThan(900);
+  });
+
+  test('labels only the recommended candidate group without completion counts', () => {
+    expect(getRoundShareGroupTitle(0, 1)).toBe('第 1 组');
+    expect(getRoundShareGroupTitle(1, 1)).toBe('第 2 组 · AI 推荐');
+    expect(getRoundShareGroupTitle(2, 1)).toBe('第 3 组');
+  });
+
+  test('rejects an export without one valid AI recommendation', async () => {
+    await expect(
+      renderRoundShareImage({
+        roundNumber: 1,
+        roundType: 'hero',
+        season: 1,
+        sets: [['武将1'], ['武将2'], ['武将3']],
+        recommendedSetIndex: 3,
+        heroes: [],
+        skills: [],
+        rosterScore: 0,
+      })
+    ).rejects.toThrow('AI 推荐组无效');
   });
 
   test('grows for a complete late-round pool and de-duplicates support entries', () => {

--- a/web/src/utils/roundShareImage.ts
+++ b/web/src/utils/roundShareImage.ts
@@ -1,6 +1,5 @@
 import { getGameAsset, type GameAssetKind, type GameAssetQuality } from '../gameAssets';
-import type { HeroMeta, RoundType, SkillMeta } from '../types/game';
-import { formatHeroRanking, formatSkillRanking } from './itemMetadata';
+import type { RoundType } from '../types/game';
 
 const IMAGE_WIDTH = 1200;
 const OUTER_PADDING = 40;
@@ -14,17 +13,15 @@ const GROUP_CARD_WIDTH =
 const CANDIDATE_CARD_WIDTH =
   (GROUP_CARD_WIDTH - GROUP_PADDING * 2 - GROUP_CARD_GAP * 2) / 3;
 const CANDIDATE_ART_HEIGHT = CANDIDATE_CARD_WIDTH * (248 / 160);
-const CANDIDATE_META_HEIGHT = 27;
 const CANDIDATE_GROUP_HEIGHT =
-  GROUP_TITLE_HEIGHT + CANDIDATE_ART_HEIGHT + CANDIDATE_META_HEIGHT + 24;
+  GROUP_TITLE_HEIGHT + CANDIDATE_ART_HEIGHT + 24;
 
 const POOL_COLUMNS = 10;
 const POOL_GAP = 10;
 const POOL_CARD_WIDTH =
   (CONTENT_WIDTH - POOL_GAP * (POOL_COLUMNS - 1)) / POOL_COLUMNS;
 const POOL_ART_HEIGHT = POOL_CARD_WIDTH * (248 / 160);
-const POOL_META_HEIGHT = 28;
-const POOL_CARD_HEIGHT = POOL_ART_HEIGHT + POOL_META_HEIGHT;
+const POOL_CARD_HEIGHT = POOL_ART_HEIGHT;
 
 const COLORS = {
   background: '#f4efe4',
@@ -32,7 +29,6 @@ const COLORS = {
   primary: '#315b50',
   secondary: '#886b35',
   text: '#222720',
-  muted: '#6f756c',
   divider: '#d6cdbb',
   support: '#a8392f',
   orange: '#9a7228',
@@ -47,19 +43,16 @@ export interface RoundShareImageInput {
   roundType: RoundType;
   season: number | null;
   sets: [string[], string[], string[]];
+  recommendedSetIndex: number;
   heroes: string[];
   skills: string[];
   supportHero?: string | null;
   supportSkills?: string[];
   rosterScore: number;
-  heroMetadata?: Record<string, HeroMeta> | null;
-  skillMetadata?: Record<string, SkillMeta> | null;
 }
 
 interface ShareCard {
   name: string;
-  kind: GameAssetKind;
-  ranking: string;
   support: boolean;
   quality: GameAssetQuality | null;
   assetPath: string | null;
@@ -72,6 +65,12 @@ interface RoundShareLayout {
 }
 
 const uniqueItems = (items: string[]): string[] => [...new Set(items)];
+
+export const getRoundShareGroupTitle = (
+  groupIndex: number,
+  recommendedSetIndex: number
+): string =>
+  `第 ${groupIndex + 1} 组${groupIndex === recommendedSetIndex ? ' · AI 推荐' : ''}`;
 
 const poolRows = (count: number): number => Math.max(1, Math.ceil(count / POOL_COLUMNS));
 
@@ -91,8 +90,8 @@ export const getRoundShareImageLayout = (
   const skillRows = poolRows(skillCount);
   const height = Math.ceil(
     40 + // top padding
-      78 + // title and badges
-      46 + // candidate section title
+      38 + // round and season badges
+      24 + // gap before candidate groups
       CANDIDATE_GROUP_HEIGHT +
       42 + // gap before roster
       50 + // roster title
@@ -111,14 +110,11 @@ export const getRoundShareImageLayout = (
 const makeShareCard = (
   name: string,
   kind: GameAssetKind,
-  ranking: string,
   support: boolean
 ): ShareCard => {
   const asset = getGameAsset(name, kind);
   return {
     name,
-    kind,
-    ranking,
     support,
     quality: asset?.quality ?? null,
     assetPath: asset?.path ?? null,
@@ -242,7 +238,6 @@ const drawShareCard = (
   y: number,
   width: number,
   artHeight: number,
-  metaHeight: number,
   nameFontSize: number
 ) => {
   context.save();
@@ -297,15 +292,6 @@ const drawShareCard = (
     card.quality === 'purple' ? COLORS.purple : COLORS.orange;
   context.lineWidth = 2;
   context.stroke();
-  context.fillStyle = COLORS.muted;
-  context.font = `600 ${Math.max(14, nameFontSize - 3)}px ${UI_FONT}`;
-  context.textAlign = 'center';
-  context.textBaseline = 'middle';
-  context.fillText(
-    fitText(context, card.ranking || (card.kind === 'hero' ? '武将' : '战法'), width),
-    x + width / 2,
-    y + artHeight + metaHeight / 2
-  );
   context.restore();
 };
 
@@ -326,7 +312,6 @@ const drawPoolGrid = (
       y + row * (POOL_CARD_HEIGHT + POOL_GAP),
       POOL_CARD_WIDTH,
       POOL_ART_HEIGHT,
-      POOL_META_HEIGHT,
       18
     );
   });
@@ -347,15 +332,20 @@ const canvasToPng = (canvas: HTMLCanvasElement): Promise<Blob> =>
 export async function renderRoundShareImage(
   input: RoundShareImageInput
 ): Promise<Blob> {
+  if (
+    !Number.isInteger(input.recommendedSetIndex) ||
+    input.recommendedSetIndex < 0 ||
+    input.recommendedSetIndex >= input.sets.length
+  ) {
+    throw new Error('AI 推荐组无效，无法生成分享图片');
+  }
+
   const supportSkills = new Set(input.supportSkills ?? []);
   const candidateCards = input.sets.flatMap((set) =>
     set.map((name) =>
       makeShareCard(
         name,
         input.roundType === 'hero' ? 'hero' : 'tactic',
-        input.roundType === 'hero'
-          ? formatHeroRanking(input.heroMetadata?.[name])
-          : formatSkillRanking(input.skillMetadata?.[name]),
         false
       )
     )
@@ -364,23 +354,13 @@ export async function renderRoundShareImage(
     ...(input.supportHero ? [input.supportHero] : []),
     ...input.heroes,
   ]).map((name) =>
-    makeShareCard(
-      name,
-      'hero',
-      formatHeroRanking(input.heroMetadata?.[name]),
-      name === input.supportHero
-    )
+    makeShareCard(name, 'hero', name === input.supportHero)
   );
   const skillCards = uniqueItems([
     ...(input.supportSkills ?? []),
     ...input.skills,
   ]).map((name) =>
-    makeShareCard(
-      name,
-      'tactic',
-      formatSkillRanking(input.skillMetadata?.[name]),
-      supportSkills.has(name)
-    )
+    makeShareCard(name, 'tactic', supportSkills.has(name))
   );
   const allCards = [...candidateCards, ...heroCards, ...skillCards];
   const [images] = await Promise.all([
@@ -411,17 +391,12 @@ export async function renderRoundShareImage(
   }
 
   let y = 40;
-  context.fillStyle = COLORS.text;
-  context.font = `800 42px ${TITLE_FONT}`;
-  context.textAlign = 'left';
-  context.textBaseline = 'top';
-  context.fillText('三谋演武 · 本轮选择', OUTER_PADDING, y);
   const typeLabel = input.roundType === 'hero' ? '武将候选' : '战法候选';
   const roundBadgeWidth = drawBadge(
     context,
     `第 ${input.roundNumber} 轮 · ${typeLabel}`,
     OUTER_PADDING,
-    y + 52,
+    y,
     COLORS.primary
   );
   if (input.season !== null) {
@@ -429,17 +404,12 @@ export async function renderRoundShareImage(
       context,
       `S${input.season}`,
       OUTER_PADDING + roundBadgeWidth + 10,
-      y + 52,
+      y,
       COLORS.secondary
     );
   }
 
-  y += 118;
-  context.fillStyle = COLORS.text;
-  context.font = `800 27px ${UI_FONT}`;
-  context.textBaseline = 'top';
-  context.fillText('候选组', OUTER_PADDING, y);
-  y += 46;
+  y += 62;
 
   input.sets.forEach((set, groupIndex) => {
     const groupX = OUTER_PADDING + groupIndex * (GROUP_CARD_WIDTH + GROUP_GAP);
@@ -452,17 +422,18 @@ export async function renderRoundShareImage(
     const groupItemsX = groupX + (GROUP_CARD_WIDTH - groupItemsWidth) / 2;
     context.save();
     roundedRect(context, groupX, y, GROUP_CARD_WIDTH, CANDIDATE_GROUP_HEIGHT, 10);
+    const isRecommended = groupIndex === input.recommendedSetIndex;
     context.fillStyle = COLORS.paper;
     context.fill();
-    context.strokeStyle = COLORS.divider;
-    context.lineWidth = 2;
+    context.strokeStyle = isRecommended ? COLORS.primary : COLORS.divider;
+    context.lineWidth = isRecommended ? 3 : 2;
     context.stroke();
-    context.fillStyle = COLORS.text;
+    context.fillStyle = isRecommended ? COLORS.primary : COLORS.text;
     context.font = `800 23px ${TITLE_FONT}`;
     context.textAlign = 'center';
     context.textBaseline = 'middle';
     context.fillText(
-      `第 ${groupIndex + 1} 组  (${set.length}/${set.length})`,
+      getRoundShareGroupTitle(groupIndex, input.recommendedSetIndex),
       groupX + GROUP_CARD_WIDTH / 2,
       y + GROUP_TITLE_HEIGHT / 2 + 3
     );
@@ -478,7 +449,6 @@ export async function renderRoundShareImage(
         y + GROUP_TITLE_HEIGHT,
         CANDIDATE_CARD_WIDTH,
         CANDIDATE_ART_HEIGHT,
-        CANDIDATE_META_HEIGHT,
         18
       );
     });


### PR DESCRIPTION
## Intent

Simplify the PNG pasted by the ‘复制给微信好友’ action so it focuses on the useful round state. Remove the ‘三谋演武 · 本轮选择’ title, the ‘候选组’ heading, candidate completion counts such as ‘(3/3)’ or ‘(2/2)’, and the entire guide-tier metadata strip under both hero and tactic cards, including ‘档’ and S/A/B labels. Keep the round and season badges, compact the reclaimed space, and clearly mark one candidate group as ‘第 N 组 · AI 推荐’ with stronger visual emphasis. Guarantee that recommendation even when the player has not clicked ‘获取 AI 推荐’: reuse a current recommendation when available, otherwise run the same deterministic recommendation engine as part of image generation without selecting a group for the player. Preserve the immediate Clipboard API call during the user gesture by supplying it the pending recommendation-and-render promise, and retain existing fallback preview, download, native-share, cancellation, roster score, support markers, and clipboard behavior. Update focused unit coverage and documentation, run all required web checks, and visually inspect the generated PNG.

## What Changed

- Compact round-share PNGs by removing redundant headings, completion counts, and guide-tier strips while retaining round/season badges, roster score, cards, and support markers.
- Emphasize exactly one candidate as `第 N 组 · AI 推荐`, reusing a current roster-matching recommendation or computing one solely for export without selecting it for the player.
- Keep the Clipboard API gesture-bound by passing it the pending recommendation-and-render promise, preserve existing share fallbacks, and update focused tests and documentation.

## Risk Assessment

✅ Low: The change is well-bounded, preserves the existing sharing fallbacks and clipboard flow, and source inspection shows the simplified image and deterministic recommendation behavior conform to the stated intent.

## Testing

No pre-supplied baseline results were present; focused unit checks, all required web typecheck/test/e2e/build gates, visual audit, and an end-user clipboard-fallback flow completed successfully. The inspected 1200×1064 PNG automatically recommended the same group as the later on-screen analysis, retained badges, score, cards and support markers, and removed the requested headings, completion counts and guide-tier strips.

- Evidence: Generated round-share PNG with automatic AI recommendation and support markers (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1BDPA6H6NENNWCV3Z4TRB8M/round-share-with-support.png</code>)
- Evidence: On-screen AI recommendation for the same candidate offers (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1BDPA6H6NENNWCV3Z4TRB8M/onscreen-ai-recommendation.png</code>)
<details>
<summary>Evidence: End-to-end round-share verification metadata</summary>

```text
{
  "flow": "seeded round 7 with support cards; clicked 复制给微信好友 before 获取 AI 推荐; fallback preview downloaded PNG; then requested on-screen analysis",
  "clipboardAvailable": false,
  "fallbackDialogVisible": true,
  "suggestedFilename": "sanmou-round-7.png",
  "png": {
    "width": 1200,
    "height": 1064,
    "bytes": 1425980
  },
  "supportHero": "张昭",
  "supportSkills": [
    "克敌如风",
    "兵贵神速"
  ],
  "offeredSets": [
    [
      "卞夫人",
      "曹丕"
    ],
    [
      "高顺",
      "凌统"
    ],
    [
      "诸葛亮2",
      "张春华"
    ]
  ],
  "onScreenRecommendedSetIndex": 2,
  "onScreenRecommendedSet": [
    "诸葛亮2",
    "张春华"
  ],
  "pageErrors": []
}
```
</details>
<details>
<summary>Evidence: Responsive visual-audit diagnostics</summary>

```text
[
  {
    "name": "desktop--advisor",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:演武配将与战法推荐",
      "H2:初始武将 (0/4)还需 4 名",
      "H2:初始战法 (0/8)还需 8 个"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--analytics",
    "errors": [],
    "title": "三国谋定天下演武数据与武将战法排行｜演武参谋",
    "headings": [
      "H1:数据洞察",
      "H2:匿名选项统计",
      "H3:游戏最常提供",
      "H3:玩家最常选择",
      "H2:历史战报分析",
      "H3:三步看懂这些数字",
      "H3:只看我关心的武将和战法",
      "H3:先看谁更值得选",
      "H3:再看哪些搭配效果好",
      "H3:看看大家常用什么",
      "H3:数据与算法说明选看内容：了解这些推荐有多可靠，不影响日常挑人挑战法。"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--team-builder",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 0 名武将、0 个战法；支援选择也会进入仓库",
      "H2:还没有可编排的卡池"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--contribute",
    "errors": [],
    "title": "上传三国谋定天下演武战报｜演武参谋",
    "headings": [
      "H1:上传战报",
      "H2:四步完成上传",
      "H2:准备 DeepSeek 提示词",
      "H2:填写并确认战报",
      "H3:手动确认双方阵容",
      "H3:确认阵容 1",
      "H3:确认阵容 2"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--contributors",
    "errors": [],
    "title": "三国谋定天下演武战报贡献榜｜演武参谋",
    "headings": [
      "H1:战报贡献榜",
      "H2:贡献者排名"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--guide",
    "errors": [],
    "title": "三国谋定天下演武武将战法排行与强队攻略｜演武参谋",
    "headings": [
      "H1:三国谋定天下演武武将、战法与阵容指南",
      "H2:国家武将排行榜",
      "H3:魏国",
      "H3:蜀国",
      "H3:吴国",
      "H3:群雄",
      "H2:战法排行榜",
      "H3:兵刃",
      "H3:谋略",
      "H3:治疗",
      "H3:防御",
      "H3:辅助",
      "H3:文武",
      "H2:强队阵容",
      "H2:阵容克制查询",
      "H2:阵容解析",
      "H3:司马懿",
      "H3:祝融"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--not-found",
    "errors": [],
    "title": "页面未找到｜演武参谋",
    "headings": [
      "H1:页面未找到"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--advisor",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:演武配将与战法推荐",
      "H2:初始武将 (0/4)还需 4 名",
      "H2:初始战法 (0/8)还需 8 个"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--analytics",
    "errors": [],
    "title": "三国谋定天下演武数据与武将战法排行｜演武参谋",
    "headings": [
      "H1:数据洞察",
      "H2:匿名选项统计",
      "H3:游戏最常提供",
      "H3:玩家最常选择",
      "H2:历史战报分析",
      "H3:三步看懂这些数字",
      "H3:只看我关心的武将和战法",
      "H3:先看谁更值得选",
      "H3:再看哪些搭配效果好",
      "H3:看看大家常用什么",
      "H3:数据与算法说明选看内容：了解这些推荐有多可靠，不影响日常挑人挑战法。"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--team-builder",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 0 名武将、0 个战法；支援选择也会进入仓库",
      "H2:还没有可编排的卡池"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--contribute",
    "errors": [],
    "title": "上传三国谋定天下演武战报｜演武参谋",
    "headings": [
      "H1:上传战报",
      "H2:四步完成上传",
      "H2:准备 DeepSeek 提示词",
      "H2:填写并确认战报",
      "H3:手动确认双方阵容",
      "H3:确认阵容 1",
      "H3:确认阵容 2"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--contributors",
    "errors": [],
    "title": "三国谋定天下演武战报贡献榜｜演武参谋",
    "headings": [
      "H1:战报贡献榜",
      "H2:贡献者排名"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--guide",
    "errors": [],
    "title": "三国谋定天下演武武将战法排行与强队攻略｜演武参谋",
    "headings": [
      "H1:三国谋定天下演武武将、战法与阵容指南",
      "H2:国家武将排行榜",
      "H3:魏国",
      "H3:蜀国",
      "H3:吴国",
      "H3:群雄",
      "H2:战法排行榜",
      "H3:兵刃",
      "H3:谋略",
      "H3:治疗",
      "H3:防御",
      "H3:辅助",
      "H3:文武",
      "H2:强队阵容",
      "H2:阵容克制查询",
      "H2:阵容解析",
      "H3:司马懿",
      "H3:祝融"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "tablet--not-found",
    "errors": [],
    "title": "页面未找到｜演武参谋",
    "headings": [
      "H1:页面未找到"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--advisor",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:演武配将与战法推荐",
      "H2:初始武将 (0/4)还需 4 名",
      "H2:初始战法 (0/8)还需 8 个"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--analytics",
    "errors": [],
    "title": "三国谋定天下演武数据与武将战法排行｜演武参谋",
    "headings": [
      "H1:数据洞察",
      "H2:匿名选项统计",
      "H3:游戏最常提供",
      "H3:玩家最常选择",
      "H2:历史战报分析",
      "H3:三步看懂这些数字",
      "H3:只看我关心的武将和战法",
      "H3:先看谁更值得选",
      "H3:再看哪些搭配效果好",
      "H3:看看大家常用什么",
      "H3:数据与算法说明选看内容：了解这些推荐有多可靠，不影响日常挑人挑战法。"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--team-builder",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 0 名武将、0 个战法；支援选择也会进入仓库",
      "H2:还没有可编排的卡池"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--contribute",
    "errors": [],
    "title": "上传三国谋定天下演武战报｜演武参谋",
    "headings": [
      "H1:上传战报",
      "H2:四步完成上传",
      "H2:准备 DeepSeek 提示词",
      "H2:填写并确认战报",
      "H3:手动确认双方阵容",
      "H3:确认阵容 1",
      "H3:确认阵容 2"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--contributors",
    "errors": [],
    "title": "三国谋定天下演武战报贡献榜｜演武参谋",
    "headings": [
      "H1:战报贡献榜",
      "H2:贡献者排名"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--guide",
    "errors": [],
    "title": "三国谋定天下演武武将战法排行与强队攻略｜演武参谋",
    "headings": [
      "H1:三国谋定天下演武武将、战法与阵容指南",
      "H2:国家武将排行榜",
      "H3:魏国",
      "H3:蜀国",
      "H3:吴国",
      "H3:群雄",
      "H2:战法排行榜",
      "H3:兵刃",
      "H3:谋略",
      "H3:治疗",
      "H3:防御",
      "H3:辅助",
      "H3:文武",
      "H2:强队阵容",
      "H2:阵容克制查询",
      "H2:阵容解析",
      "H3:司马懿",
      "H3:祝融"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--not-found",
    "errors": [],
    "title": "页面未找到｜演武参谋",
    "headings": [
      "H1:页面未找到"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--round-recommendation",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:第 1 轮：选择武将",
      "H2:当前阵容",
      "H2:本轮选择",
      "H3:第 1 组 (3/3)",
      "H3:第 2 组 (3/3)",
      "H3:第 3 组 (3/3)",
      "H2:本轮阵容方向",
      "H2:AI 推荐"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--round-recommendation",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:第 1 轮：选择武将",
      "H2:本轮选择",
      "H3:第 1 组 (3/3)",
      "H3:第 2 组 (3/3)",
      "H3:第 3 组 (3/3)",
      "H2:本轮阵容方向",
      "H2:AI 推荐"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--round-roster-expanded",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:第 1 轮：选择武将",
      "H2:当前阵容",
      "H2:本轮选择",
      "H3:第 1 组 (3/3)",
      "H3:第 2 组 (3/3)",
      "H3:第 3 组 (3/3)",
      "H2:本轮阵容方向",
      "H2:AI 推荐"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--qualification-interstitial",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:第 7 轮：选择武将",
      "H2:整军再战",
      "H2:当前阵容"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--team-builder-populated",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 9 名武将、18 个战法；支援选择也会进入仓库",
      "H2:我的比赛阵容",
      "H3:队伍 1",
      "H3:队伍 2",
      "H3:队伍 3",
      "H2:卡池仓库",
      "H3:武将仓库",
      "H3:战法仓库"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--team-builder-tactic-quality",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 1 名武将、2 个战法；支援选择也会进入仓库",
      "H2:我的比赛阵容",
      "H3:队伍 1",
      "H3:队伍 2",
      "H3:队伍 3",
      "H2:卡池仓库",
      "H3:武将仓库",
      "H3:战法仓库"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--team-builder-relationship-detail",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 1 名武将、2 个战法；支援选择也会进入仓库",
      "H2:我的比赛阵容",
      "H3:队伍 1",
      "H3:队伍 2",
      "H3:队伍 3",
      "H2:卡池仓库",
      "H3:武将仓库",
      "H3:战法仓库",
      "H2:如沐春风 × 忘私相助"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile-320--team-builder-tactic-swap",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 1 名武将、2 个战法；支援选择也会进入仓库",
      "H2:我的比赛阵容",
      "H3:队伍 1",
      "H3:队伍 2",
      "H3:队伍 3",
      "H2:卡池仓库",
      "H3:武将仓库",
      "H3:战法仓库"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--team-builder-loading",
    "errors": [],
    "title": "三国谋定天下演武三队编排｜演武参谋",
    "headings": [
      "H1:队伍策案",
      "H2:调整参赛卡池当前 9 名武将、18 个战法；支援选择也会进入仓库"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--completed-game",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:对局完成",
      "H2:当前阵容"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "mobile--discussion-dialog",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:演武配将与战法推荐",
      "H2:初始武将 (0/4)还需 4 名",
      "H2:初始战法 (0/8)还需 8 个",
      "H2:加演武讨论群"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--support-hero-dialog",
    "errors": [],
    "title": "三国谋定天下演武配将与战法推荐｜演武参谋",
    "headings": [
      "H1:第 1 轮：选择武将",
      "H2:当前阵容",
      "H2:本轮选择",
      "H3:第 1 组 (3/3)",
      "H3:第 2 组 (3/3)",
      "H3:第 3 组 (3/3)",
      "H2:推荐支援武将"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--leaderboard-loading",
    "errors": [],
    "title": "三国谋定天下演武战报贡献榜｜演武参谋",
    "headings": [
      "H1:战报贡献榜",
      "H2:贡献者排名"
    ],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  },
  {
    "name": "desktop--route-loading",
    "errors": [],
    "title": "三国谋定天下演武数据与武将战法排行｜演武参谋",
    "headings": [],
    "horizontalOverflow": 0,
    "darkSurfaces": []
  }
]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f6e2f72ebb5217bb5ab7cef3c80740a347fc8d82","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd web && pnpm exec vitest run src/components/game/__tests__/GameBoard.test.tsx src/utils/__tests__/roundShareImage.test.ts src/utils/__tests__/clipboard.test.ts`
- `cd web && pnpm typecheck`
- `cd web && pnpm test`
- `cd web && pnpm exec playwright test tests/gameCardVisuals.spec.js --grep "copies a complete round PNG" --output=/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1BDPA6H6NENNWCV3Z4TRB8M/playwright-round-share`
- <code>Ran a headless Playwright user flow from a seeded round 7 with support cards: clicked `复制给微信好友` before `获取 AI 推荐`, exercised the blocked-clipboard preview and download fallback, then requested on-screen analysis and confirmed the same third candidate group was recommended.</code>
- `cd web && pnpm test:e2e`
- `cd web && pnpm build`
- `cd web && node scripts/capture-visual-audit.mjs /var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1BDPA6H6NENNWCV3Z4TRB8M/visual-audit`
- `Visually inspected the downloaded PNG for compact layout, round/season badges, roster score, support markers, emphasized AI recommendation, and absence of the removed title, candidate completion counts, and tier metadata strips.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
