### PR TITLE
feat(web): embed team builder in the draft flow

### DIFF
--- a/GAME_RULE.md
+++ b/GAME_RULE.md
@@ -27,6 +27,10 @@ and project orientation.
   (each set contains 2 heroes)
 - Round 10: Repeat the Round 8 format — select 1 skill set from 3 options
   (each set contains 3 skills)
+- **Concurrent team building:** During every active round, the player may arrange
+  already-owned heroes and skills below the three offered sets. Automatic
+  allocation starts with the initial 4 heroes and 8 skills, leaves unsupported
+  positions open, and continues as confirmed and support picks expand the pool.
 
 ## Team Formation Rules
 

--- a/GAME_RULE.md
+++ b/GAME_RULE.md
@@ -27,10 +27,6 @@ and project orientation.
   (each set contains 2 heroes)
 - Round 10: Repeat the Round 8 format — select 1 skill set from 3 options
   (each set contains 3 skills)
-- **Concurrent team building:** During every active round, the player may arrange
-  already-owned heroes and skills below the three offered sets. Automatic
-  allocation starts with the initial 4 heroes and 8 skills, leaves unsupported
-  positions open, and continues as confirmed and support picks expand the pool.
 
 ## Team Formation Rules
 

--- a/README.md
+++ b/README.md
@@ -170,10 +170,9 @@ in the browser:
   extension for every exact-guide core so a low raw-weight curated core is
   not pruned. Unsupported heroes and skills stay in the warehouse for manual
   placement instead of being forced into a complete 9-hero/18-skill result.
-  The Team Builder is embedded directly below the three current-round option
-  sets. It starts searching with the opening 4-hero/8-skill pool—there is no
-  minimum inventory threshold—then recomputes as confirmed picks and support
-  items expand the pool while preserving valid player placements.
+  The Team Builder starts searching as soon as the opening pool exists—there
+  is no minimum inventory threshold—then recomputes as confirmed picks and
+  support items expand the pool while preserving valid player placements.
   The deterministic search runs in a client Web Worker, with a yielding
   main-thread fallback and an in-memory result cache, so it adds no Cloudflare
   Function usage and keeps the loading UI responsive. Players can then drag,

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ in the browser:
   extension for every exact-guide core so a low raw-weight curated core is
   not pruned. Unsupported heroes and skills stay in the warehouse for manual
   placement instead of being forced into a complete 9-hero/18-skill result.
+  The Team Builder is embedded directly below the three current-round option
+  sets. It starts searching with the opening 4-hero/8-skill pool—there is no
+  minimum inventory threshold—then recomputes as confirmed picks and support
+  items expand the pool while preserving valid player placements.
   The deterministic search runs in a client Web Worker, with a yielding
   main-thread fallback and an in-memory result cache, so it adds no Cloudflare
   Function usage and keeps the loading UI responsive. Players can then drag,

--- a/agent/README.md
+++ b/agent/README.md
@@ -228,8 +228,8 @@ credentials, and continues to accept local curl/CLI calls that have no
 at startup.
 
 The web integration is a private, hidden experiment. Start this Agent, then
-open `/team-builder?local-agent=1` once to enable and remember the Agent button
-in that browser. Use `/team-builder?local-agent=0` to hide it again. Enabling
+open `/?local-agent=1` once to enable and remember the Agent button in that
+browser. Use `/?local-agent=0` to hide it again. Enabling
 the flag makes no network request; the page contacts `127.0.0.1:8790` only
 after an explicit click on `智能补全阵容` or `智能复盘阵容`.
 

--- a/web/README.md
+++ b/web/README.md
@@ -25,9 +25,10 @@ the model data is generated and community reports are imported.
   analysis. This full guide is the sole UI location for the 飞将吕布 attribution.
 - **Manual Editing**: Edit team composition manually at any time
 - **Team Builder**: Three-team recommendation and accessible editor embedded
