### PR TITLE
feat(data): import Yanwu guide revision for 2026-09-08

### DIFF
--- a/.agents/manual-skills/update-game-database-from-csv/SKILL.md
+++ b/.agents/manual-skills/update-game-database-from-csv/SKILL.md
@@ -10,16 +10,16 @@ allowed-tools:
 # Update Game Database From Workbook
 
 Use `data/import_yanwu_workbook.py`; do not hand-edit the generated workbook
-fields in `web/public/game-data/database.json`. The local source retains its
-reviewed historical filename, while generated public metadata uses the separate
-current-name label `三谋演武-但丁与你.xlsx`. Follow the repository's approved
-plan/feature-branch lifecycle before changing the importer, schema, or UI.
+fields in `web/public/game-data/database.json`. The reviewed local source and
+generated public metadata both use the current-name label
+`三谋演武-但丁与你.xlsx`. Follow the repository's approved plan/feature-branch
+lifecycle before changing the importer, schema, or UI.
 
 ## Import workflow
 
 1. Put the source at the repository root with the exact filename
-   `三谋演武-飞将吕布.xlsx`. Treat it as read-only and never commit it.
-   Confirm `git check-ignore -v '三谋演武-飞将吕布.xlsx'` succeeds.
+   `三谋演武-但丁与你.xlsx`. Treat it as read-only and never commit it.
+   Confirm `git check-ignore -v '三谋演武-但丁与你.xlsx'` succeeds.
 2. Run the default dry run:
 
    ```bash
@@ -28,10 +28,9 @@ plan/feature-branch lifecycle before changing the importer, schema, or UI.
 
 3. Stop on any validation error. Do not fuzzy-match, silently skip a cell, or
    invent an alias. Report every unknown hero, skill, formation, category, or
-   layout change with its source cell. This immutable revision spans the
-   author's rename: validate the exact per-sheet author markers already encoded
-   by the importer, then normalize them to 但丁与你 in generated metadata. Add
-   any other exact alias only after explicit review and a focused test.
+   layout change with its source cell. This immutable revision uses the exact
+   current-name author marker `但丁与你` in every reviewed source cell. Add any
+   other exact alias only after explicit review and a focused test.
 4. Require exactly these sheets, in order:
 
    ```yaml
@@ -54,7 +53,7 @@ plan/feature-branch lifecycle before changing the importer, schema, or UI.
    ```yaml
    provider: 但丁与你
    workbook: 三谋演武-但丁与你.xlsx
-   updatedAt: 2026-09-02
+   updatedAt: 2026-09-08
    attribution: 攻略数据由但丁与你提供
    ```
 
@@ -109,9 +108,9 @@ plan/feature-branch lifecycle before changing the importer, schema, or UI.
   coordinate. The two 司马懿/曹操/曹丕 variants are distinguished by the
   presence of `运智铺谋` plus `谋而后动`. Fail if any label resolves to zero
   or multiple builds.
-- The exact reviewed old-name and current-name author markers in the source
-  sheets refer to the same author. Import all seven sheets, but emit only
-  `但丁与你` in the public provider, workbook label, and attribution fields.
+- Every reviewed source-sheet author marker is exactly `但丁与你`. Import all
+  seven sheets and emit `但丁与你` in the public provider, workbook label, and
+  attribution fields; historical aliases are not accepted for this revision.
 - Contact prefaces and directory links are never imported. Reject contact or
   URL markers in the generated `yanwuGuide` payload. Attribution and the two
   explicitly approved Bilibili/Douyin profile links appear only on
@@ -122,17 +121,21 @@ plan/feature-branch lifecycle before changing the importer, schema, or UI.
 
 ## Layout-drift response
 
