### PR TITLE
test(web): preserve raw weights in recommendation debug fixtures

### DIFF
--- a/web/src/services/__tests__/recommendationDebug.test.ts
+++ b/web/src/services/__tests__/recommendationDebug.test.ts
@@ -44,7 +44,8 @@ const option = (
   setIndex: number,
   rank: number,
   score: number,
-  featureId: string
+  featureId: string,
+  featureWeight = score / 10
 ): OptionAnalysis => ({
   set_index: setIndex,
   items: [`item-${setIndex}`],
@@ -64,7 +65,7 @@ const option = (
   },
   debug: {
     rawScore: score / 10,
-    evaluatedFeatures: [evaluatedFeature(featureId, score / 10, 10)],
+    evaluatedFeatures: [evaluatedFeature(featureId, featureWeight, 10)],
   },
 });
 
@@ -257,7 +258,15 @@ describe('recommendation browser debug context', () => {
         currentRoundInputs: { set1: ['appearance-lift'], set2: [], set3: [] },
         recommendation: {
           recommended_set_index: 0,
-          analysis: [option(0, 1, component.final_weight * 10, featureId)],
+          analysis: [
+            option(
+              0,
+              1,
+              component.final_weight * 10,
+              featureId,
+              component.final_weight
+            ),
+          ],
         },
       });
       const scoreRow = (
@@ -277,6 +286,45 @@ describe('recommendation browser debug context', () => {
       );
       expect(component.count_adjustment).toBeGreaterThan(0);
     }
+  });
+
+  test('preserves an exact raw model weight that does not round-trip through display points', () => {
+    const featureId = 'HS|乐进|七进七出';
+    const exactModelWeight = -0.030764;
+    const displayScore = exactModelWeight * 10;
+    expect(displayScore / 10).not.toBe(exactModelWeight);
+
+    const context = buildRoundRecommendationDebugContext({
+      season: 16,
+      roundType: 'skill',
+      gameState: {
+        current_heroes: [],
+        current_skills: [],
+        support_hero: null,
+        support_skills: [],
+        round_number: 1,
+        round_history: [],
+      },
+      currentRoundInputs: { set1: ['七进七出'], set2: [], set3: [] },
+      recommendation: {
+        recommended_set_index: 0,
+        analysis: [
+          option(0, 1, displayScore, featureId, exactModelWeight),
+        ],
+      },
+    });
+    const scoreRow = (
+      context.options as Array<{
+        score_calculation: Array<Record<string, unknown>>;
+      }>
+    )[0].score_calculation[0];
+
+    expect(scoreRow).toMatchObject({
+      feature_id: featureId,
+      weight: exactModelWeight,
+      relationship_components:
+        recommendationData.model.relationship_components?.[featureId],
+    });
   });
 
   test('reports not-ready context before a round recommendation exists', () => {


### PR DESCRIPTION
The scheduled web-battle import fails its HP/HS debug test when a rebuilt coefficient is `-0.030764`: the fixture converts the weight to display points and back, yielding `-0.030764000000000003`, which fails strict equality.

Pass the raw feature weight directly into the fixture and add a regression through the real debug exporter using the failing value. Exact weight and decomposition-metadata assertions remain intact. The change is confined to `recommendationDebug.test.ts`.

Validation: reproduced the failure before the fix and confirmed it passes afterward. Type-checking, 587 unit tests, 80 dev-server and 20 prerender Playwright tests, and the production build passed locally. The no-mistakes review found no issues; GitHub Web checks, Required PR checks, and Cloudflare Pages are green.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"06f872e64de36b9f4747d44e5e7551e5063159d2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd web && pnpm exec vitest run src/services/__tests__/recommendationDebug.test.ts -t 'exposes outcome, appearance, and final components for HP/HS scoring rows|preserves an exact raw model weight that does not round-trip through display points'`
- <code>Reconstructed the pre-fix fixture behavior by omitting the raw `featureWeight`, then ran its focused Vitest regression to confirm `-0.030764` became `-0.030764000000000003` and failed strict equality.</code>
- <code>Ran a temporary evidence test through `buildRoundRecommendationDebugContext` and confirmed the exported weight remained exactly `-0.030764` while relationship decomposition metadata was preserved.</code>
- `cd web && pnpm exec vitest run src/services/__tests__/recommendationDebug.test.ts`
- <code>Verified the commit diff is limited to `web/src/services/__tests__/recommendationDebug.test.ts` and removed all temporary evidence-test files from the worktree.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