-  below every active round's three option sets; it begins with the opening pool
-  and keeps filling as confirmed picks arrive. See [Game Phase](#game-phase)
-  for scoring, controls, and prompt behavior
+  below every active round's three option sets. See [Game Phase](#game-phase)
+  for its placement, controls, and prompt behavior, and the root
+  [Recommendation pipeline](../README.md#recommendation-pipeline) for allocation
+  and scoring policy
 - **Analytics Dashboard**: Player-friendly, question-led analytics — hero/skill model-weight rankings, one responsive six-mode relationship ranking, usage, and optional (collapsed) model diagnostics
 - **Auto-save**: Game progress automatically saved in a versioned,
   non-expiring `localStorage` record; the Team Builder uses its own
@@ -228,21 +229,17 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   highlights the highest as 玩家选择最高 (independently from the AI 推荐 card), and — only when the
   two tops differ by a meaningful margin — shows a short non-causal A/B/C disagreement note
 - **FormationWorkbench**: The draft page's light, paper-game-layout-inspired
-  three-team editor, grouped below the A/B/C option workspace. It starts
-  allocating evidence-qualified pairs, trios, and tactic routes from the opening
-  4-hero/8-skill pool instead of waiting for a complete three-team inventory.
-  The former `/team-builder` URL redirects to `/` and no longer appears in
+  three-team editor, grouped below the A/B/C option workspace. Its allocation
+  and open-slot rules are owned by the root
+  [Recommendation pipeline](../README.md#recommendation-pipeline). The former
+  `/team-builder` URL redirects to `/` and no longer appears in
   navigation or prerendered routes. It keeps prominent, lightly edge-cropped
   local hero portraits in assignments and compact inset hero thumbnails in the repository. Tactics use
   compact text-only rows without card art, generic tactic badges, or visible slot
   numbers; support tactics retain their support marker. Assigned and warehoused
   tactics share database-quality-aware orange- or purple-quality surfaces,
   readable text, dashed assignment boundaries, and state-aware selection and
-  removal controls. An empty card pool shows a focused return-to-draft action
-  instead of the workbench. With a card pool, it seeds the recommendation
-  documented in the root
-  [Recommendation pipeline](../README.md#recommendation-pipeline), leaves
-  unsupported positions blank, keeps live per-team model scores, and supports
+  removal controls. It keeps live per-team model scores and supports
   pointer/touch drag-and-drop plus keyboard and tap-to-place movement. Each
   assignment card is a whole-card hero drag and drop surface while its row,
   tactic, score, and removal controls retain their own interactions. It reserves

--- a/web/README.md
+++ b/web/README.md
@@ -24,9 +24,10 @@ the model data is generated and community reports are imported.
   team library, five championship groups, 13×13 matchup explorer, and workbook
   analysis. This full guide is the sole UI location for the 飞将吕布 attribution.
 - **Manual Editing**: Edit team composition manually at any time
-- **Team Builder**: Three-team recommendation and accessible editor; see
-  [Game Phase](#game-phase) for card-pool prerequisites, scoring, controls, and
-  prompt behavior
+- **Team Builder**: Three-team recommendation and accessible editor embedded
+  below every active round's three option sets; it begins with the opening pool
+  and keeps filling as confirmed picks arrive. See [Game Phase](#game-phase)
+  for scoring, controls, and prompt behavior
 - **Analytics Dashboard**: Player-friendly, question-led analytics — hero/skill model-weight rankings, one responsive six-mode relationship ranking, usage, and optional (collapsed) model diagnostics
 - **Auto-save**: Game progress automatically saved in a versioned,
   non-expiring `localStorage` record; the Team Builder uses its own
@@ -38,8 +39,9 @@ the model data is generated and community reports are imported.
   repair (or direct manual confirmation), strict final validation, current-model
   lineup scores, a separate contribution-season cookie, and a daily static
   contributor leaderboard at `/contributors`
-- **Recommendation debugging**: The draft recommendation and Team Builder
-  pages expose a local, read-only `sanmouDebug()` browser-console export with
+- **Recommendation debugging**: The draft page exposes a local, read-only
+  `sanmouDebug()` browser-console export with both the current option decision
+  and embedded Team Builder context, including
   the current inputs, exact feature weights/evidence, atomic outcome/count/final
   components, decision policy, and compact formation alternatives for
   agent-assisted diagnosis
@@ -225,9 +227,13 @@ in the root [Recommendation pipeline](../README.md#recommendation-pipeline).
   When the gated preference model is available it also labels each card with the 玩家选择概率,
   highlights the highest as 玩家选择最高 (independently from the AI 推荐 card), and — only when the
   two tops differ by a meaningful margin — shows a short non-causal A/B/C disagreement note
-- **FormationWorkbench**: The `/team-builder` page's light, paper-game-layout-inspired
-  three-team editor. It keeps prominent, lightly edge-cropped local hero portraits
-  in assignments and compact inset hero thumbnails in the repository. Tactics use
+- **FormationWorkbench**: The draft page's light, paper-game-layout-inspired
+  three-team editor, grouped below the A/B/C option workspace. It starts
+  allocating evidence-qualified pairs, trios, and tactic routes from the opening
+  4-hero/8-skill pool instead of waiting for a complete three-team inventory.
+  The former `/team-builder` URL redirects to `/` and no longer appears in
+  navigation or prerendered routes. It keeps prominent, lightly edge-cropped
+  local hero portraits in assignments and compact inset hero thumbnails in the repository. Tactics use
   compact text-only rows without card art, generic tactic badges, or visible slot
   numbers; support tactics retain their support marker. Assigned and warehoused
   tactics share database-quality-aware orange- or purple-quality surfaces,
@@ -421,8 +427,10 @@ Game progress is automatically saved in a versioned `gameProgress`
 
 Malformed records and records with an unsupported version are ignored. The
 legacy `gameProgress` cookie is intentionally not migrated or restored. The
-merged `/team-builder` arrangement uses a versioned, pool-keyed `teamBuilder`
-`localStorage` record. Legacy `teamBuilder` cookies are migrated,
+embedded Team Builder arrangement uses a versioned, pool-keyed `teamBuilder`
+`localStorage` record. Valid placements survive pool growth and
+are merged with newly available recommendation slots. Legacy `teamBuilder`
+cookies are migrated,
 and legacy unversioned arrangement arrays are normalized on first use, while
 stale heroes, tactics, formations, and duplicate assignments are discarded.
 Resetting game progress also clears this arrangement.
@@ -603,8 +611,8 @@ and interaction; no runtime Node server is required on Cloudflare Pages.
 
 ### Recommendation debug context
 
-After calculating a draft recommendation or waiting for `/team-builder` to
-finish, open the browser developer console and run:
+After calculating a draft recommendation or waiting for the embedded Team
+Builder to finish, open the browser developer console and run:
 
 ```js
 copy(sanmouDebug())
@@ -615,14 +623,14 @@ pretty-printed JSON, while Chrome DevTools' `copy(...)` helper places it on the
 clipboard. Paste that JSON into an agent together with the result you expected.
 For example: “I expected option A instead of B; explain why B won.”
 
-On the draft page, the export contains the current pool and offers, all three
-ranked scores, every activated model feature, support counts, and the atomic
-outcome coefficient, selection-count adjustment, and final weight where
+On the draft page, the top-level export contains the current pool and offers,
+all three ranked scores, every activated model feature, support counts, and the
+atomic outcome coefficient, selection-count adjustment, and final weight where
 applicable. It also contains the authoritative skill-to-hero route order
 (including the current-pool-order tie-break for equal HS weights) and the
-separately labelled player-choice prediction. On Team Builder, the same atomic
-components accompany `H` and `S` evidence gates; interactions remain
-outcome-only. It also contains relevant guide routes and the selected
+separately labelled player-choice prediction. Its `team_builder` field contains
+Team Builder's atomic components for `H` and `S` evidence gates; interactions
+remain outcome-only. It also contains relevant guide routes and the selected
 teams' complete score rows, unplaced-item diagnostics, the original recommendation
 versus the edited layout, and a compact winner/runner-up optimiser trace. Each
 traced guide decision reports global matched-slot cardinality, guide priority and

--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -1,0 +1,1 @@
+/team-builder / 301

--- a/web/scripts/capture-visual-audit.mjs
+++ b/web/scripts/capture-visual-audit.mjs
@@ -14,7 +14,6 @@ const assetManifest = JSON.parse(
 const routes = [
   ['advisor', '/'],
   ['analytics', '/analytics'],
-  ['team-builder', '/team-builder'],
   ['contribute', '/contribute'],
   ['contributors', '/contributors'],
   ['guide', '/guides/yanwu'],
@@ -202,7 +201,7 @@ try {
 
   await capture(browser, {
     name: 'desktop--team-builder-populated',
-    route: '/team-builder',
+    route: '/',
     viewport: viewports.desktop,
     seed: progress({ ...lateState, round7_interstitial_dismissed: true }),
     prepare: async (page) => {
@@ -224,12 +223,13 @@ try {
   qualityLayout[0].heroes[0].skills = [...qualitySkills];
   await capture(browser, {
     name: 'desktop--team-builder-tactic-quality',
-    route: '/team-builder',
+    route: '/',
     viewport: viewports.desktop,
     seed: progress({
       ...lateState,
       current_heroes: [qualityHero],
       current_skills: qualitySkills,
+      round7_interstitial_dismissed: true,
     }),
     teamBuilderLayout: {
       heroes: [qualityHero],
@@ -237,19 +237,20 @@ try {
       layout: qualityLayout,
     },
     prepare: async (page) => {
-      await page.locator('[data-skill-quality="orange"]').waitFor();
-      await page.locator('[data-skill-quality="purple"]').waitFor();
+      await page.getByTestId('skill-slot-0-0-0').waitFor({ timeout: 30000 });
+      await page.getByTestId('skill-slot-0-0-1').waitFor({ timeout: 30000 });
     },
   });
 
   await capture(browser, {
     name: 'desktop--team-builder-relationship-detail',
-    route: '/team-builder',
+    route: '/',
     viewport: viewports.desktop,
     seed: progress({
       ...lateState,
       current_heroes: [qualityHero],
       current_skills: qualitySkills,
+      round7_interstitial_dismissed: true,
     }),
     teamBuilderLayout: {
       heroes: [qualityHero],
@@ -272,12 +273,13 @@ try {
 
   await capture(browser, {
     name: 'mobile-320--team-builder-tactic-swap',
-    route: '/team-builder',
+    route: '/',
     viewport: { width: 320, height: 844 },
     seed: progress({
       ...lateState,
       current_heroes: [qualityHero],
       current_skills: qualitySkills,
+      round7_interstitial_dismissed: true,
     }),
     teamBuilderLayout: {
       heroes: [qualityHero],
@@ -314,7 +316,7 @@ try {
     await teamWorkerGate;
     await route.continue();
   });
-  const teamNavigation = teamLoadingPage.goto(`${baseURL}/team-builder`, { waitUntil: 'domcontentloaded' });
+  const teamNavigation = teamLoadingPage.goto(`${baseURL}/`, { waitUntil: 'domcontentloaded' });
   await teamLoadingPage.getByTestId('game-loading-panel').waitFor();
   await teamLoadingPage.screenshot({ path: path.join(outputDir, 'desktop--team-builder-loading.png'), fullPage: true });
   await inspectPage(teamLoadingPage, 'desktop--team-builder-loading', teamLoadingErrors);

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { describe, expect, test, vi } from 'vitest';
+import type { RouteComponents } from './routeComponents';
+
+vi.mock('./context/GameContext', () => ({
+  GameProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('./components/layout/AppLayout', () => ({
+  default: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('./seo/RouteSeo', () => ({ default: () => null }));
+vi.mock('./pages/GameAdvisor', () => ({ default: () => <div>draft</div> }));
+
+import App from './App';
+
+const EmptyRoute = () => null;
+const routeComponents: RouteComponents = {
+  Analytics: EmptyRoute,
+  Contribute: EmptyRoute,
+  Contributors: EmptyRoute,
+  YanwuGuide: EmptyRoute,
+  NotFound: EmptyRoute,
+};
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return (
+    <output data-testid="location">
+      {location.pathname}
+      {location.search}
+    </output>
+  );
+};
+
+describe('legacy Team Builder route', () => {
+  test.each(['?local-agent=1', '?local-agent=0'])(
+    'redirects to the embedded builder while preserving %s',
+    async (search) => {
+      render(
+        <MemoryRouter initialEntries={[`/team-builder${search}`]}>
+          <App routeComponents={routeComponents} />
+          <LocationProbe />
+        </MemoryRouter>
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent(`/${search}`)
+      );
+      expect(screen.getByText('draft')).toBeVisible();
+    }
+  );
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect } from 'react';
-import { Navigate, Routes, Route } from 'react-router-dom';
+import { Navigate, Routes, Route, useLocation } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material';
 import { theme } from './theme/theme';
@@ -35,6 +35,11 @@ const HydrationCurtainDismissal = () => {
   return null;
 };
 
+const LegacyTeamBuilderRedirect = () => {
+  const { search } = useLocation();
+  return <Navigate to={{ pathname: '/', search }} replace />;
+};
+
 function App({ databaseItems, routeComponents }: AppProps) {
   const {
     Analytics,
@@ -62,7 +67,7 @@ function App({ databaseItems, routeComponents }: AppProps) {
               <Routes>
                 <Route path="/" element={<GameAdvisor />} />
                 <Route path="/analytics" element={<Analytics />} />
-                <Route path="/team-builder" element={<Navigate to="/" replace />} />
+                <Route path="/team-builder" element={<LegacyTeamBuilderRedirect />} />
                 <Route path="/contribute" element={<Contribute />} />
                 <Route path="/contributors" element={<Contributors />} />
                 <Route path="/guides/yanwu" element={<YanwuGuide />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Navigate, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material';
 import { theme } from './theme/theme';
@@ -38,7 +38,6 @@ const HydrationCurtainDismissal = () => {
 function App({ databaseItems, routeComponents }: AppProps) {
   const {
     Analytics,
-    TeamBuilder,
     Contribute,
     Contributors,
     YanwuGuide,
@@ -63,7 +62,7 @@ function App({ databaseItems, routeComponents }: AppProps) {
               <Routes>
                 <Route path="/" element={<GameAdvisor />} />
                 <Route path="/analytics" element={<Analytics />} />
-                <Route path="/team-builder" element={<TeamBuilder />} />
+                <Route path="/team-builder" element={<Navigate to="/" replace />} />
                 <Route path="/contribute" element={<Contribute />} />
                 <Route path="/contributors" element={<Contributors />} />
                 <Route path="/guides/yanwu" element={<YanwuGuide />} />

--- a/web/src/components/game/GameBoard.tsx
+++ b/web/src/components/game/GameBoard.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { Container, Box, Button, Alert, CircularProgress, Typography, Paper, Snackbar } from "@mui/material";
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
@@ -13,6 +21,8 @@ import AnalysisGrid from "./AnalysisGrid";
 import KnownStrongTeams from "./KnownStrongTeams";
 import RoundShareDialog from "./RoundShareDialog";
 import ResponsiveDisclosure from "../common/ResponsiveDisclosure";
+import GameLoadingPanel from '../common/GameLoadingPanel';
+import type { TeamBuilderPanelHandle } from '../teamBuilder/TeamBuilderPanel';
 import { copyImageToClipboard, copyToClipboard } from "../../utils/clipboard";
 import { renderRoundShareImage } from "../../utils/roundShareImage";
 import type { GameState, RoundType, SetName } from "../../types/game";
@@ -26,6 +36,10 @@ import {
   registerSanmouDebugContext,
   SANMOU_DEBUG_SCHEMA,
 } from "../../services/recommendationDebug";
+
+const TeamBuilderPanel = lazy(
+  () => import('../teamBuilder/TeamBuilderPanel')
+);
 
 interface QualificationInterstitialProps {
   roundNumber: 7 | 9;
@@ -174,6 +188,7 @@ const GameBoard = () => {
   const sharePreviewUrlRef = useRef<string | null>(null);
   const shareExportSequenceRef = useRef(0);
   const mountedRef = useRef(false);
+  const teamBuilderRef = useRef<TeamBuilderPanelHandle>(null);
 
   const {
     gameState,
@@ -294,13 +309,17 @@ const GameBoard = () => {
             reason: 'The draft is complete and there is no active candidate recommendation.',
           };
         }
-        return buildRoundRecommendationDebugContext({
+        const roundContext = buildRoundRecommendationDebugContext({
           season: state.selectedSeason,
           gameState,
           roundType: getRoundType(gameState.round_number),
           currentRoundInputs,
           recommendation: currentRecommendation,
         });
+        return {
+          ...roundContext,
+          team_builder: teamBuilderRef.current?.getDebugContext() ?? null,
+        };
       }),
     [
       currentRecommendation,
@@ -849,6 +868,17 @@ const GameBoard = () => {
             </>
           }
         />
+
+        <Suspense
+          fallback={(
+            <GameLoadingPanel
+              label="正在载入队伍策案"
+              detail="正在展开武将与战法仓库…"
+            />
+          )}
+        >
+          <TeamBuilderPanel ref={teamBuilderRef} />
+        </Suspense>
 
         {currentRecommendation && (
           <>

--- a/web/src/components/game/RoundInfo.tsx
+++ b/web/src/components/game/RoundInfo.tsx
@@ -1,6 +1,4 @@
-import { Box, Button, Paper, Typography } from '@mui/material';
-import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
-import { useNavigate } from 'react-router-dom';
+import { Box, Paper, Typography } from '@mui/material';
 import { getRoundType, ROUND_NUMBERS, TOTAL_ROUNDS } from '../../services/gameLogic';
 
 interface RoundInfoProps {
@@ -9,7 +7,6 @@ interface RoundInfoProps {
 
 /** Game-board progress modelled after Yanwu's linked campaign plaques. */
 const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
-  const navigate = useNavigate();
   const roundType = getRoundType(roundNumber);
   const typeLabel = roundType === 'hero' ? '武将' : '战法';
   const roundTitle = `第 ${roundNumber} 轮：选择${typeLabel}`;
@@ -62,18 +59,7 @@ const RoundInfo = ({ roundNumber }: RoundInfoProps) => {
             第 {roundNumber} 轮 · {typeLabel}
           </Typography>
         </Box>
-        {roundNumber > 3 && (
-          <Button
-            variant="outlined"
-            color="secondary"
-            size="small"
-            startIcon={<AccountTreeOutlinedIcon />}
-            onClick={() => navigate('/team-builder')}
-            sx={{ flexShrink: 0 }}
-          >
-            队伍推荐
-          </Button>
-        )}
+
       </Box>
 
       <Box

--- a/web/src/components/game/__tests__/GameBoard.test.tsx
+++ b/web/src/components/game/__tests__/GameBoard.test.tsx
@@ -77,6 +77,9 @@ vi.mock('../RecommendationPanel', () => ({ default: () => <div /> }));
 vi.mock('../../common/ResponsiveDisclosure', () => ({
   default: ({ children }: { children: ReactNode }) => children,
 }));
+vi.mock('../../teamBuilder/TeamBuilderPanel', () => ({
+  default: () => <div data-testid="team-builder-panel" />,
+}));
 vi.mock('../../../services/recommendationDebug', () => ({
   SANMOU_DEBUG_SCHEMA: 'test',
   buildRoundRecommendationDebugContext: vi.fn(() => ({})),

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -12,7 +12,6 @@ const AppLayout = ({ children }: AppLayoutProps) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { state, dispatch } = useGame();
-  const roundNumber = state.gameState?.round_number || 0;
 
   const handleResetProgress = () => {
     if (window.confirm('确定要重置全部进度吗？此操作不可恢复。')) {
@@ -32,7 +31,6 @@ const AppLayout = ({ children }: AppLayoutProps) => {
     >
       <Header
         currentPath={location.pathname}
-        teamBuilderUnlocked={roundNumber > 3}
         hasProgress={Boolean(state.gameState)}
         onResetProgress={handleResetProgress}
       />

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -10,7 +10,6 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
 import EmojiEventsOutlinedIcon from '@mui/icons-material/EmojiEventsOutlined';
 import MenuBookOutlinedIcon from '@mui/icons-material/MenuBookOutlined';
 import MenuOutlinedIcon from '@mui/icons-material/MenuOutlined';
@@ -25,7 +24,6 @@ import JoinGroupButton from './JoinGroupButton';
 
 interface HeaderProps {
   currentPath: string;
-  teamBuilderUnlocked: boolean;
   hasProgress: boolean;
   onResetProgress: () => void;
 }
@@ -82,7 +80,6 @@ const RailNavItem = ({ path, label, icon, currentPath }: NavItemProps) => {
 
 const Header = ({
   currentPath,
-  teamBuilderUnlocked,
   hasProgress,
   onResetProgress,
 }: HeaderProps) => {
@@ -184,9 +181,6 @@ const Header = ({
         sx={{ display: { xs: 'none', md: 'flex' }, width: '100%', flexDirection: 'column', flex: 1 }}
       >
         <RailNavItem path="/" label="对局推荐" icon={<SportsEsportsOutlinedIcon />} currentPath={currentPath} />
-        {teamBuilderUnlocked && (
-          <RailNavItem path="/team-builder" label="队伍推荐" icon={<AccountTreeOutlinedIcon />} currentPath={currentPath} />
-        )}
         <RailNavItem path="/analytics" label="数据洞察" icon={<QueryStatsOutlinedIcon />} currentPath={currentPath} />
         <RailNavItem path="/guides/yanwu" label="演武攻略" icon={<MenuBookOutlinedIcon />} currentPath={currentPath} />
         <RailNavItem path="/contributors" label="战报贡献榜" icon={<EmojiEventsOutlinedIcon />} currentPath={currentPath} />
@@ -238,11 +232,6 @@ const Header = ({
           <MenuItem component={RouterLink} to="/" aria-current={current('/')} onClick={closeMenu}>
             <ListItemIcon><SportsEsportsOutlinedIcon fontSize="small" /></ListItemIcon><ListItemText>对局推荐</ListItemText>
           </MenuItem>
-          {teamBuilderUnlocked && (
-            <MenuItem component={RouterLink} to="/team-builder" aria-current={current('/team-builder')} onClick={closeMenu}>
-              <ListItemIcon><AccountTreeOutlinedIcon fontSize="small" /></ListItemIcon><ListItemText>队伍推荐</ListItemText>
-            </MenuItem>
-          )}
           <MenuItem component={RouterLink} to="/analytics" aria-current={current('/analytics')} onClick={closeMenu}>
             <ListItemIcon><QueryStatsOutlinedIcon fontSize="small" /></ListItemIcon><ListItemText>数据洞察</ListItemText>
           </MenuItem>

--- a/web/src/components/teamBuilder/TeamBuilderPanel.tsx
+++ b/web/src/components/teamBuilder/TeamBuilderPanel.tsx
@@ -219,16 +219,14 @@ const TeamBuilderPanel = forwardRef<TeamBuilderPanelHandle>((_, ref) => {
       formations: FORMATIONS,
     });
     const savedMatchesPool =
+      normalized.storedPoolKey === poolKey ||
       normalized.hasAssignments ||
-      (normalized.hasFormation && normalized.storedPoolKey === poolKey);
+      normalized.hasFormation;
 
     if (savedMatchesPool) {
       setLayout(normalized.layout);
       seededPoolKeyRef.current =
-        normalized.storedPoolKey === null ||
-        normalized.storedPoolKey === poolKey
-          ? poolKey
-          : null;
+        normalized.recommendationPoolKey === poolKey ? poolKey : null;
     } else {
       setLayout(createEmptyTeamBuilderLayout());
       seededPoolKeyRef.current = null;
@@ -241,7 +239,9 @@ const TeamBuilderPanel = forwardRef<TeamBuilderPanelHandle>((_, ref) => {
 
   useEffect(() => {
     if (hydratedKey !== poolKey) return;
-    storage.saveTeamBuilder(createStoredTeamBuilderLayout(poolKey, layout));
+    storage.saveTeamBuilder(
+      createStoredTeamBuilderLayout(poolKey, seededPoolKeyRef.current, layout)
+    );
   }, [hydratedKey, layout, poolKey]);
 
   useEffect(
@@ -269,9 +269,7 @@ const TeamBuilderPanel = forwardRef<TeamBuilderPanelHandle>((_, ref) => {
       if (bestOption && seededPoolKeyRef.current !== poolKey) {
         const recommended = layoutFromFormation(bestOption);
         setLayout((current) =>
-          teamBuilderLayoutHasHero(current)
-            ? mergeTeamBuilderRecommendation(current, recommended)
-            : recommended
+          mergeTeamBuilderRecommendation(current, recommended)
         );
         seededPoolKeyRef.current = poolKey;
       }

--- a/web/src/components/teamBuilder/TeamBuilderPanel.tsx
+++ b/web/src/components/teamBuilder/TeamBuilderPanel.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
   Alert,
   Box,
   Button,
   CircularProgress,
-  Container,
   IconButton,
   Popover,
   Snackbar,
@@ -15,47 +18,42 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AutoAwesomeOutlinedIcon from '@mui/icons-material/AutoAwesomeOutlined';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
 import RestartAltOutlinedIcon from '@mui/icons-material/RestartAltOutlined';
-import CurrentTeam from '../components/game/CurrentTeam';
-import FormationWorkbench from '../components/teamBuilder/FormationWorkbench';
+import FormationWorkbench from './FormationWorkbench';
 import AgentReviewPanel, {
   type TeamAgentRunMode,
-} from '../components/teamBuilder/AgentReviewPanel';
-import GameLoadingPanel from '../components/common/GameLoadingPanel';
-import EmptyState from '../components/common/EmptyState';
-import { useGame } from '../context/GameContext';
-import { database, recommendationData } from '../data';
+} from './AgentReviewPanel';
+import GameLoadingPanel from '../common/GameLoadingPanel';
+import { useGame } from '../../context/GameContext';
+import { database, recommendationData } from '../../data';
 import {
   recommendHybridTeamsCooperatively,
   type FormationRecommendation,
   type HeroMeta,
-} from '../services/recommendationEngine';
+} from '../../services/recommendationEngine';
 import {
   getCachedTeamFormation,
   setCachedTeamFormation,
   teamFormationCacheKey,
-} from '../services/teamFormationCache';
+} from '../../services/teamFormationCache';
 import type {
   TeamFormationStage,
   TeamFormationWorkerRequest,
   TeamFormationWorkerResponse,
-} from '../services/teamFormationWorkerProtocol';
-import { generateTeamValidationPrompt } from '../services/promptGenerator';
-import { recordSuccessfulPromptCopy } from '../services/googleAnalytics';
+} from '../../services/teamFormationWorkerProtocol';
+import { generateTeamValidationPrompt } from '../../services/promptGenerator';
+import { recordSuccessfulPromptCopy } from '../../services/googleAnalytics';
 import {
   applyTeamBuilderMove,
   cloneTeamBuilderLayout,
   createEmptyTeamBuilderLayout,
   createStoredTeamBuilderLayout,
   layoutFromFormation,
+  mergeTeamBuilderRecommendation,
   normalizeTeamBuilderLayout,
   teamBuilderLayoutHasHero,
   teamBuilderPoolKey,
@@ -63,12 +61,9 @@ import {
   type TeamBuilderMoveSource,
   type TeamBuilderMoveTarget,
   type TeamBuilderRow,
-} from '../services/teamBuilderArrangement';
-import { summarizeTeamBuilderRecommendation } from '../services/teamBuilderMessaging';
-import {
-  buildTeamFormationDebugContext,
-  registerSanmouDebugContext,
-} from '../services/recommendationDebug';
+} from '../../services/teamBuilderArrangement';
+import { summarizeTeamBuilderRecommendation } from '../../services/teamBuilderMessaging';
+import { buildTeamFormationDebugContext } from '../../services/recommendationDebug';
 import {
   LocalTeamAgentError,
   createTeamAgentRequest,
@@ -78,10 +73,10 @@ import {
   syncLocalTeamAgentExperiment,
   teamBuilderLayoutFingerprint,
   type TeamAgentResult,
-} from '../services/localTeamAgent';
-import { copyToClipboard } from '../utils/clipboard';
-import { storage } from '../utils/storage';
-import { teamBuilderInteractionPolicy } from '../theme/teamBuilderInteractions';
+} from '../../services/localTeamAgent';
+import { copyToClipboard } from '../../utils/clipboard';
+import { storage } from '../../utils/storage';
+import { teamBuilderInteractionPolicy } from '../../theme/teamBuilderInteractions';
 
 const HERO_META: HeroMeta = Object.fromEntries(
   Object.entries(database.heroes || {}).map(([name, hero]) => [
@@ -113,10 +108,13 @@ const sameTeamBuilderLayout = (
     );
   });
 
-const TeamBuilder = () => {
-  const navigate = useNavigate();
-  const { state, dispatch } = useGame();
-  const { gameState, availableHeroes, availableSkills, selectedSeason } = state;
+export interface TeamBuilderPanelHandle {
+  getDebugContext: () => Record<string, unknown>;
+}
+
+const TeamBuilderPanel = forwardRef<TeamBuilderPanelHandle>((_, ref) => {
+  const { state } = useGame();
+  const { gameState, selectedSeason } = state;
   const [formation, setFormation] =
     useState<FormationRecommendation | null>(null);
   const [resultKey, setResultKey] = useState<string | null>(null);
@@ -186,8 +184,7 @@ const TeamBuilder = () => {
       ),
     [poolKey]
   );
-  const isEligible = heroes.length >= 9 && skills.length >= 18;
-  const isPending = isEligible && resultKey !== poolKey;
+  const isPending = resultKey !== poolKey;
   const hasHero = teamBuilderLayoutHasHero(layout);
   const recommendedLayout = useMemo(() => {
     if (
@@ -209,8 +206,11 @@ const TeamBuilder = () => {
     ) {
       return null;
     }
-    return summarizeTeamBuilderRecommendation(formation.options[0].teams);
-  }, [formation, poolKey, resultKey]);
+    return summarizeTeamBuilderRecommendation(formation.options[0].teams, {
+      heroPoolCount: heroes.length,
+      skillPoolCount: skills.length,
+    });
+  }, [formation, heroes.length, poolKey, resultKey, skills.length]);
 
   useEffect(() => {
     const normalized = normalizeTeamBuilderLayout(storage.loadTeamBuilder(), {
@@ -219,14 +219,16 @@ const TeamBuilder = () => {
       formations: FORMATIONS,
     });
     const savedMatchesPool =
-      (normalized.hasAssignments &&
-        (normalized.storedPoolKey === null ||
-          normalized.storedPoolKey === poolKey)) ||
+      normalized.hasAssignments ||
       (normalized.hasFormation && normalized.storedPoolKey === poolKey);
 
     if (savedMatchesPool) {
       setLayout(normalized.layout);
-      seededPoolKeyRef.current = poolKey;
+      seededPoolKeyRef.current =
+        normalized.storedPoolKey === null ||
+        normalized.storedPoolKey === poolKey
+          ? poolKey
+          : null;
     } else {
       setLayout(createEmptyTeamBuilderLayout());
       seededPoolKeyRef.current = null;
@@ -250,11 +252,6 @@ const TeamBuilder = () => {
   );
 
   useEffect(() => {
-    if (!isEligible) {
-      setFormation(null);
-      setResultKey(null);
-      return;
-    }
     if (hydratedKey !== poolKey) return;
 
     let cancelled = false;
@@ -270,7 +267,12 @@ const TeamBuilder = () => {
       const bestOption =
         !result.incomplete ? result.options[0] : undefined;
       if (bestOption && seededPoolKeyRef.current !== poolKey) {
-        setLayout(layoutFromFormation(bestOption));
+        const recommended = layoutFromFormation(bestOption);
+        setLayout((current) =>
+          teamBuilderLayoutHasHero(current)
+            ? mergeTeamBuilderRecommendation(current, recommended)
+            : recommended
+        );
         seededPoolKeyRef.current = poolKey;
       }
     };
@@ -318,7 +320,7 @@ const TeamBuilder = () => {
     setFormationStage('matching');
     try {
       worker = new Worker(
-        new URL('../workers/teamFormation.worker.ts', import.meta.url),
+        new URL('../../workers/teamFormation.worker.ts', import.meta.url),
         { type: 'module' }
       );
       worker.onmessage = ({
@@ -362,22 +364,9 @@ const TeamBuilder = () => {
     formationCacheKey,
     heroes,
     hydratedKey,
-    isEligible,
     poolKey,
     skills,
   ]);
-
-  const handleUpdateTeam = (
-    updatedHeroes: string[],
-    updatedSkills: string[]
-  ) => {
-    if (!gameState) return;
-    dispatch({
-      type: 'UPDATE_TEAM',
-      heroes: updatedHeroes,
-      skills: updatedSkills,
-    });
-  };
 
   const markEdited = () => {
     seededPoolKeyRef.current = poolKey;
@@ -536,9 +525,10 @@ const TeamBuilder = () => {
     recommendedLayout !== null &&
     sameTeamBuilderLayout(layout, recommendedLayout);
 
-  useEffect(
-    () =>
-      registerSanmouDebugContext(() =>
+  useImperativeHandle(
+    ref,
+    () => ({
+      getDebugContext: () =>
         buildTeamFormationDebugContext({
           season: selectedSeason,
           heroes,
@@ -546,17 +536,15 @@ const TeamBuilder = () => {
           supportItems,
           formation,
           resultReady:
-            hydratedKey === poolKey &&
-            (!isEligible || resultKey === poolKey),
+            hydratedKey === poolKey && resultKey === poolKey,
           currentLayout: layout,
           currentLayoutMatchesRecommendation: isSystemRecommendation,
-        })
-      ),
+        }),
+    }),
     [
       formation,
       heroes,
       hydratedKey,
-      isEligible,
       isSystemRecommendation,
       layout,
       poolKey,
@@ -568,46 +556,42 @@ const TeamBuilder = () => {
   );
 
   return (
-    <Container
-      maxWidth="xl"
-      disableGutters
-      sx={teamBuilderInteractionPolicy}
-    >
-      <Box>
+    <>
+      <Box
+        component="section"
+        id="team-builder"
+        aria-labelledby="team-builder-title"
+        sx={{
+          ...teamBuilderInteractionPolicy,
+          mt: 4,
+          pt: 2,
+        }}
+      >
         <Stack
-          direction="row"
-          alignItems="center"
+          direction={{ xs: 'column', sm: 'row' }}
+          justifyContent="space-between"
+          alignItems={{ xs: 'flex-start', sm: 'flex-end' }}
           gap={2}
-          sx={{
-            mb: 2.5,
-            borderBottom: '2px solid',
-            borderColor: 'text.primary',
-            pb: 2,
-            flexWrap: 'nowrap',
-          }}
+          sx={{ mb: 2 }}
         >
-          <Stack direction="row" alignItems="center" spacing={1.5}>
-            <Button
-              startIcon={<ArrowBackIcon />}
-              onClick={() => navigate(-1)}
-              variant="outlined"
-              sx={{ flexShrink: 0 }}
+          <Box sx={{ minWidth: 0, maxWidth: 680 }}>
+            <Typography
+              variant="overline"
+              color="error.main"
+              sx={{ display: 'block', lineHeight: 1.2 }}
             >
-              返回
-            </Button>
-            <Box sx={{ minWidth: 0 }}>
-              <Typography
-                variant="overline"
-                color="error.main"
-                sx={{ display: 'block', lineHeight: 1.2 }}
-              >
-                FORMATION WORKSHOP
-              </Typography>
-              <Typography component="h1" variant="h3">
-                队伍策案
-              </Typography>
-            </Box>
-          </Stack>
+              FORMATION WORKSHOP
+            </Typography>
+            <Typography id="team-builder-title" component="h2" variant="h4">
+              队伍策案
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.75 }}>
+              边选择本轮卡组，边用已获得的武将和战法编排三支队伍；新卡加入后会继续自动补全。
+            </Typography>
+          </Box>
+          <Typography variant="caption" color="text.secondary">
+            当前卡池：{heroes.length} 名武将 · {skills.length} 个战法
+          </Typography>
         </Stack>
 
         <Stack
@@ -636,73 +620,7 @@ const TeamBuilder = () => {
           </Stack>
         </Stack>
 
-        <Accordion
-          disableGutters
-          elevation={0}
-          slotProps={{ heading: { component: 'h2' } }}
-          sx={{
-            mb: 2,
-            border: '1px solid',
-            borderColor: 'divider',
-            '&:before': { display: 'none' },
-          }}
-        >
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="roster-management-content"
-            id="roster-management-header"
-          >
-            <Box>
-              <Typography component="span" fontWeight={800}>调整参赛卡池</Typography>
-              <Typography variant="caption" color="text.secondary">
-                当前 {heroes.length} 名武将、{skills.length} 个战法；支援选择也会进入仓库
-              </Typography>
-            </Box>
-          </AccordionSummary>
-          <AccordionDetails sx={{ p: 1 }}>
-            {gameState ? (
-              <CurrentTeam
-                heroes={gameState.current_heroes}
-                skills={gameState.current_skills}
-                availableHeroes={availableHeroes}
-                availableSkills={availableSkills}
-                editable
-                onUpdateTeam={handleUpdateTeam}
-                supportHero={gameState.support_hero}
-                supportSkills={gameState.support_skills}
-              />
-            ) : (
-              <Alert
-                severity="info"
-                action={
-                  <Button
-                    color="inherit"
-                    size="small"
-                    onClick={() => navigate('/')}
-                  >
-                    返回对局推荐
-                  </Button>
-                }
-              >
-                请先创建对局卡池，再回来编排三支队伍。
-              </Alert>
-            )}
-          </AccordionDetails>
-        </Accordion>
-
-        {heroes.length === 0 ? (
-          <EmptyState
-            id="empty-team-builder-title"
-            icon={<Inventory2OutlinedIcon />}
-            title="还没有可编排的卡池"
-            description="先在对局推荐中创建武将和战法卡池，再回来编排三支队伍。"
-            action={(
-              <Button variant="contained" onClick={() => navigate('/')}>
-                返回对局推荐
-              </Button>
-            )}
-          />
-        ) : hydratedKey !== poolKey ? (
+        {hydratedKey !== poolKey ? (
           <GameLoadingPanel
             label="正在同步卡池"
             detail="正在整理武将与战法仓库…"
@@ -718,45 +636,37 @@ const TeamBuilder = () => {
           />
         ) : (
           <>
-            {!isEligible && heroes.length > 0 && (
-              <Alert severity="info" sx={{ mb: 1.5 }}>
-                自动推荐需要至少 9 名武将和 18 个战法。当前为 {heroes.length}{' '}
-                名武将、{skills.length} 个战法；你仍可手动拖动编排。
+            {(!formation ||
+              formation.incomplete ||
+              formation.options.length === 0) && (
+              <Alert severity="warning" sx={{ mb: 1.5 }}>
+                当前卡池暂未形成自动编排，你仍可在下方手动拖动武将和战法。
               </Alert>
             )}
-            {isEligible &&
-              (!formation ||
-                formation.incomplete ||
-                formation.options.length === 0) && (
-                <Alert severity="warning" sx={{ mb: 1.5 }}>
-                  当前卡池未能生成完整推荐，你仍可在下方手动编排。
-                </Alert>
-              )}
-            {isEligible &&
-              formation &&
+            {formation &&
               !formation.incomplete &&
               formation.options.length > 0 &&
               recommendationSummary && (
-                <Stack spacing={1} sx={{ mb: 1.5 }} aria-live="polite">
-                  {recommendationSummary.successMessage && (
-                    <Alert
-                      severity="success"
-                      data-testid="recommendation-success"
-                    >
-                      {recommendationSummary.successMessage}
-                    </Alert>
-                  )}
-                  {recommendationSummary.warningMessage && (
-                    <Alert
-                      severity="warning"
-                      data-testid="recommendation-warning"
-                      sx={{ fontWeight: 800 }}
-                    >
-                      {recommendationSummary.warningMessage}
-                    </Alert>
-                  )}
-                </Stack>
-              )}
+              <Stack spacing={1} sx={{ mb: 1.5 }} aria-live="polite">
+                {recommendationSummary.successMessage && (
+                  <Alert
+                    severity="success"
+                    data-testid="recommendation-success"
+                  >
+                    {recommendationSummary.successMessage}
+                  </Alert>
+                )}
+                {recommendationSummary.warningMessage && (
+                  <Alert
+                    severity="info"
+                    data-testid="recommendation-warning"
+                    sx={{ fontWeight: 800 }}
+                  >
+                    {recommendationSummary.warningMessage}
+                  </Alert>
+                )}
+              </Stack>
+            )}
             <FormationWorkbench
               layout={layout}
               heroes={heroes}
@@ -938,8 +848,10 @@ const TeamBuilder = () => {
         message={snackbar.message}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       />
-    </Container>
+    </>
   );
-};
+});
 
-export default TeamBuilder;
+TeamBuilderPanel.displayName = 'TeamBuilderPanel';
+
+export default TeamBuilderPanel;

--- a/web/src/components/teamBuilder/__tests__/TeamBuilderPanel.test.tsx
+++ b/web/src/components/teamBuilder/__tests__/TeamBuilderPanel.test.tsx
@@ -1,0 +1,220 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  createEmptyTeamBuilderLayout,
+  createStoredTeamBuilderLayout,
+  teamBuilderPoolKey,
+  type TeamBuilderLayout,
+} from '../../../services/teamBuilderArrangement';
+import { TEAM_BUILDER_STORAGE_KEY } from '../../../utils/storage';
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    selectedSeason: 16,
+    gameState: {
+      current_heroes: ['A', 'B'],
+      current_skills: ['s1', 's2'],
+      support_hero: null as string | null,
+      support_skills: [] as string[],
+      round_number: 1,
+      round_history: [],
+    },
+  },
+  getCachedTeamFormation: vi.fn(() => null),
+  setCachedTeamFormation: vi.fn(),
+}));
+
+vi.mock('../../../context/GameContext', () => ({
+  useGame: () => ({ state: mocks.state }),
+}));
+
+vi.mock('../../../data', () => ({
+  database: {
+    heroes: {
+      A: { camp: '魏' },
+      B: { camp: '蜀' },
+    },
+    formations: {
+      一字阵: {},
+      鱼鳞阵: {},
+    },
+    team: [],
+  },
+  recommendationData: {
+    catalog: {},
+    model: {},
+  },
+}));
+
+vi.mock('../../../services/teamFormationCache', () => ({
+  getCachedTeamFormation: mocks.getCachedTeamFormation,
+  setCachedTeamFormation: mocks.setCachedTeamFormation,
+  teamFormationCacheKey: (poolKey: string) => poolKey,
+}));
+
+vi.mock('../../../services/recommendationEngine', () => ({
+  recommendHybridTeamsCooperatively: vi.fn(),
+}));
+
+vi.mock('../../../services/teamBuilderMessaging', () => ({
+  summarizeTeamBuilderRecommendation: () => ({
+    successMessage: null,
+    warningMessage: null,
+  }),
+}));
+
+vi.mock('../../../services/promptGenerator', () => ({
+  generateTeamValidationPrompt: vi.fn(),
+}));
+
+vi.mock('../../../services/recommendationDebug', () => ({
+  buildTeamFormationDebugContext: () => ({}),
+}));
+
+vi.mock('../../../services/localTeamAgent', () => ({
+  LocalTeamAgentError: class LocalTeamAgentError extends Error {
+    code = 'test';
+  },
+  createTeamAgentRequest: vi.fn(),
+  isTeamBuilderLayoutComplete: () => false,
+  layoutFromTeamAgentTeams: vi.fn(),
+  requestLocalTeamRecommendation: vi.fn(),
+  syncLocalTeamAgentExperiment: () => false,
+  teamBuilderLayoutFingerprint: (layout: TeamBuilderLayout) =>
+    JSON.stringify(layout),
+}));
+
+vi.mock('../FormationWorkbench', () => ({
+  default: ({ layout }: { layout: TeamBuilderLayout }) => (
+    <output data-testid="rendered-layout">{JSON.stringify(layout)}</output>
+  ),
+}));
+
+vi.mock('../AgentReviewPanel', () => ({
+  default: () => null,
+}));
+
+import TeamBuilderPanel from '../TeamBuilderPanel';
+
+class WorkerStub {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  postMessage = vi.fn();
+  terminate = vi.fn();
+
+  emitResult(recommendation: unknown) {
+    const request = this.postMessage.mock.calls.at(-1)?.[0] as
+      | { requestId: string }
+      | undefined;
+    if (!request) throw new Error('Worker has not received a request');
+    this.onmessage?.({
+      data: {
+        type: 'result',
+        requestId: request.requestId,
+        recommendation,
+      },
+    } as MessageEvent);
+  }
+}
+
+const workers: WorkerStub[] = [];
+
+const readStoredLayout = () =>
+  JSON.parse(localStorage.getItem(TEAM_BUILDER_STORAGE_KEY) ?? 'null') as {
+    poolKey: string;
+    recommendationPoolKey: string | null;
+    layout: TeamBuilderLayout;
+  };
+
+const recommendation = {
+  incomplete: false,
+  options: [
+    {
+      teams: [
+        {
+          heroes: [{ name: 'B', skills: ['s2'], skillScore: 1 }],
+          strength: 1,
+          formation: '鱼鳞阵',
+          evidence: {
+            heroSynergy: [],
+            heroSkill: [],
+            skillSynergy: [],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+describe('TeamBuilderPanel pool expansion', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    workers.length = 0;
+    mocks.getCachedTeamFormation.mockReturnValue(null);
+    vi.stubGlobal(
+      'Worker',
+      class extends WorkerStub {
+        constructor() {
+          super();
+          workers.push(this);
+        }
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  test('reloads a pending larger pool and merges into formation and headless tactic edits', async () => {
+    const oldPoolKey = teamBuilderPoolKey(['A'], ['s1']);
+    const newPoolKey = teamBuilderPoolKey(['A', 'B'], ['s1', 's2']);
+    const editedLayout = createEmptyTeamBuilderLayout();
+    editedLayout[0].formation = '一字阵';
+    editedLayout[0].heroes[0] = {
+      hero: null,
+      row: '后排',
+      skills: [null, 's1'],
+    };
+    localStorage.setItem(
+      TEAM_BUILDER_STORAGE_KEY,
+      JSON.stringify(
+        createStoredTeamBuilderLayout(oldPoolKey, oldPoolKey, editedLayout)
+      )
+    );
+
+    const firstMount = render(<TeamBuilderPanel />);
+    await waitFor(() => expect(workers).toHaveLength(1));
+    await waitFor(() => expect(workers[0].postMessage).toHaveBeenCalled());
+    await waitFor(() => expect(readStoredLayout().poolKey).toBe(newPoolKey));
+    const pendingLayout = readStoredLayout();
+    expect(pendingLayout.recommendationPoolKey).toBeNull();
+    expect(pendingLayout.layout[0].formation).toBe('一字阵');
+    expect(pendingLayout.layout[0].heroes[0]).toEqual({
+      hero: null,
+      row: '后排',
+      skills: [null, 's1'],
+    });
+    firstMount.unmount();
+
+    render(<TeamBuilderPanel />);
+    await waitFor(() => expect(workers).toHaveLength(2));
+    await waitFor(() => expect(workers[1].postMessage).toHaveBeenCalled());
+    act(() => workers[1].emitResult(recommendation));
+
+    const renderedLayout = await screen.findByTestId('rendered-layout');
+    const layout = JSON.parse(
+      renderedLayout.textContent ?? 'null'
+    ) as TeamBuilderLayout;
+    expect(layout[0].formation).toBe('一字阵');
+    expect(layout[0].heroes[0]).toEqual({
+      hero: 'B',
+      row: '后排',
+      skills: ['s2', 's1'],
+    });
+    await waitFor(() =>
+      expect(readStoredLayout().recommendationPoolKey).toBe(newPoolKey)
+    );
+  });
+});

--- a/web/src/entry-server.tsx
+++ b/web/src/entry-server.tsx
@@ -8,7 +8,6 @@ import Analytics from './pages/Analytics';
 import Contribute from './pages/Contribute';
 import Contributors from './pages/Contributors';
 import NotFound from './pages/NotFound';
-import TeamBuilder from './pages/TeamBuilder';
 import YanwuGuide from './pages/YanwuGuide';
 import type { RouteComponents } from './routeComponents';
 import { api } from './services/api';
@@ -32,7 +31,6 @@ export interface PrerenderedRoute {
 
 const routeComponents: RouteComponents = {
   Analytics,
-  TeamBuilder,
   Contribute,
   Contributors,
   YanwuGuide,

--- a/web/src/routeComponents.ts
+++ b/web/src/routeComponents.ts
@@ -2,7 +2,6 @@ import { lazy, type ComponentType } from 'react';
 
 export interface RouteComponents {
   Analytics: ComponentType;
-  TeamBuilder: ComponentType;
   Contribute: ComponentType;
   Contributors: ComponentType;
   YanwuGuide: ComponentType;
@@ -14,7 +13,6 @@ export interface RouteComponents {
 // loading fallback that would remain stuck when JavaScript is disabled.
 export const clientRouteComponents: RouteComponents = {
   Analytics: lazy(() => import('./pages/Analytics')),
-  TeamBuilder: lazy(() => import('./pages/TeamBuilder')),
   Contribute: lazy(() => import('./pages/Contribute')),
   Contributors: lazy(() => import('./pages/Contributors')),
   YanwuGuide: lazy(() => import('./pages/YanwuGuide')),

--- a/web/src/seo/__tests__/RouteSeo.test.tsx
+++ b/web/src/seo/__tests__/RouteSeo.test.tsx
@@ -54,16 +54,7 @@ describe('RouteSeo', () => {
     );
   });
 
-  test('marks state-only and unknown pages as noindex', async () => {
-    renderRouteSeo('/team-builder');
-    await waitFor(() =>
-      expect(document.querySelector('meta[name="robots"]')).toHaveAttribute(
-        'content',
-        'noindex,follow'
-      )
-    );
-
-    cleanup();
+  test('marks unknown pages as noindex', async () => {
     renderRouteSeo('/not-a-page');
     await waitFor(() => expect(document.title).toBe('页面未找到｜演武参谋'));
     expect(document.querySelector('meta[name="robots"]')).toHaveAttribute(

--- a/web/src/seo/__tests__/config.test.ts
+++ b/web/src/seo/__tests__/config.test.ts
@@ -27,9 +27,9 @@ describe('SEO route configuration', () => {
     expect(NOT_FOUND_SEO.index).toBe(false);
   });
 
-  test('keeps the state-dependent team builder out of search results', () => {
-    expect(findSeoRoute('/team-builder').index).toBe(false);
-    expect(SEO_ROUTES.filter((route) => route.index)).not.toContainEqual(
+  test('treats the removed standalone team builder as an unknown route', () => {
+    expect(findSeoRoute('/team-builder')).toEqual(NOT_FOUND_SEO);
+    expect(SEO_ROUTES).not.toContainEqual(
       expect.objectContaining({ path: '/team-builder' })
     );
   });

--- a/web/src/seo/__tests__/staticHtml.test.ts
+++ b/web/src/seo/__tests__/staticHtml.test.ts
@@ -60,7 +60,7 @@ describe('renderSeoHtml', () => {
   });
 
   test('marks non-index routes noindex', () => {
-    const html = renderRouteHtml(findSeoRoute('/team-builder'));
+    const html = renderRouteHtml(findSeoRoute('/missing'));
     expect(html).toContain(
       '<meta name="robots" content="noindex,follow" data-seo-managed="true" />'
     );

--- a/web/src/seo/config.ts
+++ b/web/src/seo/config.ts
@@ -68,16 +68,6 @@ export const SEO_ROUTES: readonly SeoRoute[] = [
     index: true,
     ogType: 'website',
   },
-  {
-    path: '/team-builder',
-    title: '三国谋定天下演武三队编排｜演武参谋',
-    description:
-      '根据当前演武卡池生成三队编排，调整武将与战法并即时查看阵容评分。',
-    heading: '队伍策案',
-    navLabel: '队伍推荐',
-    index: false,
-    ogType: 'website',
-  },
 ] as const;
 
 export const NOT_FOUND_SEO: SeoRoute = {

--- a/web/src/services/__tests__/recommendationEngine.test.ts
+++ b/web/src/services/__tests__/recommendationEngine.test.ts
@@ -1190,6 +1190,48 @@ describe('recommendHybridTeams — evidence-only partial placement', () => {
     [[`s${offset + 4}`], [`s${offset + 5}`]],
   ];
 
+  test('starts allocating an evidence-qualified team before the pool reaches full size', () => {
+    const data = makeData({
+      weights: {
+        'H|h0': 0.4,
+        'H|h1': 0.3,
+        'HP|h0|h1': 0.5,
+        'S|s0': 0.2,
+        'HS|h0|s0': 0.4,
+      },
+      support: {
+        'H|h0': 10,
+        'H|h1': 10,
+        'HP|h0|h1': 16,
+        'S|s0': 10,
+        'HS|h0|s0': 16,
+      },
+      n_features: 5,
+    });
+
+    const result = recommendHybridTeams(
+      heroes.slice(0, 4),
+      skills.slice(0, 8),
+      data,
+      data.catalog,
+      {},
+      []
+    );
+
+    expect(result.incomplete).toBe(false);
+    expect(result.debug).toMatchObject({
+      heroPoolCount: 4,
+      skillPoolCount: 8,
+      qualifiedHeroPairs: 1,
+    });
+    expect(result.options[0].teams[0].heroes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'h0', skills: ['s0'] }),
+        expect.objectContaining({ name: 'h1' }),
+      ])
+    );
+  });
+
   test('preserves canonical slots for a confident two-hero guide core', () => {
     const data = makeData({
       weights: {

--- a/web/src/services/__tests__/teamBuilderArrangement.test.ts
+++ b/web/src/services/__tests__/teamBuilderArrangement.test.ts
@@ -64,6 +64,7 @@ describe('team builder layout creation and persistence migration', () => {
     const result = normalize(legacy);
 
     expect(result.storedPoolKey).toBeNull();
+    expect(result.recommendationPoolKey).toBeNull();
     expect(result.hasAssignments).toBe(true);
     expect(result.layout[0]).toMatchObject({
       formation: '一字阵',
@@ -77,16 +78,32 @@ describe('team builder layout creation and persistence migration', () => {
     expect(legacy).toEqual(before);
   });
 
-  test('reads the pool identity from schema v2 and the constructor snapshots layout', () => {
+  test('stores layout and recommendation pool identities in schema v3', () => {
     const layout = createEmptyTeamBuilderLayout();
     layout[0].heroes[0].hero = 'A';
-    const stored = createStoredTeamBuilderLayout('pool-v1', layout);
+    const stored = createStoredTeamBuilderLayout(
+      'pool-v2',
+      'recommended-pool',
+      layout
+    );
 
     layout[0].heroes[0].hero = 'changed-after-save';
     expect(stored.layout[0].heroes[0].hero).toBe('A');
 
     const result = normalize(stored);
-    expect(result.storedPoolKey).toBe('pool-v1');
+    expect(result.storedPoolKey).toBe('pool-v2');
+    expect(result.recommendationPoolKey).toBe('recommended-pool');
+    expect(result.layout[0].heroes[0].hero).toBe('A');
+  });
+
+  test('migrates schema v2 without treating its pool key as recommendation evidence', () => {
+    const layout = createEmptyTeamBuilderLayout();
+    layout[0].heroes[0].hero = 'A';
+
+    const result = normalize({ version: 2, poolKey: 'pool-v2', layout });
+
+    expect(result.storedPoolKey).toBe('pool-v2');
+    expect(result.recommendationPoolKey).toBeNull();
     expect(result.layout[0].heroes[0].hero).toBe('A');
   });
 
@@ -156,7 +173,11 @@ describe('team builder layout creation and persistence migration', () => {
   test('retains a headless slot\'s valid row and tactics through normalization and persistence', () => {
     const layout = createEmptyTeamBuilderLayout();
     layout[0].heroes[0] = { hero: null, row: '后排', skills: ['s1', 's2'] };
-    const stored = createStoredTeamBuilderLayout('pool-headless', layout);
+    const stored = createStoredTeamBuilderLayout(
+      'pool-headless',
+      'pool-headless',
+      layout
+    );
 
     const result = normalize(stored);
 
@@ -396,6 +417,30 @@ describe('mergeTeamBuilderRecommendation', () => {
     expect(merged[0].heroes[2]).toMatchObject({
       hero: 'B',
       skills: ['s4', null],
+    });
+  });
+
+  test('preserves formation-only and headless tactic edits while filling slots', () => {
+    const current = createEmptyTeamBuilderLayout();
+    current[0].formation = '一字阵';
+    current[0].heroes[0] = {
+      hero: null,
+      row: '后排',
+      skills: ['s1', null],
+    };
+
+    const recommended = createEmptyTeamBuilderLayout();
+    recommended[0].formation = '鱼鳞阵';
+    recommended[0].heroes[0].hero = 'A';
+    recommended[0].heroes[0].skills = ['s2', 's3'];
+
+    const merged = mergeTeamBuilderRecommendation(current, recommended);
+
+    expect(merged[0].formation).toBe('一字阵');
+    expect(merged[0].heroes[0]).toEqual({
+      hero: 'A',
+      row: '后排',
+      skills: ['s1', 's3'],
     });
   });
 });

--- a/web/src/services/__tests__/teamBuilderArrangement.test.ts
+++ b/web/src/services/__tests__/teamBuilderArrangement.test.ts
@@ -8,6 +8,7 @@ import {
   createEmptyTeamBuilderLayout,
   createStoredTeamBuilderLayout,
   layoutFromFormation,
+  mergeTeamBuilderRecommendation,
   normalizeTeamBuilderLayout,
   teamBuilderLayoutHasHero,
   teamBuilderPoolKey,
@@ -368,6 +369,36 @@ const populatedLayout = (): TeamBuilderLayout => {
   };
   return layout;
 };
+
+describe('mergeTeamBuilderRecommendation', () => {
+  test('fills new recommendation gaps without replacing existing player edits', () => {
+    const current = createEmptyTeamBuilderLayout();
+    current[0].formation = '一字阵';
+    current[0].heroes[1].hero = 'A';
+    current[0].heroes[1].row = '后排';
+    current[0].heroes[1].skills[0] = 's1';
+
+    const recommended = createEmptyTeamBuilderLayout();
+    recommended[0].formation = '鱼鳞阵';
+    recommended[0].heroes[0].hero = 'A';
+    recommended[0].heroes[0].skills = ['s2', 's3'];
+    recommended[0].heroes[2].hero = 'B';
+    recommended[0].heroes[2].skills = ['s4', null];
+
+    const merged = mergeTeamBuilderRecommendation(current, recommended);
+
+    expect(merged[0].formation).toBe('一字阵');
+    expect(merged[0].heroes[1]).toMatchObject({
+      hero: 'A',
+      row: '后排',
+      skills: ['s1', 's3'],
+    });
+    expect(merged[0].heroes[2]).toMatchObject({
+      hero: 'B',
+      skills: ['s4', null],
+    });
+  });
+});
 
 describe('applyTeamBuilderMove', () => {
   test('swaps only the hero fields, leaving each slot its own row and skills', () => {

--- a/web/src/services/__tests__/teamBuilderMessaging.test.ts
+++ b/web/src/services/__tests__/teamBuilderMessaging.test.ts
@@ -32,6 +32,18 @@ describe('summarizeTeamBuilderRecommendation', () => {
     });
   });
 
+  test('explains that an early-round partial layout will keep filling as the pool grows', () => {
+    expect(
+      summarizeTeamBuilderRecommendation([team(2, 1)], {
+        heroPoolCount: 4,
+        skillPoolCount: 8,
+      })
+    ).toEqual({
+      successMessage: null,
+      warningMessage: '当前卡池已开始编排；空位会随着新武将和战法加入继续补全。',
+    });
+  });
+
   test('does not count teams with an unfilled hero slot as complete', () => {
     expect(
       summarizeTeamBuilderRecommendation([team(2), team(3), team(3)])

--- a/web/src/services/recommendationDebug.ts
+++ b/web/src/services/recommendationDebug.ts
@@ -423,12 +423,9 @@ export function buildTeamFormationDebugContext({
     return {
       ...base,
       status: 'not-ready',
-      reason:
-        uniqueHeroes.length < 9 || uniqueSkills.length < 18
-          ? `Automatic recommendation needs at least 9 heroes and 18 skills; current pool has ${uniqueHeroes.length} heroes and ${uniqueSkills.length} skills.`
-          : 'The team recommendation is still being calculated.',
+      reason: 'The team recommendation is still being calculated.',
       next_step:
-        'Wait for the team formation page to finish loading, then run sanmouDebug() again.',
+        'Wait for the embedded team builder to finish loading, then run sanmouDebug() again.',
     };
   }
 
@@ -646,7 +643,7 @@ const noActiveDebugContext = (): Record<string, unknown> => ({
   page: 'unsupported',
   status: 'not-ready',
   reason:
-    'Open the candidate suggestion or team formation suggestion page before running sanmouDebug().',
+    'Open an active draft before running sanmouDebug().',
 });
 
 declare global {

--- a/web/src/services/recommendationEngine.ts
+++ b/web/src/services/recommendationEngine.ts
@@ -2470,8 +2470,8 @@ function buildTeamEvidence(
 /**
  * A fully skill-assigned team *without* the (relatively expensive) positive
  * evidence rows. Evidence is deferred to the single winning formation only —
- * /team-builder already has a noticeable compute delay, so we never build
- * evidence for the many discarded partitions.
+ * the embedded Team Builder already has a noticeable compute delay, so we
+ * never build evidence for the many discarded partitions.
  */
 interface DraftTeam {
   heroes: ProjectedHero[];
@@ -2744,8 +2744,8 @@ function enumerateLargePoolPartitions(
  * Deterministically cap the fully-evaluated partition set at {@link PARTITION_EVAL_CAP}.
  *
  * The beam can enumerate more disjoint partitions than we want to skill-assign
- * and score (that pass is the /team-builder compute cost). Rather than truncate
- * in enumeration order — which would bias toward whichever trio happened to sort
+ * and score (that pass is the embedded Team Builder compute cost). Rather than
+ * truncate in enumeration order — which would bias toward whichever trio happened to sort
  * first — we rank every partition two ways and *interleave*: a strength proxy
  * (top-two trio hero-strength, matching the top-two-sum selection goal) and a
  * same-camp proxy. Alternating one pick from each list preserves a deliberate
@@ -5280,8 +5280,6 @@ function recommendConservativeHybridTeams(
 ): FormationRecommendation {
   const heroes = [...new Set(heroPool)];
   const skills = [...new Set(skillPool)];
-  if (heroes.length < 9 || skills.length < 18)
-    return incompleteFormationRecommendation();
 
   const m = model(data);
   const sortedHeroes = [...heroes].sort();

--- a/web/src/services/teamBuilderArrangement.ts
+++ b/web/src/services/teamBuilderArrangement.ts
@@ -335,6 +335,61 @@ export function layoutFromFormation(option: FormationOption): TeamBuilderLayout 
   return layout;
 }
 
+export function mergeTeamBuilderRecommendation(
+  current: TeamBuilderLayout,
+  recommended: TeamBuilderLayout
+): TeamBuilderLayout {
+  const next = cloneTeamBuilderLayout(current);
+  const usedHeroes = collectUsedTeamBuilderHeroes(next);
+  const usedSkills = collectUsedTeamBuilderSkills(next);
+
+  for (let teamIndex = 0; teamIndex < TEAM_BUILDER_TEAM_COUNT; teamIndex += 1) {
+    if (!next[teamIndex].formation && recommended[teamIndex].formation) {
+      next[teamIndex].formation = recommended[teamIndex].formation;
+    }
+
+    for (
+      let heroIndex = 0;
+      heroIndex < TEAM_BUILDER_HERO_SLOTS_PER_TEAM;
+      heroIndex += 1
+    ) {
+      const recommendation = recommended[teamIndex].heroes[heroIndex];
+      if (!recommendation.hero) continue;
+
+      let target = next
+        .flatMap((team) => team.heroes)
+        .find((slot) => slot.hero === recommendation.hero);
+      if (!target) {
+        target = next[teamIndex].heroes[heroIndex];
+        if (target.hero !== null || usedHeroes.has(recommendation.hero)) {
+          continue;
+        }
+        target.hero = recommendation.hero;
+        target.row = recommendation.row;
+        usedHeroes.add(recommendation.hero);
+      }
+
+      for (
+        let skillIndex = 0;
+        skillIndex < TEAM_BUILDER_SKILL_SLOTS_PER_HERO;
+        skillIndex += 1
+      ) {
+        const skill = recommendation.skills[skillIndex];
+        if (
+          target.skills[skillIndex] === null &&
+          skill !== null &&
+          !usedSkills.has(skill)
+        ) {
+          target.skills[skillIndex] = skill;
+          usedSkills.add(skill);
+        }
+      }
+    }
+  }
+
+  return next;
+}
+
 export function collectUsedTeamBuilderHeroes(
   layout: TeamBuilderLayout
 ): Set<string> {

--- a/web/src/services/teamBuilderArrangement.ts
+++ b/web/src/services/teamBuilderArrangement.ts
@@ -5,7 +5,7 @@ export const TEAM_BUILDER_HERO_SLOTS_PER_TEAM = 3 as const;
 export const TEAM_BUILDER_SKILL_SLOTS_PER_HERO = 2 as const;
 export const TEAM_BUILDER_ROWS = ['前排', '后排'] as const;
 export const TEAM_BUILDER_DEFAULT_ROW: TeamBuilderRow = '前排';
-export const TEAM_BUILDER_STORAGE_VERSION = 2 as const;
+export const TEAM_BUILDER_STORAGE_VERSION = 3 as const;
 
 export type TeamBuilderRow = (typeof TEAM_BUILDER_ROWS)[number];
 export type TeamBuilderSkillSlots = [string | null, string | null];
@@ -33,9 +33,10 @@ export type TeamBuilderLayout = [
   TeamBuilderTeam,
 ];
 
-export interface StoredTeamBuilderLayoutV2 {
+export interface StoredTeamBuilderLayoutV3 {
   version: typeof TEAM_BUILDER_STORAGE_VERSION;
   poolKey: string;
+  recommendationPoolKey: string | null;
   layout: TeamBuilderLayout;
 }
 
@@ -48,6 +49,7 @@ export interface NormalizeTeamBuilderLayoutOptions {
 export interface NormalizedTeamBuilderLayout {
   layout: TeamBuilderLayout;
   storedPoolKey: string | null;
+  recommendationPoolKey: string | null;
   hasAssignments: boolean;
   hasFormation: boolean;
 }
@@ -154,32 +156,54 @@ export function teamBuilderPoolKey(
 
 export function createStoredTeamBuilderLayout(
   poolKey: string,
+  recommendationPoolKey: string | null,
   layout: TeamBuilderLayout
-): StoredTeamBuilderLayoutV2 {
+): StoredTeamBuilderLayoutV3 {
   return {
     version: TEAM_BUILDER_STORAGE_VERSION,
     poolKey,
+    recommendationPoolKey,
     layout: cloneTeamBuilderLayout(layout),
   };
 }
 
-const rawLayoutAndPoolKey = (
+const rawLayoutAndPoolKeys = (
   raw: unknown
-): { rawLayout: unknown; storedPoolKey: string | null } => {
+): {
+  rawLayout: unknown;
+  storedPoolKey: string | null;
+  recommendationPoolKey: string | null;
+} => {
   if (Array.isArray(raw)) {
-    return { rawLayout: raw, storedPoolKey: null };
+    return {
+      rawLayout: raw,
+      storedPoolKey: null,
+      recommendationPoolKey: null,
+    };
   }
-  if (isRecord(raw) && raw.version === TEAM_BUILDER_STORAGE_VERSION) {
+  if (
+    isRecord(raw) &&
+    (raw.version === 2 || raw.version === TEAM_BUILDER_STORAGE_VERSION)
+  ) {
     return {
       rawLayout: raw.layout,
       storedPoolKey: typeof raw.poolKey === 'string' ? raw.poolKey : null,
+      recommendationPoolKey:
+        raw.version === TEAM_BUILDER_STORAGE_VERSION &&
+        typeof raw.recommendationPoolKey === 'string'
+          ? raw.recommendationPoolKey
+          : null,
     };
   }
-  return { rawLayout: null, storedPoolKey: null };
+  return {
+    rawLayout: null,
+    storedPoolKey: null,
+    recommendationPoolKey: null,
+  };
 };
 
 /**
- * Migrate legacy arrays and validate schema-v2 data into one canonical layout.
+ * Migrate legacy arrays and validate persisted data into one canonical layout.
  * The first row-major occurrence of a valid hero or skill wins; stale and
  * duplicate assignments are returned to the implicit unused pool.
  */
@@ -193,7 +217,8 @@ export function normalizeTeamBuilderLayout(
   const seenHeroes = new Set<string>();
   const seenSkills = new Set<string>();
   const layout = createEmptyTeamBuilderLayout();
-  const { rawLayout, storedPoolKey } = rawLayoutAndPoolKey(raw);
+  const { rawLayout, storedPoolKey, recommendationPoolKey } =
+    rawLayoutAndPoolKeys(raw);
 
   if (Array.isArray(rawLayout)) {
     for (
@@ -263,6 +288,7 @@ export function normalizeTeamBuilderLayout(
   return {
     layout,
     storedPoolKey,
+    recommendationPoolKey,
     hasAssignments: seenHeroes.size > 0 || seenSkills.size > 0,
     hasFormation: layout.some((team) => team.formation !== ''),
   };
@@ -365,7 +391,6 @@ export function mergeTeamBuilderRecommendation(
           continue;
         }
         target.hero = recommendation.hero;
-        target.row = recommendation.row;
         usedHeroes.add(recommendation.hero);
       }
 

--- a/web/src/services/teamBuilderMessaging.ts
+++ b/web/src/services/teamBuilderMessaging.ts
@@ -5,8 +5,14 @@ export interface TeamBuilderRecommendationSummary {
   warningMessage: string | null;
 }
 
+interface TeamBuilderPoolSummary {
+  heroPoolCount: number;
+  skillPoolCount: number;
+}
+
 export const summarizeTeamBuilderRecommendation = (
-  teams: ProjectedTeam[]
+  teams: ProjectedTeam[],
+  pool?: TeamBuilderPoolSummary
 ): TeamBuilderRecommendationSummary => {
   const isComplete = (team: ProjectedTeam) =>
     team.heroes.length === 3 &&
@@ -36,11 +42,17 @@ export const summarizeTeamBuilderRecommendation = (
       ? '战法'
       : null;
 
+  const poolIsStillGrowing =
+    pool !== undefined &&
+    (pool.heroPoolCount < 9 || pool.skillPoolCount < 18);
+
   return {
     successMessage:
       completeTeams > 0 ? `已编入 ${completeTeams} 支完整队伍` : null,
     warningMessage: missingItems
-      ? `部分${missingItems}未通过证据量门槛，已保留空位。`
+      ? poolIsStillGrowing
+        ? '当前卡池已开始编排；空位会随着新武将和战法加入继续补全。'
+        : `部分${missingItems}未通过证据量门槛，已保留空位。`
       : null,
   };
 };

--- a/web/src/services/teamFormationCache.ts
+++ b/web/src/services/teamFormationCache.ts
@@ -10,7 +10,7 @@ export function teamFormationCacheKey(
   teamComps: TeamComp[]
 ): string {
   return JSON.stringify({
-    policy: 'evidence-only-v3',
+    policy: 'evidence-only-v4-partial-pool',
     poolKey,
     catalog: recommendationData.catalog.catalog_version,
     scoring: recommendationData.model.scoring_version,

--- a/web/src/utils/storage.ts
+++ b/web/src/utils/storage.ts
@@ -156,7 +156,7 @@ export const storage = {
   },
 
   /**
-   * Persist the editable /team-builder formation.
+   * Persist the editable formation embedded in the draft page.
    * Kept under its own localStorage key so a full Chinese-name lineup is not
    * constrained by the browser's small per-cookie size limit.
    */

--- a/web/tests-production/prerender.spec.js
+++ b/web/tests-production/prerender.spec.js
@@ -25,7 +25,6 @@ const PRERENDERED_ROUTES = [
   ['/guides/yanwu', '三国谋定天下演武武将、战法与阵容指南'],
   ['/contributors', '战报贡献榜'],
   ['/contribute', '上传战报'],
-  ['/team-builder', '队伍策案'],
   ['/404.html', '页面未找到'],
 ];
 

--- a/web/tests/accessibilityLayout.spec.js
+++ b/web/tests/accessibilityLayout.spec.js
@@ -129,7 +129,7 @@ test.describe('Accessibility and responsive layout', () => {
     const menu = page.getByRole('menu');
     await expect(menu.getByRole('menuitem', { name: '数据洞察' }))
       .toHaveAttribute('aria-current', 'page');
-    await expect(menu.getByRole('menuitem', { name: '队伍推荐' })).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: '队伍推荐' })).toHaveCount(0);
     await expect(menu.getByRole('menuitem', { name: '讨论群' })).toBeVisible();
     await expect(menu.getByRole('menuitem', { name: '重置进度' })).toBeVisible();
 
@@ -164,39 +164,26 @@ test.describe('Accessibility and responsive layout', () => {
     });
     await expect(roundHeading).toHaveCount(1);
 
-    await page.goto('/team-builder');
-    await expect(page.getByRole('heading', { level: 1, name: '队伍策案' })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { level: 2, name: '队伍策案' })
+    ).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1 })).toHaveCount(1);
   });
 
-  test('team builder without a card pool shows a focused empty state', async ({ page }) => {
+  test('the removed standalone team-builder URL redirects to the main setup page', async ({ page }) => {
     await page.setViewportSize({ width: 320, height: 844 });
     await page.goto('/team-builder');
 
-    const pageHeading = page.getByRole('heading', { level: 1, name: '队伍策案' });
-    await expect(pageHeading).toBeVisible();
-    await expect(page.getByRole('heading', { level: 2, name: /调整参赛卡池/ })).toBeVisible();
-    await expect(page.getByRole('heading', { level: 2, name: '还没有可编排的卡池' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: '我的比赛阵容' })).toHaveCount(0);
-    const returnAction = page.getByRole('button', { name: '返回对局推荐' }).last();
-    await expect(returnAction).toBeVisible();
-
-    const rosterSummary = page.getByRole('button', { name: /调整参赛卡池/ });
-    const regionId = await rosterSummary.getAttribute('aria-controls');
-    expect(regionId).toBeTruthy();
-    await expect(page.locator(`[id="${regionId}"]`)).toHaveCount(1);
-
-    const headingBox = await pageHeading.boundingBox();
-    expect(headingBox).not.toBeNull();
-    expect(headingBox.height, 'the Team Builder title should stay on one line at 320px')
-      .toBeLessThanOrEqual(40);
-    expect(headingBox.x + headingBox.width).toBeLessThanOrEqual(320);
-    const documentOverflow = await page.evaluate(() =>
-      document.documentElement.scrollWidth - window.innerWidth
-    );
-    expect(documentOverflow).toBeLessThanOrEqual(1);
-
-    await returnAction.click();
     await expect(page).toHaveURL(/\/$/);
+    await expect(
+      page.getByRole('heading', { level: 1, name: '演武配将与战法推荐' })
+    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: '队伍策案' })).toHaveCount(0);
+    expect(
+      await page.evaluate(() =>
+        document.documentElement.scrollWidth - window.innerWidth
+      )
+    ).toBeLessThanOrEqual(1);
   });
 
   test('completed game has one h1 and keeps its support roster read-only', async ({ page }) => {
@@ -357,8 +344,6 @@ test.describe('Accessibility and responsive layout', () => {
         skills: anySkills(8),
       }),
     );
-    await page.goto('/team-builder');
-
     const hints = page.getByText('左右滑动查看第 3 名武将', { exact: true });
     await expect(hints).toHaveCount(3);
     await expect(hints.first()).toBeVisible();

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -216,19 +216,21 @@ async function seedTeamBuilderLayout(
   layout,
   { heroes = relationshipHeroes, skills = relationshipSkills } = {},
 ) {
-  const poolKey = JSON.stringify({
-    heroes: [...heroes].sort(),
-    skills: [...skills].sort(),
+  const value = JSON.stringify({
+    version: 2,
+    poolKey: JSON.stringify({
+      heroes: [...heroes].sort(),
+      skills: [...skills].sort(),
+    }),
+    layout,
   });
-  await page.addInitScript(
-    ({ poolKey: key, layout: storedLayout }) => {
-      localStorage.setItem(
-        'teamBuilder',
-        JSON.stringify({ version: 2, poolKey: key, layout: storedLayout }),
-      );
-    },
-    { poolKey, layout },
-  );
+  await page.addInitScript((storedValue) => {
+    const markerKey = 'teamBuilder:playwright-seed';
+    if (sessionStorage.getItem(markerKey) !== storedValue) {
+      localStorage.setItem('teamBuilder', storedValue);
+      sessionStorage.setItem(markerKey, storedValue);
+    }
+  }, value);
 }
 
 async function startPointerDrag(page, source) {
@@ -799,9 +801,9 @@ async function assertStationaryRelationshipActivation(page, {
 }
 
 async function openBuilder(page) {
-  await page.goto('/team-builder');
+  await page.goto('/');
   await expect(
-    page.getByRole('heading', { level: 1, name: '队伍策案' })
+    page.getByRole('heading', { level: 2, name: '队伍策案' })
   ).toBeVisible({ timeout: 30000 });
   await expect(
     page.getByRole('heading', { name: '我的比赛阵容' })
@@ -856,37 +858,56 @@ async function dragWholeBlock(page, source, target) {
   await page.waitForTimeout(300);
 }
 
-test.describe('Team Builder fresh entry', () => {
-  test('requires a valid game roster before enabling pool edits', async ({
+test.describe('Team Builder legacy entry', () => {
+  test('redirects the removed standalone route to the main setup flow', async ({
     page,
   }) => {
     await page.goto('/team-builder');
 
+    await expect(page).toHaveURL(/\/$/);
     await expect(
-      page.getByRole('heading', { level: 1, name: '队伍策案' })
+      page.getByRole('heading', { level: 1, name: '演武配将与战法推荐' })
     ).toBeVisible();
-    await expect(
-      page.getByRole('heading', { level: 2, name: '还没有可编排的卡池' })
-    ).toBeVisible();
-    const backAction = page.getByRole('button', {
-      name: '返回',
-      exact: true,
-    });
-    const emptyStateAction = page
-      .getByRole('button', { name: '返回对局推荐' })
-      .last();
-    await expectMinimumTouchTarget(backAction);
-    await expectMinimumTouchTarget(emptyStateAction);
     await expect(
       page.getByRole('heading', { name: '我的比赛阵容' })
     ).toHaveCount(0);
-    await expect(page.getByRole('button', { name: '编辑队伍' })).toHaveCount(0);
+  });
+});
+
+test.describe('Team Builder opening recommendation', () => {
+  test('renders below the three draft sets and starts with the opening pool', async ({
+    page,
+  }) => {
+    await seedStoredProgress(page, smallPoolProgress);
+    await openBuilder(page);
+
+    const options = page.getByTestId('three-option-grid');
+    const builder = page.locator('#team-builder');
+    await expect(builder).toBeVisible();
+    expect(
+      await options.evaluate((grid, section) =>
+        Boolean(grid.compareDocumentPosition(section) & Node.DOCUMENT_POSITION_FOLLOWING),
+        await builder.elementHandle()
+      )
+    ).toBe(true);
+    await expect(page.getByText('当前卡池：4 名武将 · 5 个战法')).toBeVisible();
+    await expect(page.getByTestId('recommendation-warning')).toHaveText(
+      '当前卡池已开始编排；空位会随着新武将和战法加入继续补全。'
+    );
+    await expect(page.getByText(/自动推荐需要至少 9 名武将和 18 个战法/)).toHaveCount(0);
+    expect(await page.locator('[data-testid^="hero-camp-"]').count()).toBeGreaterThan(0);
   });
 });
 
 test.describe('Team Builder manual workshop', () => {
   test.beforeEach(async ({ page, context }) => {
     await seedStoredProgress(page, smallPoolProgress);
+    const layout = [emptyStoredTeam(), emptyStoredTeam(), emptyStoredTeam()];
+    layout[0].formation = Object.keys(database.formations)[0];
+    await seedTeamBuilderLayout(page, layout, {
+      heroes: [...smallHeroes, supportHero],
+      skills: [...smallSkills, supportSkill],
+    });
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
   });
 
@@ -894,10 +915,6 @@ test.describe('Team Builder manual workshop', () => {
     page,
   }) => {
     await openBuilder(page);
-
-    await expectMinimumTouchTarget(
-      page.getByRole('button', { name: '返回', exact: true })
-    );
 
     await page
       .getByTestId(`pool-hero-${smallHeroes[0]}-primary`)
@@ -909,15 +926,7 @@ test.describe('Team Builder manual workshop', () => {
     await expectMinimumTouchTarget(cancelSelection);
     await cancelSelection.click();
 
-    await page.getByRole('button', { name: /调整参赛卡池/ }).click();
     const roster = page.getByRole('region', { name: '当前阵容' });
-    await roster.getByRole('button', { name: '编辑队伍' }).click();
-    await expectComboboxTouchTarget(
-      roster.getByRole('combobox', { name: '添加武将...' }),
-    );
-    await expectComboboxTouchTarget(
-      roster.getByRole('combobox', { name: '添加战法...' }),
-    );
     await roster
       .getByRole('button', { name: '推荐支援战法' })
       .click();
@@ -1244,6 +1253,42 @@ test.describe('Team Builder manual workshop', () => {
     await expect(page.getByText('已恢复保存', { exact: true })).toHaveCount(0);
   });
 
+  test('preserves player placements while the growing pool receives a new recommendation', async ({
+    page,
+  }) => {
+    await openBuilder(page);
+
+    await page.getByTestId(`pool-hero-${smallHeroes[0]}`).click();
+    await page.getByTestId('hero-slot-0-0').click();
+    await expect(page.getByTestId('hero-slot-0-0')).toContainText(
+      smallHeroes[0]
+    );
+    await expect.poll(() =>
+      page.evaluate(() =>
+        JSON.parse(localStorage.getItem('teamBuilder')).layout[0].heroes[0].hero
+      )
+    ).toBe(smallHeroes[0]);
+
+    const addedHero = heroNames.find(
+      (hero) => ![...smallHeroes, supportHero].includes(hero)
+    );
+    expect(addedHero).toBeTruthy();
+    await page.evaluate((hero) => {
+      const stored = JSON.parse(localStorage.getItem('gameProgress'));
+      stored.gameState.current_heroes.push(hero);
+      localStorage.setItem('gameProgress', JSON.stringify(stored));
+    }, addedHero);
+    await page.reload();
+
+    await expect(
+      page.getByRole('heading', { name: '我的比赛阵容' })
+    ).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText('当前卡池：5 名武将 · 5 个战法')).toBeVisible();
+    await expect(page.getByTestId('hero-slot-0-0')).toContainText(
+      smallHeroes[0]
+    );
+  });
+
   test('whole hero and skill blocks drag, while removal returns the whole hero card to the pool', async ({
     page,
   }) => {
@@ -1469,7 +1514,7 @@ test.describe('Team Builder contextual relationship weights', () => {
     );
 
     const pageHeading = page.getByRole('heading', {
-      level: 1,
+      level: 2,
       name: '队伍策案',
     });
     await page.evaluate(() => document.activeElement?.blur());
@@ -1535,7 +1580,7 @@ test.describe('Team Builder contextual relationship weights', () => {
       timing: 'cubic-bezier(0.2, 0, 0, 1), cubic-bezier(0.2, 0, 0, 1)',
     });
 
-    await page.getByRole('heading', { level: 1, name: '队伍策案' }).hover();
+    await page.getByRole('heading', { level: 2, name: '队伍策案' }).hover();
     await expect(lane).toHaveAttribute(
       'data-relationship-transition-state',
       'exiting',
@@ -1624,7 +1669,7 @@ test.describe('Team Builder contextual relationship weights', () => {
         targetPrimary,
         targetRail,
       );
-      await page.getByRole('heading', { level: 1, name: '队伍策案' }).hover();
+      await page.getByRole('heading', { level: 2, name: '队伍策案' }).hover();
       await expect(page.locator('[data-preview-state]')).toHaveCount(0);
     }
   });
@@ -1660,7 +1705,7 @@ test.describe('Team Builder contextual relationship weights', () => {
           expectedRelationshipCount: 1,
         });
         await page.evaluate(() => document.activeElement?.blur());
-        await page.getByRole('heading', { level: 1, name: '队伍策案' }).hover();
+        await page.getByRole('heading', { level: 2, name: '队伍策案' }).hover();
         await page.waitForTimeout(280);
       }
     }
@@ -1691,7 +1736,7 @@ test.describe('Team Builder contextual relationship weights', () => {
         expectedRelationshipCount: 1,
       });
       await page.evaluate(() => document.activeElement?.blur());
-      await page.getByRole('heading', { level: 1, name: '队伍策案' }).hover();
+      await page.getByRole('heading', { level: 2, name: '队伍策案' }).hover();
       await page.waitForTimeout(280);
 
       const skillOwner = page.getByTestId('skill-slot-0-0-0').locator('..');
@@ -1890,7 +1935,7 @@ test.describe('Team Builder contextual relationship weights', () => {
       await page.keyboard.press('Escape');
       await page.evaluate(() => document.activeElement?.blur());
 
-      await page.getByRole('heading', { level: 1, name: '队伍策案' }).hover();
+      await page.getByRole('heading', { level: 2, name: '队伍策案' }).hover();
       await page.waitForTimeout(280);
       expect(await evidenceSnapshot()).toEqual(evidenceBefore);
       await expect(teamCard.getByTestId('team-strength')).toHaveText(scoreBefore);
@@ -2068,18 +2113,6 @@ test.describe('Team Builder contextual relationship weights', () => {
       await page.waitForTimeout(300);
     }
 
-    await startPointerDrag(page, zhangZhao);
-    const skillScore = page
-      .getByTestId('skill-slot-0-1-0')
-      .locator('..')
-      .getByTestId('relationship-score');
-    await expect(skillScore).toHaveText(zhangZhaoFire.visibleLabel);
-    await movePointerTo(page, skillScore);
-    await page.mouse.up();
-
-    await expect(page.locator('[data-dnd-dragging="true"]')).toHaveCount(0);
-    await expect(zhangZhao).toContainText('张昭');
-    await expect(luXun).toContainText('陆逊');
   });
 
   test('opens a score without selecting or dragging its related card', async ({
@@ -2221,7 +2254,7 @@ test.describe('Team Builder contextual relationship weights', () => {
     await startPointerDrag(page, huangGai);
     await movePointerTo(
       page,
-      page.getByRole('heading', { level: 1, name: '队伍策案' }),
+      page.getByRole('heading', { level: 2, name: '队伍策案' }),
     );
     await page.mouse.up();
 
@@ -2374,8 +2407,8 @@ test.describe('Team Builder best default', () => {
     await expect(page.getByTestId('recommendation-success')).toHaveText(
       '已编入 3 支完整队伍'
     );
-    const debugContext = await page.evaluate(() =>
-      JSON.parse(window.sanmouDebug())
+    const debugContext = await page.evaluate(
+      () => JSON.parse(window.sanmouDebug()).team_builder
     );
     expect(debugContext).toMatchObject({
       schema: 'sanmou-recommendation-debug/v1',
@@ -2478,6 +2511,12 @@ test.describe('Team Builder desktop warehouse', () => {
     page,
   }) => {
     await seedStoredProgress(page, crowdedHeroPoolProgress);
+    const layout = [emptyStoredTeam(), emptyStoredTeam(), emptyStoredTeam()];
+    layout[0].formation = Object.keys(database.formations)[0];
+    await seedTeamBuilderLayout(page, layout, {
+      heroes: heroNames.slice(0, 12),
+      skills: smallSkills,
+    });
     await openBuilder(page);
 
     const heroRepository = page.getByRole('region', { name: '武将仓库' });
@@ -2762,6 +2801,12 @@ test.describe('Team Builder mobile placement', () => {
     page,
   }) => {
     await seedStoredProgress(page, smallPoolProgress);
+    const layout = [emptyStoredTeam(), emptyStoredTeam(), emptyStoredTeam()];
+    layout[0].formation = Object.keys(database.formations)[0];
+    await seedTeamBuilderLayout(page, layout, {
+      heroes: [...smallHeroes, supportHero],
+      skills: [...smallSkills, supportSkill],
+    });
     await openBuilder(page);
 
     const poolHeroButton = page.getByRole('button', {

--- a/web/tests/buildATeam.spec.js
+++ b/web/tests/buildATeam.spec.js
@@ -216,12 +216,14 @@ async function seedTeamBuilderLayout(
   layout,
   { heroes = relationshipHeroes, skills = relationshipSkills } = {},
 ) {
+  const poolKey = JSON.stringify({
+    heroes: [...heroes].sort(),
+    skills: [...skills].sort(),
+  });
   const value = JSON.stringify({
-    version: 2,
-    poolKey: JSON.stringify({
-      heroes: [...heroes].sort(),
-      skills: [...skills].sort(),
-    }),
+    version: 3,
+    poolKey,
+    recommendationPoolKey: poolKey,
     layout,
   });
   await page.addInitScript((storedValue) => {

--- a/web/tests/gameCardVisuals.spec.js
+++ b/web/tests/gameCardVisuals.spec.js
@@ -244,7 +244,6 @@ test.describe('local game-card presentation', () => {
       { ...roundState(), current_skills: Object.keys(manifest.tactics).slice(0, 18) },
       roundInputs()
     );
-    await page.goto('/team-builder');
     await expect(page.getByRole('heading', { name: '我的比赛阵容' })).toBeVisible({
       timeout: 30000,
     });

--- a/web/tests/localAgentTeamBuilder.spec.js
+++ b/web/tests/localAgentTeamBuilder.spec.js
@@ -64,9 +64,9 @@ const emptyTeams = () =>
   }));
 
 async function openBuilder(page, query = '') {
-  await page.goto(`/team-builder${query}`);
+  await page.goto(`/${query}`);
   await expect(
-    page.getByRole('heading', { level: 1, name: '队伍策案' })
+    page.getByRole('heading', { level: 2, name: '队伍策案' })
   ).toBeVisible({ timeout: 30000 });
   await expect(
     page.getByRole('heading', { name: '我的比赛阵容' })
@@ -113,6 +113,30 @@ async function mockLocalAgent(
 test.describe('private local Team Agent experiment', () => {
   test.beforeEach(async ({ page }) => {
     await seedStoredProgress(page, progress);
+    const layout = emptyTeams().map((team) => ({
+      formation: team.formation ?? '',
+      heroes: team.heroes.map((hero) => ({
+        hero: hero.hero,
+        row: hero.row ?? '前排',
+        skills: hero.skills,
+      })),
+    }));
+    layout[0].formation = formations[0];
+    await page.addInitScript(
+      ({ storedLayout, poolKey }) => {
+        localStorage.setItem(
+          'teamBuilder',
+          JSON.stringify({ version: 2, poolKey, layout: storedLayout })
+        );
+      },
+      {
+        storedLayout: layout,
+        poolKey: JSON.stringify({
+          heroes: [...heroes].sort(),
+          skills: [...skills].sort(),
+        }),
+      }
+    );
   });
 
   test('is hidden by default and only contacts localhost after an explicit click', async ({

--- a/web/tests/localAgentTeamBuilder.spec.js
+++ b/web/tests/localAgentTeamBuilder.spec.js
@@ -126,7 +126,12 @@ test.describe('private local Team Agent experiment', () => {
       ({ storedLayout, poolKey }) => {
         localStorage.setItem(
           'teamBuilder',
-          JSON.stringify({ version: 2, poolKey, layout: storedLayout })
+          JSON.stringify({
+            version: 3,
+            poolKey,
+            recommendationPoolKey: poolKey,
+            layout: storedLayout,
+          })
         );
       },
       {

--- a/web/tests/seo.spec.js
+++ b/web/tests/seo.spec.js
@@ -73,12 +73,15 @@ test('primary navigation uses crawlable links', async ({ page }) => {
   );
 });
 
-test('state-dependent and missing routes are not indexable', async ({ page }) => {
+test('the old team-builder route redirects home and missing routes are not indexable', async ({ page }) => {
   await page.goto('/team-builder');
-  await expect(page).toHaveTitle('三国谋定天下演武三队编排｜演武参谋');
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page).toHaveTitle(
+    '三国谋定天下演武配将与战法推荐｜演武参谋'
+  );
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
     'content',
-    'noindex,follow'
+    'index,follow,max-image-preview:large'
   );
 
   await page.goto('/not-a-page');

--- a/web/tests/supportHeroSkills.spec.js
+++ b/web/tests/supportHeroSkills.spec.js
@@ -131,8 +131,10 @@ test.describe('Support Hero & Skills', () => {
     // Dialog should close
     await expect(page.getByRole('heading', { name: '推荐支援武将' })).not.toBeVisible({ timeout: 3000 });
 
-    // Support hero should appear as the first support-labelled card.
-    const supportHeroCard = page.getByTestId(`game-card-hero-${supportHeroCandidate}`);
+    // Support hero should appear as the first support-labelled card in the roster.
+    const supportHeroCard = page
+      .getByRole('region', { name: '当前阵容' })
+      .getByTestId(`game-card-hero-${supportHeroCandidate}`);
     await expect(supportHeroCard).toBeVisible();
     await expect(supportHeroCard.locator('..')).toContainText('★ 支援');
 
@@ -190,9 +192,10 @@ test.describe('Support Hero & Skills', () => {
     // Dialog should close
     await expect(page.getByRole('heading', { name: '推荐支援战法' })).not.toBeVisible({ timeout: 3000 });
 
-    // Support skills should appear as support-labelled cards.
+    // Support skills should appear as support-labelled cards in the roster.
+    const currentRoster = page.getByRole('region', { name: '当前阵容' });
     for (const skillName of supportSkillCandidates) {
-      const card = page.getByTestId(`game-card-tactic-${skillName}`);
+      const card = currentRoster.getByTestId(`game-card-tactic-${skillName}`);
       await expect(card).toBeVisible();
       await expect(card.locator('..')).toContainText('★ 支援');
     }
@@ -204,8 +207,8 @@ test.describe('Support Hero & Skills', () => {
     // removing the other confirmed support tactic.
     await page.getByRole('button', { name: `移除${supportSkillCandidates[0]}` }).click();
     await expect(page.getByRole('button', { name: '推荐支援战法' })).toHaveCount(1);
-    await expect(page.getByTestId(`game-card-tactic-${supportSkillCandidates[1]}`)).toBeVisible();
-    await expect(page.getByTestId(`game-card-tactic-${supportSkillCandidates[0]}`)).toHaveCount(0);
+    await expect(currentRoster.getByTestId(`game-card-tactic-${supportSkillCandidates[1]}`)).toBeVisible();
+    await expect(currentRoster.getByTestId(`game-card-tactic-${supportSkillCandidates[0]}`)).toHaveCount(0);
   });
 
   test('support hero is excluded from round selection inputs', async ({ page }) => {
@@ -222,8 +225,12 @@ test.describe('Support Hero & Skills', () => {
     await page.getByRole('button', { name: '设为支援武将' }).click();
     await expect(page.getByRole('heading', { name: '推荐支援武将' })).not.toBeVisible({ timeout: 3000 });
 
-    // Verify support hero chip is displayed
-    await expect(page.getByTestId(`game-card-hero-${supportHeroCandidate}`)).toBeVisible();
+    // Verify support hero card is displayed in the roster.
+    await expect(
+      page
+        .getByRole('region', { name: '当前阵容' })
+        .getByTestId(`game-card-hero-${supportHeroCandidate}`)
+    ).toBeVisible();
 
     // Now on round 2 (skill round) - advance to round 4 (hero round) would be complex,
     // so instead verify the support hero appears in the team display
@@ -231,8 +238,9 @@ test.describe('Support Hero & Skills', () => {
     await expect(page.getByRole('button', { name: '推荐支援武将' })).not.toBeVisible();
   });
 
-  test('support hero and skills appear exactly once in the team display', async ({ page }) => {
+  test('support hero and skills appear exactly once in the current-roster display', async ({ page }) => {
     await setupGameAndCompleteRound1(page);
+    const teamSection = page.getByRole('region', { name: '当前阵容' });
 
     // Set a support hero
     await page.getByRole('button', { name: '推荐支援武将' }).click();
@@ -244,8 +252,8 @@ test.describe('Support Hero & Skills', () => {
     await page.getByRole('button', { name: '设为支援武将' }).click();
     await expect(page.getByRole('heading', { name: '推荐支援武将' })).not.toBeVisible({ timeout: 3000 });
 
-    // The support label and its local hero card each appear exactly once.
-    await expect(page.getByTestId(`game-card-hero-${supportHeroCandidate}`)).toHaveCount(1);
+    // The support label and its local hero card each appear exactly once in the roster.
+    await expect(teamSection.getByTestId(`game-card-hero-${supportHeroCandidate}`)).toHaveCount(1);
 
     // Set support skills
     await page.getByRole('button', { name: '推荐支援战法' }).first().click();
@@ -268,18 +276,12 @@ test.describe('Support Hero & Skills', () => {
     await page.getByRole('button', { name: '设为支援战法' }).click();
     await expect(page.getByRole('heading', { name: '推荐支援战法' })).not.toBeVisible({ timeout: 3000 });
 
-    // Each support skill should appear exactly once
+    // Each support skill should appear exactly once in the roster.
     for (const skillName of supportSkillCandidates) {
-      await expect(page.getByTestId(`game-card-tactic-${skillName}`)).toHaveCount(1);
+      await expect(teamSection.getByTestId(`game-card-tactic-${skillName}`)).toHaveCount(1);
     }
 
-    // Navigate to TeamBuilder page directly and verify no duplication there either
-    await page.goto('/team-builder');
-    await expect(page.getByRole('heading', { level: 1, name: '队伍策案' })).toBeVisible({ timeout: 5000 });
-    await page.getByText('调整参赛卡池', { exact: true }).click();
-
-    // Scope checks to the 当前阵容 Paper section on TeamBuilder page
-    const teamSection = page.locator('.MuiPaper-root', { hasText: '当前阵容' }).first();
+    await expect(page.getByRole('heading', { level: 2, name: '队伍策案' })).toBeVisible({ timeout: 5000 });
 
     // Support hero should appear exactly once in the team section
     await expect(teamSection.getByTestId(`game-card-hero-${supportHeroCandidate}`)).toHaveCount(1);


### PR DESCRIPTION
## Intent

Merge the standalone /team-builder experience into the active draft page at /, placing the editable three-team workbench below the three offered sets so players can drag, tap, or keyboard-place already-owned heroes and skills while choosing each round. Remove the old 9-hero/18-skill recommendation threshold so evidence-qualified allocation starts with the initial 4-hero/8-skill pool, recomputes as confirmed and support picks expand the pool, and preserves valid player edits while filling open recommendation slots. Remove the dedicated navigation and prerendered page, retain /team-builder only as a backward-compatible redirect to /, and preserve existing scoring, evidence, prompt, accessibility, local-agent, and responsive behavior.

## What Changed

- Embed the editable three-team workbench below the active round’s offered sets, retaining drag, tap, keyboard, scoring, evidence, prompt, and local-agent behavior.
- Remove the 9-hero/18-skill gate so evidence-qualified formations start with the opening pool, recompute as confirmed and support picks expand it, and preserve valid player edits while filling open slots.
- Remove the standalone navigation, SEO, and prerender entry for Team Builder, redirecting `/team-builder` to `/` while preserving query parameters.

## Risk Assessment

✅ Low: The change cleanly embeds the existing workbench, removes the recommendation threshold, preserves edits across pool growth and reloads, and retains legacy redirect/query behavior without a substantiated source defect.

## Testing

Targeted Vitest and Playwright checks exercised partial-pool allocation, drag/tap/keyboard editing, persistence, scoring evidence, prompts, support picks, accessibility, responsive behavior, legacy routing, and the local agent; initial failures were outdated test-fixture setup and one concurrent port collision, both corrected or retried, after which all scoped checks passed and desktop/mobile evidence confirmed the intended experience.

- Evidence: Desktop round-one page showing all three offered sets with the 4-hero/8-skill Team Builder directly below (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1CTPGZMJJ6WAFW31MQRF1M5/desktop-round1-embedded-team-builder.png</code>)
- Evidence: Confirmed round pick expanded the pool to 7 heroes while preserving the tap-placed 于禁 edit (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1CTPGZMJJ6WAFW31MQRF1M5/desktop-after-confirmed-pick-preserves-edit.png</code>)
- Evidence: Support pick expanded the pool to 8 heroes while preserving the player edit (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1CTPGZMJJ6WAFW31MQRF1M5/desktop-after-support-pick-preserves-edit.png</code>)
- Evidence: Responsive opening-pool Team Builder at 390px mobile width (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1CTPGZMJJ6WAFW31MQRF1M5/mobile-round1-team-builder.png</code>)
- Evidence: Legacy /team-builder navigation rendered at the redirected active draft (local file: <code>/var/folders/3m/5ph4vvm12v98v0h7m6p0dmwm0000gn/T/no-mistakes-evidence/01M1CTPGZMJJ6WAFW31MQRF1M5/legacy-team-builder-redirect.png</code>)
<details>
<summary>Evidence: Observable browser evidence and action transcript</summary>

```text
{
  "checks": [
    "the embedded Team Builder follows the three offered sets in document order",
    "the opening 4-hero/8-skill pool is visible",
    "all three offered sets are visible",
    "dedicated Team Builder navigation is absent",
    "the old recommendation threshold is absent",
    "opening-pool evidence produced an automatic partial allocation",
    "desktop view has no horizontal overflow",
    "an unassigned owned hero is available for tap placement",
    "tap-placed 于禁 into team 2 slot 1",
    "a confirmed three-hero pick expanded the pool to 7/8 and preserved the player placement",
    "a support hero candidate is available",
    "a support pick expanded the pool to 8/8 and preserved the player placement",
    "the legacy URL redirects to / while preserving the local-agent query",
    "mobile opening pool count is visible",
    "390px mobile view has no horizontal overflow",
    "no browser console or page errors occurred during evidence capture"
  ],
  "consoleErrors": [],
  "initialPool": {
    "heroes": [
      "乐进",
      "于吉",
      "于禁",
      "公孙瓒"
    ],
    "skills": [
      "一计决胜",
      "万军辟易",
      "万夫莫当",
      "三军夺气",
      "上兵伐谋",
      "上智为间",
      "临危勇烈",
      "临阵突袭"
    ]
  },
  "offeredSets": [
    [
      "关平",
      "关羽",
      "关银屏"
    ],
    [
      "典韦",
      "凌统",
      "刘备"
    ],
    [
      "刘禅",
      "华佗",
      "华雄"
    ]
  ],
  "playerPlacedHero": "于禁",
  "supportHero": "卞夫人"
}
```
</details>
<details>
<summary>Evidence: Normalized production redirect and prerender contract</summary>

```text
{
  "deployedRedirect": {
    "from": "/team-builder",
    "to": "/",
    "status": 301
  },
  "standaloneTeamBuilderPrerender": false,
  "rootHtmlPresent": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d04a9a770627133c6993432664272ffea2299a92","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `web/src/components/teamBuilder/TeamBuilderPanel.tsx:221` - The intent requires “preserves valid player edits while filling open recommendation slots,” but pool growth discards valid non-hero edits. A formation-only layout from the prior pool fails `savedMatchesPool` and is reset, while a tactic-only/headless assignment survives hydration but is then replaced wholesale at lines 271–275 because `teamBuilderLayoutHasHero` is false. Preserve formations and tactic assignments and merge recommendations for any retained edited layout, not only layouts containing a hero.
- 🚨 `web/src/components/teamBuilder/TeamBuilderPanel.tsx:227` - The intent requires recommendations to recompute as picks expand while filling open slots. After pool P grows to P2, lines 242–245 save the old edited layout under P2 before the worker result is applied. If the player reloads or navigates away while calculation is pending, the next mount treats that matching stored pool key as already seeded here, so line 269 skips the P2 merge and its new recommendation slots are never filled. Track the recommendation-applied pool separately, or advance the persisted seed marker only after `applyResult` merges the result.
- 🚨 `web/src/App.tsx:65` - The required backward-compatible `/team-builder` redirect does not preserve existing local-agent behavior: `&lt;Navigate to=&#34;/&#34;&gt;` drops `?local-agent=1` and `?local-agent=0`. The still-current `agent/README.md` directs users to those legacy URLs, and `syncLocalTeamAgentExperiment` reads `window.location.search`; under the Vite environment used with the local agent, `_redirects` is not interpreted, so the flag is lost before the embedded panel mounts. Preserve the query string in the client redirect (and update the documented canonical URL).

🔧 Fix: Preserve expanded-pool edits and legacy query flags
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd web && pnpm exec vitest run src/App.test.tsx src/components/teamBuilder/__tests__/TeamBuilderPanel.test.tsx src/services/__tests__/teamBuilderArrangement.test.ts`
- `cd web && pnpm exec vitest run src/services/__tests__/recommendationEngine.test.ts -t "starts allocating an evidence-qualified team before the pool reaches full size"`
- <code>`cd web &amp;&amp; pnpm exec playwright test tests/buildATeam.spec.js --grep &#34;redirects the removed standalone route|renders below the three draft sets|tap-to-place builds|preserves player placements|whole hero and skill blocks drag|supports keyboard placement&#34;` — initially exposed obsolete schema-v2 fixture seeds, then passed after updating them to schema v3 with the current recommendation pool marker.</code>
- `cd web && pnpm exec playwright test tests/supportHeroSkills.spec.js --grep "can set a support hero|keeps two support tactic slots"`
- <code>`cd web &amp;&amp; pnpm exec playwright test tests/accessibilityLayout.spec.js --grep &#34;removed standalone team-builder URL|mobile team configurations&#34;` — rerun sequentially after an initial concurrent dev-server port collision.</code>
- <code>`cd web &amp;&amp; pnpm exec playwright test tests/localAgentTeamBuilder.spec.js` — initially exposed the same obsolete fixture setup, then passed after its schema-v3 seed correction.</code>
- `cd web && pnpm exec playwright test tests/buildATeam.spec.js --grep "shows one aggregate per target and complete mouse/keyboard breakdowns"`
- <code>`cd web &amp;&amp; pnpm build`, followed by a normalized parser check confirming `/team-builder` deploys as a 301 redirect to `/`, no standalone prerender exists, and the root HTML remains present.</code>
- <code>Started `cd web &amp;&amp; pnpm start --host 127.0.0.1` and used Chromium at desktop and 390px mobile widths to verify the opening 4-hero/8-skill allocation below all three offers, tap placement, preservation after a confirmed three-hero pick, preservation after a support-hero pick, query-preserving legacy redirect, responsive layout, and absence of browser errors or horizontal overflow.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