-An earlier seven-sheet revision attributed every sheet to `飞将吕布`, ranked all
-100 catalog heroes, and pinned a full timestamp. The current immutable revision
-uses reviewed source markers from both sides of the same author's rename,
-normalizes public attribution to `但丁与你`, intentionally leaves `小乔`
-unranked, and pins the source's date-only value. Before that, the workbook used
-five sheets, the filename `三谋吕布-演武.xlsx`, provider `三谋吕布`, fixed
-matchup row anchors, and no imported skill ranking sheet. If a future workbook
-changes filename, author markers, sheet order, categories, cardinalities, or
-matchup identity, stop at dry-run, report the complete drift, agree on the new
-contract, then update the importer, focused tests, this skill, and affected UI
-together.
+The current immutable seven-sheet revision uses the filename and author marker
+`但丁与你` throughout, intentionally leaves `小乔` unranked, and pins the
+source's date-only value `2026-09-08`. Compared with the 2026-09-02 revision,
+曹纯 moved from C to B, while 甄洛 and 周泰 moved from B to C and 吕蒙 moved
+from C to D; skill rankings, builds, matchups, championship groups, analyses,
+and audited cardinalities did not change. That previous revision used reviewed
+source markers from both sides of the author's rename and retained the local
+filename `三谋演武-飞将吕布.xlsx`. An earlier seven-sheet revision attributed
+every sheet to `飞将吕布`, ranked all 100 catalog heroes, and pinned a full
+timestamp. Before that, the workbook used five sheets, the filename
+`三谋吕布-演武.xlsx`, provider `三谋吕布`, fixed matchup row anchors, and no
+imported skill ranking sheet. If a future workbook changes filename, author
+markers, sheet order, categories, cardinalities, or matchup identity, stop at
+dry-run, report the complete drift, agree on the new contract, then update the
+importer, focused tests, this skill, and affected UI together.
 
 The importer is dry-run by default, validates before writing, and uses an atomic
 replace only when output bytes changed.

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ bilibili/
 # Local guide source (contains provider contact details; import derived data only)
 三谋吕布-演武.xlsx
 三谋演武-飞将吕布.xlsx
+三谋演武-但丁与你.xlsx
 
 # Playwright test output
 test-results/

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ patterns can be reviewed later; transport submission IDs remain D1-only.
 - `make build-telemetry EXPORT=/path/to/round_telemetry.sql` — validate the
   current D1 table export, fold rows newer than the committed cursor, and
   rebuild the public aggregate artifact plus `data/telemetry_state.json`.
-- `make import-yanwu` — validate the local seven-sheet
-  `三谋演武-但丁与你.xlsx` without writing; `make import-yanwu APPLY=1` atomically
-  updates the derived guide data in `database.json`.
+- `make import-yanwu` — validate the local seven-sheet workbook under the
+  [reviewed import contract](.agents/manual-skills/update-game-database-from-csv/SKILL.md#import-workflow)
+  without writing; `make import-yanwu APPLY=1` atomically updates the derived
+  guide data in `database.json`.
 - `make web` — start the React dev server (http://localhost:3000).
 
 ## Recommendation pipeline
@@ -514,8 +515,9 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
   `pnpm recommend` fixture run.
 - `data/import_yanwu_workbook.py` — strict, deterministic seven-sheet workbook
   importer. It defaults to a no-write dry run and requires `--apply` to update
-  `web/public/game-data/database.json`; the reviewed local source remains
-  untracked and uses the same `三谋演武-但丁与你.xlsx` label as public metadata.
+  `web/public/game-data/database.json`; its exact local-source and metadata
+  contract is owned by the
+  [reviewed import workflow](.agents/manual-skills/update-game-database-from-csv/SKILL.md#import-workflow).
 - `data/mechanics_contract.py` — strict production/evaluation loader and minimal
   browser scoring-contract derivation for reviewed MECH relationships.
 - `data/manage_mech_catalog.py` — deterministic lifecycle tooling for the

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ patterns can be reviewed later; transport submission IDs remain D1-only.
   current D1 table export, fold rows newer than the committed cursor, and
   rebuild the public aggregate artifact plus `data/telemetry_state.json`.
 - `make import-yanwu` — validate the local seven-sheet
-  `三谋演武-飞将吕布.xlsx` without writing; `make import-yanwu APPLY=1` atomically
+  `三谋演武-但丁与你.xlsx` without writing; `make import-yanwu APPLY=1` atomically
   updates the derived guide data in `database.json`.
 - `make web` — start the React dev server (http://localhost:3000).
 
@@ -514,8 +514,8 @@ pnpm dlx wrangler@4.112.0 d1 execute "$CLOUDFLARE_D1_DATABASE_NAME" \
   `pnpm recommend` fixture run.
 - `data/import_yanwu_workbook.py` — strict, deterministic seven-sheet workbook
   importer. It defaults to a no-write dry run and requires `--apply` to update
-  `web/public/game-data/database.json`; the historical local source filename
-  stays untracked while public metadata uses `三谋演武-但丁与你.xlsx`.
+  `web/public/game-data/database.json`; the reviewed local source remains
+  untracked and uses the same `三谋演武-但丁与你.xlsx` label as public metadata.
 - `data/mechanics_contract.py` — strict production/evaluation loader and minimal
   browser scoring-contract derivation for reviewed MECH relationships.
 - `data/manage_mech_catalog.py` — deterministic lifecycle tooling for the

--- a/data/import_yanwu_workbook.py
+++ b/data/import_yanwu_workbook.py
@@ -27,7 +27,7 @@ from openpyxl.worksheet.worksheet import Worksheet
 
 
 ROOT = Path(__file__).resolve().parents[1]
-LOCAL_WORKBOOK_NAME = "三谋演武-飞将吕布.xlsx"
+LOCAL_WORKBOOK_NAME = "三谋演武-但丁与你.xlsx"
 PUBLIC_WORKBOOK_LABEL = "三谋演武-但丁与你.xlsx"
 DEFAULT_WORKBOOK = ROOT / LOCAL_WORKBOOK_NAME
 DEFAULT_DATABASE = ROOT / "web/public/game-data/database.json"
@@ -45,19 +45,18 @@ PROVIDER = "但丁与你"
 # This is the reviewed date printed by this immutable workbook revision.
 # Keeping it source-controlled preserves byte-for-byte idempotence without
 # inventing a time that the source does not provide.
-UPDATED_AT = "2026-09-02"
+UPDATED_AT = "2026-09-08"
 ATTRIBUTION = "攻略数据由但丁与你提供"
 
-# The workbook was assembled across the author's rename. These exact source
-# markers identify the same reviewed author and normalize to PROVIDER in the
-# generated database; no other aliases or fuzzy matching are accepted.
+# The reviewed current-name marker must appear in every source data sheet; no
+# historical aliases or fuzzy matching are accepted for this workbook revision.
 SOURCE_PROVIDER_CELLS = {
     ("武将Tier", "A2"): "但丁与你",
-    ("战法Tier", "A2"): "飞将吕布",
-    ("强队Tier", "B2"): "飞将吕布",
-    ("克制关系", "A1"): "飞将吕布",
-    ("夺冠御三家", "A2"): "飞将吕布",
-    ("阵容解析", "B2"): "飞将吕布",
+    ("战法Tier", "A2"): "但丁与你",
+    ("强队Tier", "B2"): "但丁与你",
+    ("克制关系", "A1"): "但丁与你",
+    ("夺冠御三家", "A2"): "但丁与你",
+    ("阵容解析", "B2"): "但丁与你",
 }
 
 HERO_RANKINGS = ("S", "A", "B", "C", "D")

--- a/data/test_import_yanwu_workbook.py
+++ b/data/test_import_yanwu_workbook.py
@@ -45,14 +45,14 @@ from data.import_yanwu_workbook import (
 )
 
 
-def test_reviewed_author_markers_cover_the_renamed_workbook_layout() -> None:
+def test_reviewed_author_markers_cover_the_current_workbook_layout() -> None:
     assert SOURCE_PROVIDER_CELLS == {
         ("武将Tier", "A2"): "但丁与你",
-        ("战法Tier", "A2"): "飞将吕布",
-        ("强队Tier", "B2"): "飞将吕布",
-        ("克制关系", "A1"): "飞将吕布",
-        ("夺冠御三家", "A2"): "飞将吕布",
-        ("阵容解析", "B2"): "飞将吕布",
+        ("战法Tier", "A2"): "但丁与你",
+        ("强队Tier", "B2"): "但丁与你",
+        ("克制关系", "A1"): "但丁与你",
+        ("夺冠御三家", "A2"): "但丁与你",
+        ("阵容解析", "B2"): "但丁与你",
     }
     workbook = Workbook()
     workbook.active.title = EXPECTED_SHEETS[0]
@@ -525,7 +525,7 @@ def _valid_database() -> dict[str, object]:
     }
 
 
-def test_published_database_uses_the_current_workbook_label() -> None:
+def test_published_database_uses_the_current_workbook_revision() -> None:
     database_path = (
         Path(__file__).resolve().parents[1]
         / "web/public/game-data/database.json"
@@ -539,18 +539,27 @@ def test_published_database_uses_the_current_workbook_label() -> None:
         "updatedAt": UPDATED_AT,
         "attribution": ATTRIBUTION,
     }
+    assert {
+        hero: database["heroes"][hero]["ranking"]
+        for hero in ("曹纯", "甄洛", "周泰", "吕蒙")
+    } == {
+        "曹纯": "B",
+        "甄洛": "C",
+        "周泰": "C",
+        "吕蒙": "D",
+    }
 
 
 def test_generated_database_invariants_cover_schema_and_references() -> None:
     database = _valid_database()
     validate_generated_database(database)
 
-    local_filename_in_public_metadata = copy.deepcopy(database)
-    local_filename_in_public_metadata["yanwuGuide"]["source"]["workbook"] = (
-        LOCAL_WORKBOOK_NAME
+    historical_filename_in_public_metadata = copy.deepcopy(database)
+    historical_filename_in_public_metadata["yanwuGuide"]["source"]["workbook"] = (
+        "三谋演武-飞将吕布.xlsx"
     )
     with pytest.raises(ImportValidationError, match="source metadata"):
-        validate_generated_database(local_filename_in_public_metadata)
+        validate_generated_database(historical_filename_in_public_metadata)
 
     unranked_hero = copy.deepcopy(database)
     unranked_hero["heroes"]["甲"].pop("ranking")
@@ -589,14 +598,14 @@ def test_audited_workbook_cardinalities_fail_closed() -> None:
         validate_import_cardinalities(missing_build)
 
 
-def test_import_keeps_the_historical_local_filename_contract(tmp_path: Path) -> None:
+def test_import_uses_the_current_local_filename_contract(tmp_path: Path) -> None:
     database_path = tmp_path / "database.json"
     database_path.write_text("{}", encoding="utf-8")
 
-    public_label_path = tmp_path / PUBLIC_WORKBOOK_LABEL
-    public_label_path.touch()
+    historical_path = tmp_path / "三谋演武-飞将吕布.xlsx"
+    historical_path.touch()
     with pytest.raises(ImportValidationError, match="workbook filename must be"):
-        run_import(public_label_path, database_path, apply=False)
+        run_import(historical_path, database_path, apply=False)
 
     local_path = tmp_path / LOCAL_WORKBOOK_NAME
     local_path.touch()

--- a/web/README.md
+++ b/web/README.md
@@ -360,12 +360,12 @@ Core app data is bundled at build time. Copied web-LLM prompts may fetch the pub
   label `三谋演武-但丁与你.xlsx`, plus the 13×13 matchup matrix, five championship
   reference groups, and analysis sections. Copied
   prompts link to the file with a weekly `?v=<week-start-date>` cache-buster.
-- `../data/import_yanwu_workbook.py` — validates the exact seven-sheet
-  `三谋演武-但丁与你.xlsx` contract and renders the guide-backed portion of the
-  database deterministically. It is dry-run by default, writes only with
-  `--apply`, requires the reviewed current-name author markers, and excludes the
-  workbook's contact line. The separately reviewed social profile links are
-  page-owned content, not imported workbook payload.
+- `../data/import_yanwu_workbook.py` — implements the
+  [reviewed seven-sheet import contract](../.agents/manual-skills/update-game-database-from-csv/SKILL.md#import-workflow)
+  and renders the guide-backed portion of the database deterministically. It is
+  dry-run by default, writes only with `--apply`, and excludes the workbook's
+  contact line. The separately reviewed social profile links are page-owned
+  content, not imported workbook payload.
 - `public/game-data/formula.md` — public formula reference for copied web-LLM prompts.
 - `src/recommendation_data.json` — the paired-model artifact **generated** by
   `data/build_recommendation_data.py` (don't hand-edit).

--- a/web/README.md
+++ b/web/README.md
@@ -361,12 +361,11 @@ Core app data is bundled at build time. Copied web-LLM prompts may fetch the pub
   reference groups, and analysis sections. Copied
   prompts link to the file with a weekly `?v=<week-start-date>` cache-buster.
 - `../data/import_yanwu_workbook.py` — validates the exact seven-sheet
-  `三谋演武-飞将吕布.xlsx` contract and renders the guide-backed portion of the
+  `三谋演武-但丁与你.xlsx` contract and renders the guide-backed portion of the
   database deterministically. It is dry-run by default, writes only with
-  `--apply`, publishes the separate current-name workbook label
-  `三谋演武-但丁与你.xlsx`, normalizes the reviewed author-name markers to 但丁与你, and
-  excludes the workbook's contact line. The separately reviewed social profile
-  links are page-owned content, not imported workbook payload.
+  `--apply`, requires the reviewed current-name author markers, and excludes the
+  workbook's contact line. The separately reviewed social profile links are
+  page-owned content, not imported workbook payload.
 - `public/game-data/formula.md` — public formula reference for copied web-LLM prompts.
 - `src/recommendation_data.json` — the paired-model artifact **generated** by
   `data/build_recommendation_data.py` (don't hand-edit).

--- a/web/public/game-data/database.json
+++ b/web/public/game-data/database.json
@@ -375,7 +375,7 @@
         "xg": 167
       },
       "season": 4,
-      "ranking": "C"
+      "ranking": "B"
     },
     "司马懿": {
       "skill": "鹰视狼顾",
@@ -440,7 +440,7 @@
         "xg": 129
       },
       "season": 3,
-      "ranking": "B"
+      "ranking": "C"
     },
     "公孙瓒": {
       "skill": "威震塞外",
@@ -726,7 +726,7 @@
         "xg": 126
       },
       "season": 1,
-      "ranking": "B"
+      "ranking": "C"
     },
     "刘备": {
       "skill": "携民渡江",
@@ -972,7 +972,7 @@
         "xg": 176
       },
       "season": 1,
-      "ranking": "C"
+      "ranking": "D"
     },
     "太史慈": {
       "skill": "弦无虛发",
@@ -7524,7 +7524,7 @@
     "source": {
       "provider": "但丁与你",
       "workbook": "三谋演武-但丁与你.xlsx",
-      "updatedAt": "2026-09-02",
+      "updatedAt": "2026-09-08",
       "attribution": "攻略数据由但丁与你提供"
     },
     "matchups": {


### PR DESCRIPTION
## Intent

Apply the new game-data changes from the reviewed 三谋演武-但丁与你.xlsx workbook, update the update-game-database-from-csv manual skill, and create a pull request through no-mistakes. Adopt the current workbook filename and exact 但丁与你 author markers, pin the source date to 2026-09-08, and regenerate database.json so only 曹纯 C→B, 甄洛 B→C, 周泰 B→C, 吕蒙 C→D, and the reviewed source date change. Keep the XLSX ignored and uncommitted, preserve unchanged skill/team/matchup/championship/analysis data and audited cardinalities, update importer tests and documentation, and prove dry-run validation, apply idempotence, JSON validity, and all required web checks.

## What Changed

- Update the Yanwu guide source date to 2026-09-08 and adjust only four hero rankings: 曹纯 C→B, 甄洛 B→C, 周泰 B→C, and 吕蒙 C→D.
- Require the current `三谋演武-但丁与你.xlsx` filename and exact `但丁与你` source markers, with importer tests covering the revised contract and published data.
- Ignore the local workbook and align the manual import skill and project documentation with the current seven-sheet workflow.

## Risk Assessment

✅ Low: The change is narrowly scoped and the database diff contains exactly the four required ranking transitions plus the source-date update, while all other audited guide data remains unchanged.

## Testing

No prior baseline test results were supplied; focused importer tests, marker rejection, dry-run/apply/idempotence round-trip, semantic base/target audit, guide rendering tests, production build/prerender checks, and visual evidence all succeeded, and transient worktree outputs were removed.

- Evidence: Rendered Yanwu guide attribution and 2026-09-08 update date (local file: <code>~/.no-mistakes/evidence/01M1ZMHPKW4K3YQH45M551YB3J/yanwu-guide-attribution-2026-09-08.png</code>)
- Evidence: Rendered national hero rankings showing the reviewed tier placements (local file: <code>~/.no-mistakes/evidence/01M1ZMHPKW4K3YQH45M551YB3J/yanwu-guide-reviewed-hero-tiers.png</code>)

<details>
<summary>Evidence: Semantic database delta, preserved payload hashes, JSON validity, and audited cardinalities</summary>

```text
database.json: valid JSON
exact semantic changes:
  heroes.吕蒙.ranking: C -> D
  heroes.周泰.ranking: B -> C
  heroes.曹纯.ranking: C -> B
  heroes.甄洛.ranking: B -> C
  yanwuGuide.source.updatedAt: 2026-09-02 -> 2026-09-08
source metadata: 但丁与你 | 三谋演武-但丁与你.xlsx | 2026-09-08
unchanged payload hashes:
  skills: 15829f4f56c7062bfbcf500b25cb8ab1ca600c600626fd671bb16366397396f5
  teams: fad54e76bc87fe2183fe540b4ff0c839086b9785b9e0ea806ca244cb54d4c564
  matchups: 1322bc207f1e44e02d9f3ffbf8ef9cc65ccd8aa03c0193e2e01d1544bbea23b5
  championshipGroups: be53d7e915edc0c9cfa2be7a67b7327dfeb49c790784330631905d5256bd5e84
  analysisSections: 8dc4faeeb81f7c2ad0170e6218be899c5e8d63950b1e820bffb99c5b4a8878ea
audited cardinalities:
  heroes=100
  ranked_heroes=99
  skills=231
  ranked_skills=98
  skill_categories=6
  strong_entries=70
  championship_entries=15
  teams=79
  cross_source_overlaps=3
  matchup_builds=13
  championship_groups=5
  analysis_sections=2
  analysis_points=6
database sha256: cbece60a43362b56ff3a3f670b85619c7c8f884654b948f678c66e09ad10ef9f
RESULT: target database has only the four reviewed tier moves and source-date update; all preserved payloads and audited cardinalities match.
```
</details>
<details>
<summary>Evidence: Importer dry-run, first apply, idempotent second apply, and byte-identity transcript</summary>

```text
=== dry run against base database copy ===
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- index
mode=dry-run
heroes=100
ranked_heroes=99
skills=231
ranked_skills=98
skill_categories=6
strong_entries=70
championship_entries=15
teams=79
cross_source_overlaps=3
matchup_builds=13
championship_groups=5
analysis_sections=2
analysis_points=6
changes=yes
written=no
dry-run only; pass --apply to replace the database atomically
=== first apply ===
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- index
mode=apply
heroes=100
ranked_heroes=99
skills=231
ranked_skills=98
skill_categories=6
strong_entries=70
championship_entries=15
teams=79
cross_source_overlaps=3
matchup_builds=13
championship_groups=5
analysis_sections=2
analysis_points=6
changes=yes
written=yes
=== second apply (idempotence) ===
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- index
mode=apply
heroes=100
ranked_heroes=99
skills=231
ranked_skills=98
skill_categories=6
strong_entries=70
championship_entries=15
teams=79
cross_source_overlaps=3
matchup_builds=13
championship_groups=5
analysis_sections=2
analysis_points=6
changes=no
written=no
=== generated output identity ===
cbece60a43362b56ff3a3f670b85619c7c8f884654b948f678c66e09ad10ef9f  ~/.no-mistakes/evidence/01M1ZMHPKW4K3YQH45M551YB3J/importer-e2e/database.json
cbece60a43362b56ff3a3f670b85619c7c8f884654b948f678c66e09ad10ef9f  web/public/game-data/database.json
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"670630d1844ef44222be804615589ef13a3cdbb2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `uv run pytest data/test_import_yanwu_workbook.py -v`
- <code>Executed `_validate_provider` against all six reviewed source cells, accepting exact `但丁与你` markers and rejecting `飞将吕布` with cell-specific diagnostics.</code>
- <code>Compared the parsed public `database.json` against base commit `a4ed14163ae9cc39054fec89e036a7dfd51a27a8`, asserting exactly five semantic changes and identical skill, team, matchup, championship, and analysis payloads.</code>
- <code>Generated a deterministic seven-sheet evidence workbook from the committed target contract, then ran `data/import_yanwu_workbook.py` in dry-run, first-apply, and second-apply modes against a base database copy; the applied output was byte-identical to committed `database.json` and the second apply wrote nothing.</code>
- <code>`git check-ignore -v --no-index &#39;三谋演武-但丁与你.xlsx&#39;` and `git ls-files --error-unmatch &#39;三谋演武-但丁与你.xlsx&#39;`</code>
- `cd web && pnpm exec vitest run src/components/game/__tests__/AnalysisGrid.test.tsx`
- `cd web && pnpm exec playwright test tests/yanwuGuide.spec.js`
- `cd web && pnpm build`
- `cd web && pnpm exec playwright test tests-production/prerender.spec.js --config playwright.prerender.config.js --grep 'production HTML contains|/guides/yanwu keeps its page content visible|content-rich routes expose'`
- <code>Loaded the production preview in Chromium, asserted the rendered `但丁与你` attribution, `2026-09-08` date, and 曹纯=B、甄洛=C、周泰=C、吕蒙=D placements, then captured reviewer-visible screenshots.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
