### PR TITLE
fix(web): unlock all support heroes from season four onward

### DIFF
--- a/GAME_RULE.md
+++ b/GAME_RULE.md
@@ -15,14 +15,16 @@ and project orientation.
 - Round 4: Select 1 hero set from 3 options (each set contains 3 heroes)
 - Round 5: Select 1 skill set from 3 options (each set contains 3 skills)
 - Round 6: Select 1 skill set from 3 options (each set contains 3 skills)
-- **Optional support pick (unchanged):** After Round 6, the current-team panel
+- **Optional support pick:** After Round 6, the current-team panel
   may add 1 unchosen hero and 2 unchosen non-hero skills. The support choices
   use the existing `recommendSingleHero` / `recommendTwoSkills`
   recommendations and are carried through the later rounds. Support heroes
-  unlock cumulatively in S1–S3 (S1 only, S1–S2, then S1–S3); from S4 onward,
-  heroes from every season are available. Owned heroes and active offered-set
-  heroes remain excluded from support choices. Support skills retain their
-  existing introduction-season ≤ player-season limit.
+  unlock cumulatively by introduction season in S1–S3 (S1 only, S1–S2, then
+  S1–S3); from S4 onward, heroes from every season are available, including
+  later seasons. Automatic recommendations and manual support search use the
+  same eligibility rules. Owned heroes and active offered-set heroes remain
+  excluded from support choices. Support skills retain their existing
+  introduction-season ≤ player-season limit.
 - **Qualification after Round 6:** Confirm the win in one click to unlock Round 7.
 - Round 7: Select 1 hero set from 3 options (each set contains 2 heroes)
 - Round 8: Select 1 skill set from 3 options (each set contains 3 skills)

--- a/GAME_RULE.md
+++ b/GAME_RULE.md
@@ -18,7 +18,11 @@ and project orientation.
 - **Optional support pick (unchanged):** After Round 6, the current-team panel
   may add 1 unchosen hero and 2 unchosen non-hero skills. The support choices
   use the existing `recommendSingleHero` / `recommendTwoSkills`
-  recommendations and are carried through the later rounds.
+  recommendations and are carried through the later rounds. Support heroes
+  unlock cumulatively in S1–S3 (S1 only, S1–S2, then S1–S3); from S4 onward,
+  heroes from every season are available. Owned heroes and active offered-set
+  heroes remain excluded from support choices. Support skills retain their
+  existing introduction-season ≤ player-season limit.
 - **Qualification after Round 6:** Confirm the win in one click to unlock Round 7.
 - Round 7: Select 1 hero set from 3 options (each set contains 2 heroes)
 - Round 8: Select 1 skill set from 3 options (each set contains 3 skills)

--- a/web/README.md
+++ b/web/README.md
@@ -13,9 +13,8 @@ the model data is generated and community reports are imported.
 
 - **Setup Phase**: Select starting heroes and skills with pinyin search support,
   and pick the current season (defaults to the latest available). Initial setup
-  and round inputs remain season-unrestricted. Support heroes unlock
-  cumulatively in S1–S3, then all hero seasons unlock from S4 onward; support
-  skills still require an introduction season no later than the player's season.
+  and round inputs remain season-unrestricted. See
+  [GAME_RULE.md](../GAME_RULE.md#game-flow) for support eligibility.
 - **每天演武 (Beta)**: `/daily-yanwu` is an immersive opening-draw demo with one
   fixed public hero, three initially hidden personal-hero slots, and eight public
   tactics. It draws three distinct heroes from the local art-backed pool,
@@ -229,9 +228,10 @@ support items, without recommending or applying a formation.
   one support slot first and the tactic list places two first; each open slot
   displays only a plus sign. Accepting a support choice replaces only the open
   slot or slots, keeps selected support cards ahead of the ordinary roster, and
-  removing one restores its placeholder. Active A/B/C offers are excluded from
-  roster and support editing, while option editing and saved-progress restore
-  reject owned roster items, so offers and the roster remain disjoint. A roster
+  removing one restores its placeholder. Manual roster additions share the
+  [support season rules](../GAME_RULE.md#game-flow). Active A/B/C offers are
+  excluded from roster and support editing, while option editing and saved-progress
+  restore reject owned roster items, so offers and the roster remain disjoint. A roster
   save or support change keeps the active offers, current recommendation, and
   selected option visible while automatically rescoring them. Only a request
   for the newest roster revision may replace those scores or settle the analysis

--- a/web/README.md
+++ b/web/README.md
@@ -11,7 +11,11 @@ the model data is generated and community reports are imported.
 
 ## Features
 
-- **Setup Phase**: Select starting heroes and skills with pinyin search support, and pick the current season (defaults to the latest available; the season only limits support hero/skill availability, not initial setup or round inputs)
+- **Setup Phase**: Select starting heroes and skills with pinyin search support,
+  and pick the current season (defaults to the latest available). Initial setup
+  and round inputs remain season-unrestricted. Support heroes unlock
+  cumulatively in S1–S3, then all hero seasons unlock from S4 onward; support
+  skills still require an introduction season no later than the player's season.
 - **每天演武 (Beta)**: `/daily-yanwu` is an immersive opening-draw demo with one
   fixed public hero, three initially hidden personal-hero slots, and eight public
   tactics. It draws three distinct heroes from the local art-backed pool,

--- a/web/src/components/game/CurrentTeam.tsx
+++ b/web/src/components/game/CurrentTeam.tsx
@@ -62,10 +62,11 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
     () => new Set(Object.values(state.currentRoundInputs ?? {}).flat()),
     [state.currentRoundInputs],
   );
+  // Intentionally shared by roster additions, support recommendations,
+  // and manual support search.
   const supportAvailableHeroes = useMemo(
     () => (availableHeroes || []).filter((hero) => {
       const season = seasonHeroMetadata[hero]?.season;
-      // S1–S3 unlock heroes cumulatively; S4+ unlocks every hero season.
       return (
         !activeOfferItems.has(hero) &&
         (selectedSeason === null || selectedSeason >= 4 || season === undefined || season <= selectedSeason)

--- a/web/src/components/game/CurrentTeam.tsx
+++ b/web/src/components/game/CurrentTeam.tsx
@@ -65,9 +65,10 @@ const CurrentTeam = ({ heroes, skills, availableHeroes, heroMetadata = null, ski
   const supportAvailableHeroes = useMemo(
     () => (availableHeroes || []).filter((hero) => {
       const season = seasonHeroMetadata[hero]?.season;
+      // S1–S3 unlock heroes cumulatively; S4+ unlocks every hero season.
       return (
         !activeOfferItems.has(hero) &&
-        (selectedSeason === null || season === undefined || season <= selectedSeason)
+        (selectedSeason === null || selectedSeason >= 4 || season === undefined || season <= selectedSeason)
       );
     }),
     [activeOfferItems, availableHeroes, seasonHeroMetadata, selectedSeason],

--- a/web/src/components/game/__tests__/CurrentTeam.test.tsx
+++ b/web/src/components/game/__tests__/CurrentTeam.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
 import CurrentTeam from '../CurrentTeam';
 
@@ -210,6 +211,76 @@ describe('CurrentTeam support actions', () => {
       ['坚壁清野', '清风驱疾'],
       expect.any(Array),
       expect.any(Array),
+      expect.anything(),
+      2,
+    );
+  });
+
+  test.each([
+    { season: 1, expected: ['曹操'] },
+    { season: 2, expected: ['曹操', '孙权'] },
+    { season: 3, expected: ['曹操', '孙权', '周瑜'] },
+    { season: 4, expected: ['曹操', '孙权', '周瑜', '司马懿', '陆逊', '姜维'] },
+    { season: 5, expected: ['曹操', '孙权', '周瑜', '司马懿', '陆逊', '姜维'] },
+    { season: 7, expected: ['曹操', '孙权', '周瑜', '司马懿', '陆逊', '姜维'] },
+  ])('uses the cumulative S1–S3 / unrestricted S4+ hero pool in S$season', ({ season, expected }) => {
+    mocks.state.selectedSeason = season;
+    mocks.state.currentRoundInputs = { set1: ['袁绍'], set2: [], set3: [] };
+    const seasonMetadata = {
+      曹操: { season: 1 },
+      孙权: { season: 2 },
+      周瑜: { season: 3 },
+      司马懿: { season: 4 },
+      陆逊: { season: 5 },
+      姜维: { season: 16 },
+      袁绍: { season: 1 },
+    };
+    render(team({
+      availableHeroes: [...heroes, ...Object.keys(seasonMetadata)],
+      heroMetadata: seasonMetadata,
+    }));
+
+    fireEvent.click(screen.getByRole('button', { name: '推荐支援武将' }));
+
+    // Exact candidates also prove owned heroes and active offers stay excluded.
+    expect(mocks.recommendSingleHero).toHaveBeenCalledWith(
+      expected,
+      heroes,
+      skills,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test.each([4, 7])('allows searching and selecting a later-season support hero in S%i', async (season) => {
+    mocks.state.selectedSeason = season;
+    render(team({
+      availableHeroes: [...availableHeroes, '姜维'],
+      heroMetadata: { 曹操: { season: 1 }, 姜维: { season: 16 } },
+    }));
+    fireEvent.click(screen.getByRole('button', { name: '推荐支援武将' }));
+    await userEvent.type(screen.getByLabelText('搜索武将...'), '姜维');
+    fireEvent.click(await screen.findByRole('option', { name: /^姜维/ }));
+    fireEvent.click(screen.getByRole('button', { name: '设为支援武将' }));
+
+    expect(mocks.dispatch).toHaveBeenCalledWith({ type: 'SET_SUPPORT_HERO', hero: '姜维' });
+  });
+
+  test.each([4, 7])('keeps support tactics season-limited in S%i', (season) => {
+    mocks.state.selectedSeason = season;
+    render(team({
+      skillMetadata: {
+        百战不殆: { season: 1 },
+        坚壁清野: { season: 4 },
+        清风驱疾: { season: 16 },
+      },
+    }));
+    fireEvent.click(screen.getAllByRole('button', { name: '推荐支援战法' })[0]);
+
+    expect(mocks.recommendTwoSkills).toHaveBeenCalledWith(
+      ['百战不殆', '坚壁清野'],
+      heroes,
+      skills,
       expect.anything(),
       2,
     );

--- a/web/src/components/game/__tests__/CurrentTeam.test.tsx
+++ b/web/src/components/game/__tests__/CurrentTeam.test.tsx
@@ -243,13 +243,13 @@ describe('CurrentTeam support actions', () => {
     fireEvent.click(screen.getByRole('button', { name: '推荐支援武将' }));
 
     // Exact candidates also prove owned heroes and active offers stay excluded.
-    expect(mocks.recommendSingleHero).toHaveBeenCalledWith(
+    // Limit diagnostics to the pools instead of dumping the entire model.
+    expect(mocks.recommendSingleHero).toHaveBeenCalledTimes(1);
+    expect(mocks.recommendSingleHero.mock.calls[0].slice(0, 3)).toEqual([
       expected,
       heroes,
       skills,
-      expect.anything(),
-      expect.anything(),
-    );
+    ]);
   });
 
   test.each([4, 7])('allows searching and selecting a later-season support hero in S%i', async (season) => {

--- a/web/tests/seasonSelection.spec.js
+++ b/web/tests/seasonSelection.spec.js
@@ -19,6 +19,8 @@ const olderSeason = 3;
 
 const futureHeroes = heroEntries
   .filter(([, hero]) => hero.season > olderSeason)
+  // Keep the latest-season heroes independent of setup and active offers.
+  .sort(([, a], [, b]) => a.season - b.season)
   .map(([name]) => name);
 const eligibleHeroes = heroEntries
   .filter(([, hero]) => hero.season <= olderSeason)
@@ -54,20 +56,11 @@ const futureRoundHero = futureHeroes.find(
 const futureSupportHero = futureHeroes.find(
   (hero) => !setupHeroes.includes(hero) && hero !== futureRoundHero
 );
-const futureSupportSkill = futureRegularSkills.find(
-  (skill) => !setupSkills.includes(skill)
-);
-const eligibleSupportHero = eligibleHeroes.find(
-  (hero) => !setupHeroes.includes(hero)
-);
-const eligibleSupportSkill = eligibleOrangeSkills.find(
-  (skill) => !setupSkills.includes(skill)
-);
 
 async function chooseSeason(page, season) {
   const selector = page.getByRole('combobox', { name: '当前赛季' });
   await selector.click();
-  await page.getByRole('option', { name: `赛季 ${season}` }).click();
+  await page.getByRole('option', { name: `赛季 ${season}`, exact: true }).click();
   await expect(selector).toHaveText(`赛季 ${season}`);
 }
 
@@ -85,7 +78,37 @@ async function selectSetupItems(page) {
   }
 }
 
+async function capture(page, testInfo, name) {
+  const path = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({ path, fullPage: true, animations: 'disabled' });
+  await testInfo.attach(name, { path, contentType: 'image/png' });
+}
+
+async function expectCandidateNames(dialog, expected) {
+  // Read the actual scored recommendation rows, not just the top suggestion.
+  const names = dialog.getByRole('list').locator('.MuiChip-label');
+  await expect(names).toHaveCount(expected.length);
+  expect((await names.allTextContents()).sort()).toEqual([...expected].sort());
+}
+
+async function checkSupportSkills(page, season, testInfo) {
+  const futureSkill = regularSkillEntries.find(
+    ([name, skill]) => skill.season > season && !setupSkills.includes(name)
+  )?.[0];
+  expect(futureSkill).toBeTruthy();
+  await page.getByRole('button', { name: '推荐支援战法' }).first().click();
+  const dialog = page.getByRole('dialog', { name: '推荐支援战法' });
+  await expectCandidateNames(dialog, regularSkillEntries
+    .filter(([name, skill]) => skill.season <= season && !setupSkills.includes(name))
+    .map(([name]) => name));
+  await dialog.getByLabel('搜索战法...').fill(futureSkill);
+  await expect(page.getByText('无匹配结果')).toBeVisible();
+  await capture(page, testInfo, `S${season}-blocks-S${database.skills[futureSkill].season}-tactic-${futureSkill}`);
+  await dialog.getByRole('button', { name: '关闭' }).click();
+}
+
 test.describe('Season selection', () => {
+  test.use({ viewport: { width: 1440, height: 1000 } });
   test('defaults to the latest database season and remembers changes', async ({
     page,
   }) => {
@@ -103,81 +126,19 @@ test.describe('Season selection', () => {
     ).toHaveText(`赛季 ${olderSeason}`);
   });
 
-  test('limits only support candidates while newer items remain enterable', async ({
-    page,
-  }) => {
-    expect(futureHeroes.length).toBeGreaterThanOrEqual(3);
-    expect(futureRegularSkills.length).toBeGreaterThanOrEqual(2);
-    expect(setupHeroes).toHaveLength(4);
-    expect(setupSkills).toHaveLength(8);
-    expect(futureRoundHero).toBeTruthy();
-    expect(futureSupportHero).toBeTruthy();
-    expect(futureSupportSkill).toBeTruthy();
-    expect(eligibleSupportHero).toBeTruthy();
-    expect(eligibleSupportSkill).toBeTruthy();
+  for (const season of [1, 2, 3]) {
+    test(`S${season} unlocks heroes cumulatively without limiting setup or round inputs`, async ({ page }, testInfo) => {
+      expect(setupHeroes).toHaveLength(4);
+      expect(setupSkills).toHaveLength(8);
+      expect(futureRoundHero).toBeTruthy();
+      expect(futureSupportHero).toBeTruthy();
 
-    await page.context().clearCookies();
-    await page.goto('/');
-    await expect(
-      page.getByRole('combobox', { name: '当前赛季' })
-    ).toBeVisible({ timeout: 30000 });
-    await chooseSeason(page, olderSeason);
-
-    // A newer-season hero and skill remain valid initial-setup entries.
-    await selectSetupItems(page);
-    await page.getByRole('button', { name: '开始对局' }).click();
-
-    await expect(page.getByText(`赛季 ${olderSeason}`, { exact: true })).toBeVisible();
-    await expect(
-      page.getByRole('heading', { level: 1, name: '第 1 轮：选择武将' }),
-    ).toHaveCount(1);
-
-    // Newer-season heroes also remain valid offered-set entries.
-    const roundInput = page.getByLabel('输入武将名或拼音搜索武将').first();
-    await roundInput.fill(futureRoundHero);
-    await expect(
-      page.getByRole('option', { name: futureRoundHero })
-    ).toBeVisible();
-    await page.getByRole('option', { name: futureRoundHero }).click();
-
-    // A different, unowned and unoffered newer-season hero is excluded by
-    // season alone, from both recommendations and manual support search.
-    await page.getByRole('button', { name: '推荐支援武将' }).click();
-    const heroDialog = page.getByRole('dialog');
-    await expect(heroDialog).toContainText(eligibleSupportHero);
-    await expect(
-      heroDialog.getByText(futureSupportHero, { exact: true })
-    ).toHaveCount(0);
-    const heroSearch = heroDialog.getByLabel('搜索武将...');
-    await heroSearch.fill(futureSupportHero);
-    await expect(page.getByText('无匹配结果')).toBeVisible();
-    await heroDialog.getByRole('button', { name: '关闭' }).click();
-
-    // Support skills use the same season boundary.
-    await page.getByRole('button', { name: '推荐支援战法' }).first().click();
-    const skillDialog = page.getByRole('dialog');
-    await expect(skillDialog).toContainText(eligibleSupportSkill);
-    await expect(
-      skillDialog.getByText(futureSupportSkill, { exact: true })
-    ).toHaveCount(0);
-    const skillSearch = skillDialog.getByLabel('搜索战法...');
-    await skillSearch.fill(futureSupportSkill);
-    await expect(page.getByText('无匹配结果')).toBeVisible();
-  });
-
-  for (const season of [4, 7]) {
-    test(`S${season} allows later-season support heroes but still excludes owned and offered heroes`, async ({ page }) => {
-      const laterHero = heroEntries.find(
-        ([name, hero]) => hero.season > season &&
-          !setupHeroes.includes(name) && name !== futureRoundHero
-      )?.[0];
-      expect(laterHero).toBeTruthy();
-
-      await page.context().clearCookies();
       await page.goto('/');
       await chooseSeason(page, season);
+      // Newer heroes and tactics remain valid initial-setup entries.
       await selectSetupItems(page);
       await page.getByRole('button', { name: '开始对局' }).click();
+      await expect(page.getByText(`赛季 ${season}`, { exact: true })).toBeVisible();
 
       const roundInput = page.getByLabel('输入武将名或拼音搜索武将').first();
       await roundInput.fill(futureRoundHero);
@@ -185,20 +146,124 @@ test.describe('Season selection', () => {
 
       await page.getByRole('button', { name: '推荐支援武将' }).click();
       const dialog = page.getByRole('dialog', { name: '推荐支援武将' });
-      await expect(dialog.getByText(laterHero, { exact: true }).first()).toBeVisible();
+      await expectCandidateNames(dialog, heroEntries
+        .filter(([name, hero]) => hero.season <= season && !setupHeroes.includes(name))
+        .map(([name]) => name));
+      const search = dialog.getByLabel('搜索武将...');
+      // This independent future hero is neither owned nor in an active offer.
+      await search.fill(futureSupportHero);
+      await expect(page.getByText('无匹配结果')).toBeVisible();
+      await capture(page, testInfo, `S${season}-blocks-future-hero-${futureSupportHero}`);
+
+      const recommendedHero = await dialog.getByRole('list').locator('.MuiChip-label').first().innerText();
+      // Check every cumulative boundary in manual search, not only S1.
+      for (let introduction = 1; introduction <= season + 1; introduction++) {
+        const witness = heroEntries.find(([name, hero]) =>
+          hero.season === introduction && !setupHeroes.includes(name) &&
+          name !== futureRoundHero && name !== recommendedHero)?.[0];
+        expect(witness).toBeTruthy();
+        await search.fill(witness);
+        if (introduction <= season) {
+          await expect(page.getByRole('option').filter({ has: page.getByText(witness, { exact: true }) })).toBeVisible();
+          if (introduction === season) await capture(page, testInfo, `S${season}-allows-boundary-hero-${witness}`);
+        } else {
+          await expect(page.getByText('无匹配结果')).toBeVisible();
+        }
+      }
+      await dialog.getByRole('button', { name: '关闭' }).click();
+      await checkSupportSkills(page, season, testInfo);
+
+      // CurrentTeam's ordinary editor deliberately shares the support pool.
+      await page.getByRole('button', { name: '编辑队伍' }).click();
+      await page.getByLabel('添加武将...').fill(futureSupportHero);
+      await expect(page.getByText('无匹配结果')).toBeVisible();
+      await page.getByRole('button', { name: '取消', exact: true }).click();
+
+      // Complete only the first draft round to also exercise unrestricted
+      // future-season tactic entry through the real round-2 UI.
+      const offered = [futureRoundHero, ...heroEntries
+        .map(([name]) => name)
+        .filter(name => !setupHeroes.includes(name) && name !== futureRoundHero)
+        .slice(0, 8)];
+      for (let index = 1; index < offered.length; index++) {
+        await page.getByLabel('输入武将名或拼音搜索武将').nth(Math.floor(index / 3)).fill(offered[index]);
+        await page.getByRole('option').filter({ has: page.getByText(offered[index], { exact: true }) }).click();
+      }
+      await page.getByRole('button', { name: '获取 AI 推荐' }).click();
+      await expect(page.getByText('推荐：第')).toBeVisible();
+      await page.getByRole('button', { name: '选择本组' }).first().click();
+      await page.getByRole('button', { name: '确认选择并进入下一轮' }).click();
+      const futureSkill = futureRegularSkills.find(name => !setupSkills.includes(name));
+      await page.getByLabel('输入战法名或拼音搜索战法').first().fill(futureSkill);
+      await page.getByRole('option').filter({ has: page.getByText(futureSkill, { exact: true }) }).click();
+      await expect(page.getByRole('heading', { level: 1, name: '第 2 轮：选择战法' })).toBeVisible();
+      await expect(page.getByTestId(`game-card-tactic-${futureSkill}`).first()).toBeVisible();
+      await capture(page, testInfo, `S${season}-future-tactic-in-normal-round`);
+    });
+  }
+
+  for (const season of [4, 5, 7]) {
+    test(`S${season} allows later-season support heroes but still excludes owned and offered heroes`, async ({ page }, testInfo) => {
+      // Use the latest hero season to prove that "all" is not capped at S4/S7.
+      const latestHeroSeason = Math.max(...heroEntries.map(([, hero]) => hero.season));
+      const laterHeroes = heroEntries.filter(([name, hero]) =>
+        hero.season === latestHeroSeason && !setupHeroes.includes(name) && name !== futureRoundHero
+      ).map(([name]) => name);
+      expect(latestHeroSeason).toBeGreaterThan(season);
+      expect(laterHeroes.length).toBeGreaterThanOrEqual(2);
+      const [laterHero, editorHero] = laterHeroes;
+
+      await page.goto('/');
+      await chooseSeason(page, season);
+      await selectSetupItems(page);
+      await page.getByRole('button', { name: '开始对局' }).click();
+      const roundInput = page.getByLabel('输入武将名或拼音搜索武将').first();
+      await roundInput.fill(futureRoundHero);
+      await page.getByRole('option', { name: futureRoundHero }).click();
+
+      await page.getByRole('button', { name: '推荐支援武将' }).click();
+      const dialog = page.getByRole('dialog', { name: '推荐支援武将' });
+      await expectCandidateNames(dialog, heroEntries
+        .filter(([name]) => !setupHeroes.includes(name) && name !== futureRoundHero)
+        .map(([name]) => name));
+      // Accept the actual engine suggestion before exercising manual search.
+      const recommendedHero = await dialog.getByRole('alert').locator('strong').innerText();
+      await dialog.getByRole('button', { name: '设为支援武将' }).click();
+      await expect(page.getByTestId(`game-card-hero-${recommendedHero}`).locator('..')).toContainText('★ 支援');
+      await capture(page, testInfo, `S${season}-auto-recommended-S${database.heroes[recommendedHero].season}-${recommendedHero}`);
+      await page.getByRole('button', { name: `移除${recommendedHero}`, exact: true }).click();
+      await page.getByRole('button', { name: '推荐支援武将' }).click();
       const search = dialog.getByLabel('搜索武将...');
       for (const excludedHero of [setupHeroes[0], futureRoundHero]) {
-        await expect(dialog.getByText(excludedHero, { exact: true })).toHaveCount(0);
         await search.fill(excludedHero);
         await expect(page.getByText('无匹配结果')).toBeVisible();
       }
+      await capture(page, testInfo, `S${season}-excludes-offered-hero-${futureRoundHero}`);
       await search.fill(laterHero);
-      await page.getByRole('option', { name: laterHero }).click();
+      const laterHeroOption = page.getByRole('option').filter({ has: page.getByText(laterHero, { exact: true }) });
+      await expect(laterHeroOption).toBeVisible();
+      await capture(page, testInfo, `S${season}-allows-S${latestHeroSeason}-hero-${laterHero}`);
+      await laterHeroOption.click();
       await dialog.getByRole('button', { name: '设为支援武将' }).click();
 
       const supportCard = page.getByTestId(`game-card-hero-${laterHero}`);
       await expect(supportCard).toBeVisible();
       await expect(supportCard.locator('..')).toContainText('★ 支援');
+      await checkSupportSkills(page, season, testInfo);
+
+      await page.getByRole('button', { name: '编辑队伍' }).click();
+      await page.getByLabel('添加武将...').fill(editorHero);
+      await page.getByRole('option').filter({ has: page.getByText(editorHero, { exact: true }) }).click();
+      await page.getByRole('button', { name: '保存修改' }).click();
+      await expect(page.getByTestId(`game-card-hero-${editorHero}`)).toBeVisible();
+
+      // Reload observes the application's writes, rather than injecting state.
+      await page.reload();
+      await expect(supportCard).toBeVisible();
+      await expect(supportCard.locator('..')).toContainText('★ 支援');
+      await expect(page.getByTestId(`game-card-hero-${editorHero}`)).toBeVisible();
+      await expect(page.getByTestId(`game-card-hero-${futureRoundHero}`).first()).toBeVisible();
+      await capture(page, testInfo, `S${season}-confirmed-S${latestHeroSeason}-support-after-reload`);
     });
   }
 });

--- a/web/tests/seasonSelection.spec.js
+++ b/web/tests/seasonSelection.spec.js
@@ -15,7 +15,7 @@ const maxSeason = Math.max(
   ...heroEntries.map(([, hero]) => hero.season),
   ...skillEntries.map(([, skill]) => skill.season)
 );
-const olderSeason = maxSeason - 1;
+const olderSeason = 3;
 
 const futureHeroes = heroEntries
   .filter(([, hero]) => hero.season > olderSeason)
@@ -50,6 +50,9 @@ const setupSkills = [
 ];
 const futureRoundHero = futureHeroes.find(
   (hero) => !setupHeroes.includes(hero)
+);
+const futureSupportHero = futureHeroes.find(
+  (hero) => !setupHeroes.includes(hero) && hero !== futureRoundHero
 );
 const futureSupportSkill = futureRegularSkills.find(
   (skill) => !setupSkills.includes(skill)
@@ -103,11 +106,12 @@ test.describe('Season selection', () => {
   test('limits only support candidates while newer items remain enterable', async ({
     page,
   }) => {
-    expect(futureHeroes.length).toBeGreaterThanOrEqual(2);
+    expect(futureHeroes.length).toBeGreaterThanOrEqual(3);
     expect(futureRegularSkills.length).toBeGreaterThanOrEqual(2);
     expect(setupHeroes).toHaveLength(4);
     expect(setupSkills).toHaveLength(8);
     expect(futureRoundHero).toBeTruthy();
+    expect(futureSupportHero).toBeTruthy();
     expect(futureSupportSkill).toBeTruthy();
     expect(eligibleSupportHero).toBeTruthy();
     expect(eligibleSupportSkill).toBeTruthy();
@@ -136,16 +140,16 @@ test.describe('Season selection', () => {
     ).toBeVisible();
     await page.getByRole('option', { name: futureRoundHero }).click();
 
-    // The same newer-season hero is absent from both support recommendation
-    // results and manual support search, while an eligible hero remains.
+    // A different, unowned and unoffered newer-season hero is excluded by
+    // season alone, from both recommendations and manual support search.
     await page.getByRole('button', { name: '推荐支援武将' }).click();
     const heroDialog = page.getByRole('dialog');
     await expect(heroDialog).toContainText(eligibleSupportHero);
     await expect(
-      heroDialog.getByText(futureRoundHero, { exact: true })
+      heroDialog.getByText(futureSupportHero, { exact: true })
     ).toHaveCount(0);
     const heroSearch = heroDialog.getByLabel('搜索武将...');
-    await heroSearch.fill(futureRoundHero);
+    await heroSearch.fill(futureSupportHero);
     await expect(page.getByText('无匹配结果')).toBeVisible();
     await heroDialog.getByRole('button', { name: '关闭' }).click();
 
@@ -160,4 +164,41 @@ test.describe('Season selection', () => {
     await skillSearch.fill(futureSupportSkill);
     await expect(page.getByText('无匹配结果')).toBeVisible();
   });
+
+  for (const season of [4, 7]) {
+    test(`S${season} allows later-season support heroes but still excludes owned and offered heroes`, async ({ page }) => {
+      const laterHero = heroEntries.find(
+        ([name, hero]) => hero.season > season &&
+          !setupHeroes.includes(name) && name !== futureRoundHero
+      )?.[0];
+      expect(laterHero).toBeTruthy();
+
+      await page.context().clearCookies();
+      await page.goto('/');
+      await chooseSeason(page, season);
+      await selectSetupItems(page);
+      await page.getByRole('button', { name: '开始对局' }).click();
+
+      const roundInput = page.getByLabel('输入武将名或拼音搜索武将').first();
+      await roundInput.fill(futureRoundHero);
+      await page.getByRole('option', { name: futureRoundHero }).click();
+
+      await page.getByRole('button', { name: '推荐支援武将' }).click();
+      const dialog = page.getByRole('dialog', { name: '推荐支援武将' });
+      await expect(dialog.getByText(laterHero, { exact: true }).first()).toBeVisible();
+      const search = dialog.getByLabel('搜索武将...');
+      for (const excludedHero of [setupHeroes[0], futureRoundHero]) {
+        await expect(dialog.getByText(excludedHero, { exact: true })).toHaveCount(0);
+        await search.fill(excludedHero);
+        await expect(page.getByText('无匹配结果')).toBeVisible();
+      }
+      await search.fill(laterHero);
+      await page.getByRole('option', { name: laterHero }).click();
+      await dialog.getByRole('button', { name: '设为支援武将' }).click();
+
+      const supportCard = page.getByTestId(`game-card-hero-${laterHero}`);
+      await expect(supportCard).toBeVisible();
+      await expect(supportCard.locator('..')).toContainText('★ 支援');
+    });
+  }
 });


### PR DESCRIPTION
## Intent

用户要求：在 ./web 中支援武将取决于玩家的赛季，S1 只有 S1 的武将，S2 有 S1 和 S2 的武将，以此类推到 S3；从 S4 开始，支援武将应该全部可以选择，包括 S4 和 S4 以上所有赛季，也保留较早赛季武将。用户已明确批准方案：S1–S3 按介绍赛季累计开放，S4 及以后所有赛季支援武将开放，自动推荐和手动搜索使用相同规则；仍排除已拥有和当前候选组中的武将。本次仅调整武将，支援战法保持原来的介绍赛季不晚于玩家赛季限制，初始设置和常规回合输入继续不限赛季。保留 CurrentTeam 中支援和当前阵容手动添加武将共用候选池的现有结构，不改推荐评分、存档或数据库；规则文档同步更新。补充行为单元测试和 E2E，尤其验证 S1/S2/S3 的累计边界与 S4/S5/S7 可选后续赛季武将、支援战法限制不变、已拥有和当前候选组排除仍有效；原 E2E 改用独立未拥有未提供的未来武将，避免将候选组排除误判成赛季限制。修改前回归用例复现了筛选问题；本地已通过 pnpm typecheck、pnpm test（597 测试）、pnpm test:e2e（82 开发 E2E + 20 生产预渲染 E2E）和 pnpm build。此变更仅涉及 web 运行时代码和规则文档，按 DEVELOPMENT.md/web/AGENTS.md 仅跑 web 验证，不跑不相关的 Python/PaddleOCR/agent 测试。整个 no-mistakes CLI 和 daemon 的遥测均已关闭；完成验证、推送、创建 PR 和 CI 后停在 checks-passed，留给用户审查合并。

## What Changed
- Allow heroes from every season at S4+ while retaining cumulative S1–S3 availability in the shared pool for support recommendations, manual support search, and roster additions. Keep owned and active-offer heroes excluded.
- Expand unit and E2E coverage for S1/S2/S3 boundaries, S4/S5/S7 future-hero selection, unchanged support-tactic limits, and unrestricted setup/round inputs. Use independent future heroes to distinguish season filtering from offer exclusions.
- Update `GAME_RULE.md` and `web/README.md` to document hero eligibility and the shared roster-addition rules.

## Risk Assessment

✅ Low: The bounded shared-pool change implements cumulative S1–S3 and unrestricted S4+ hero availability while preserving tactic restrictions, owned/offer exclusions, scoring, and persistence.

## Testing

Baseline and strengthened targeted tests passed after resolving local runner setup and test-fixture issues. Base-commit replay reproduced the regression; browser workflows and inspected screenshots demonstrated the required season rules, automatic/manual support selection, exclusions, unchanged tactic limits, unrestricted ordinary inputs, and persistence.

<details>
<summary>Evidence: Complete visual evidence gallery: S1/S2/S3/S4/S5/S7 workflows</summary>

```text
<!doctype html><html lang="zh-CN"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>支援武将赛季规则 — 浏览器证据</title><style>body{font:16px/1.6 system-ui,sans-serif;background:#f6f2e7;color:#263b34;margin:32px auto;max-width:1500px;padding:0 24px}header{background:#fffdf7;padding:24px;border:1px solid #cbbda2}nav a{margin-right:20px;color:#365f51}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(380px,1fr));gap:20px}figure{margin:0;background:#fffdf7;border:1px solid #cbbda2;padding:12px}figcaption{font-weight:650;margin-bottom:12px}img{width:100%;height:auto}code{overflow-wrap:anywhere}h2{margin-top:42px}</style><header><h1>支援武将赛季规则 — 浏览器证据</h1><p>真实本地 React 页面；通过初始设置、推荐弹窗、手动搜索、确认支援及刷新完成操作，无预置存档或推荐 API mock。点击图片查看完整尺寸。</p><p>S1/S2/S3：累计开放，并验证下一赛季边界。S4/S5/S7：完整推荐列表包含各赛季未拥有且未提供的武将，自动推荐和手动搜索均可确认；支援战法仍受介绍赛季限制。初始设置和常规回合输入仍不限赛季，CurrentTeam 的手动添加继续使用共用候选池。</p><p>数据见实际目录：于吉为 S4；刘禅、糜夫人与暗渡阴平为 S16；诸葛亮2 为 S8。支援成功后的截图保留当前赛季标识、★ 支援标记及原候选组。</p><p>验证入口：<code>cd web &amp;&amp; ./node_modules/.bin/playwright test tests/seasonSelection.spec.js --workers=1 --reporter=line --output=~/.no-mistakes/evidence/01M22R620VSXEN2FBMT00G0KVV/season-matrix</code></p><nav><a href="#s1">S1</a><a href="#s2">S2</a><a href="#s3">S3</a><a href="#s4">S4</a><a href="#s5">S5</a><a href="#s7">S7</a></nav></header><section id="s1"><h2>S1 — 累计开放 S1–S1 武将</h2><div class="grid"><figure><figcaption>S1：本赛季边界武将可搜索 — 曹操</figcaption><a href="season-matrix/seasonSelection-Season-sel-2f93a-iting-setup-or-round-inputs/S1-allows-boundary-hero-%E6%9B%B9%E6%93%8D.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-2f93a-iting-setup-or-round-inputs/S1-allows-boundary-hero-%E6%9B%B9%E6%93%8D.png" alt="S1：本赛季边界武将可搜索 — 曹操"></a></figure><figure><figcaption>S1：支援战法仍排除 S16 暗渡阴平</figcaption><a href="season-matrix/seasonSelection-Season-sel-2f93a-iting-setup-or-round-inputs/S1-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-2f93a-iting-setup-or-round-inputs/S1-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png" alt="S1：支援战法仍排除 S16 暗渡阴平"></a></figure><figure><figcaption>S1：未拥有、未提供的 S4 于吉仍不可选</figcaption><a href="season-matrix/seasonSelection-Season-sel-2f93a-iting-setup-or-round-inputs/S1-blocks-future-hero-%E4%BA%8E%E5%90%89.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-2f93a-iting-setup-or-round-inputs/S1-blocks-future-hero-%E4%BA%8E%E5%90%89.png" alt="S1：未拥有、未提供的 S4 于吉仍不可选"></a></figure><figure><figcaption>S1：常规第二轮仍可输入 S16 暗渡阴平</figcaption><a href="season-matrix/seasonSelection-Season-sel-2f93a-iting-setup-or-round-inputs/S1-future-tactic-in-normal-round.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-2f93a-iting-setup-or-round-inputs/S1-future-tactic-in-normal-round.png" alt="S1：常规第二轮仍可输入 S16 暗渡阴平"></a></figure></div></section><section id="s2"><h2>S2 — 累计开放 S1–S2 武将</h2><div class="grid"><figure><figcaption>S2：本赛季边界武将可搜索 — 贾诩</figcaption><a href="season-matrix/seasonSelection-Season-sel-00c69-iting-setup-or-round-inputs/S2-allows-boundary-hero-%E8%B4%BE%E8%AF%A9.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-00c69-iting-setup-or-round-inputs/S2-allows-boundary-hero-%E8%B4%BE%E8%AF%A9.png" alt="S2：本赛季边界武将可搜索 — 贾诩"></a></figure><figure><figcaption>S2：支援战法仍排除 S16 暗渡阴平</figcaption><a href="season-matrix/seasonSelection-Season-sel-00c69-iting-setup-or-round-inputs/S2-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-00c69-iting-setup-or-round-inputs/S2-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png" alt="S2：支援战法仍排除 S16 暗渡阴平"></a></figure><figure><figcaption>S2：未拥有、未提供的 S4 于吉仍不可选</figcaption><a href="season-matrix/seasonSelection-Season-sel-00c69-iting-setup-or-round-inputs/S2-blocks-future-hero-%E4%BA%8E%E5%90%89.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-00c69-iting-setup-or-round-inputs/S2-blocks-future-hero-%E4%BA%8E%E5%90%89.png" alt="S2：未拥有、未提供的 S4 于吉仍不可选"></a></figure><figure><figcaption>S2：常规第二轮仍可输入 S16 暗渡阴平</figcaption><a href="season-matrix/seasonSelection-Season-sel-00c69-iting-setup-or-round-inputs/S2-future-tactic-in-normal-round.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-00c69-iting-setup-or-round-inputs/S2-future-tactic-in-normal-round.png" alt="S2：常规第二轮仍可输入 S16 暗渡阴平"></a></figure></div></section><section id="s3"><h2>S3 — 累计开放 S1–S3 武将</h2><div class="grid"><figure><figcaption>S3：本赛季边界武将可搜索 — 甘夫人</figcaption><a href="season-matrix/seasonSelection-Season-sel-72d38-iting-setup-or-round-inputs/S3-allows-boundary-hero-%E7%94%98%E5%A4%AB%E4%BA%BA.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-72d38-iting-setup-or-round-inputs/S3-allows-boundary-hero-%E7%94%98%E5%A4%AB%E4%BA%BA.png" alt="S3：本赛季边界武将可搜索 — 甘夫人"></a></figure><figure><figcaption>S3：支援战法仍排除 S16 暗渡阴平</figcaption><a href="season-matrix/seasonSelection-Season-sel-72d38-iting-setup-or-round-inputs/S3-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-72d38-iting-setup-or-round-inputs/S3-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png" alt="S3：支援战法仍排除 S16 暗渡阴平"></a></figure><figure><figcaption>S3：未拥有、未提供的 S4 于吉仍不可选</figcaption><a href="season-matrix/seasonSelection-Season-sel-72d38-iting-setup-or-round-inputs/S3-blocks-future-hero-%E4%BA%8E%E5%90%89.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-72d38-iting-setup-or-round-inputs/S3-blocks-future-hero-%E4%BA%8E%E5%90%89.png" alt="S3：未拥有、未提供的 S4 于吉仍不可选"></a></figure><figure><figcaption>S3：常规第二轮仍可输入 S16 暗渡阴平</figcaption><a href="season-matrix/seasonSelection-Season-sel-72d38-iting-setup-or-round-inputs/S3-future-tactic-in-normal-round.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-72d38-iting-setup-or-round-inputs/S3-future-tactic-in-normal-round.png" alt="S3：常规第二轮仍可输入 S16 暗渡阴平"></a></figure></div></section><section id="s4"><h2>S4 — 所有赛季武将开放，战法维持原限制</h2><div class="grid"><figure><figcaption>S4：手动搜索可选 S16 刘禅</figcaption><a href="season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-allows-S16-hero-%E5%88%98%E7%A6%85.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-allows-S16-hero-%E5%88%98%E7%A6%85.png" alt="S4：手动搜索可选 S16 刘禅"></a></figure><figure><figcaption>S4：接受真实自动推荐，S8 诸葛亮2 标记为支援</figcaption><a href="season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-auto-recommended-S8-%E8%AF%B8%E8%91%9B%E4%BA%AE2.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-auto-recommended-S8-%E8%AF%B8%E8%91%9B%E4%BA%AE2.png" alt="S4：接受真实自动推荐，S8 诸葛亮2 标记为支援"></a></figure><figure><figcaption>S4：支援战法仍排除 S16 暗渡阴平</figcaption><a href="season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png" alt="S4：支援战法仍排除 S16 暗渡阴平"></a></figure><figure><figcaption>S4：刷新后保留 S16 刘禅支援及手动添加的糜夫人</figcaption><a href="season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-confirmed-S16-support-after-reload.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-confirmed-S16-support-after-reload.png" alt="S4：刷新后保留 S16 刘禅支援及手动添加的糜夫人"></a></figure><figure><figcaption>S4：当前候选组中的关银屏不可重复作为支援</figcaption><a href="season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-excludes-offered-hero-%E5%85%B3%E9%93%B6%E5%B1%8F.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-excludes-offered-hero-%E5%85%B3%E9%93%B6%E5%B1%8F.png" alt="S4：当前候选组中的关银屏不可重复作为支援"></a></figure></div></section><section id="s5"><h2>S5 — 所有赛季武将开放，战法维持原限制</h2><div class="grid"><figure><figcaption>S5：手动搜索可选 S16 刘禅</figcaption><a href="season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-allows-S16-hero-%E5%88%98%E7%A6%85.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-allows-S16-hero-%E5%88%98%E7%A6%85.png" alt="S5：手动搜索可选 S16 刘禅"></a></figure><figure><figcaption>S5：接受真实自动推荐，S8 诸葛亮2 标记为支援</figcaption><a href="season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-auto-recommended-S8-%E8%AF%B8%E8%91%9B%E4%BA%AE2.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-auto-recommended-S8-%E8%AF%B8%E8%91%9B%E4%BA%AE2.png" alt="S5：接受真实自动推荐，S8 诸葛亮2 标记为支援"></a></figure><figure><figcaption>S5：支援战法仍排除 S16 暗渡阴平</figcaption><a href="season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png" alt="S5：支援战法仍排除 S16 暗渡阴平"></a></figure><figure><figcaption>S5：刷新后保留 S16 刘禅支援及手动添加的糜夫人</figcaption><a href="season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-confirmed-S16-support-after-reload.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-confirmed-S16-support-after-reload.png" alt="S5：刷新后保留 S16 刘禅支援及手动添加的糜夫人"></a></figure><figure><figcaption>S5：当前候选组中的关银屏不可重复作为支援</figcaption><a href="season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-excludes-offered-hero-%E5%85%B3%E9%93%B6%E5%B1%8F.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-excludes-offered-hero-%E5%85%B3%E9%93%B6%E5%B1%8F.png" alt="S5：当前候选组中的关银屏不可重复作为支援"></a></figure></div></section><section id="s7"><h2>S7 — 所有赛季武将开放，战法维持原限制</h2><div class="grid"><figure><figcaption>S7：手动搜索可选 S16 刘禅</figcaption><a href="season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-allows-S16-hero-%E5%88%98%E7%A6%85.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-allows-S16-hero-%E5%88%98%E7%A6%85.png" alt="S7：手动搜索可选 S16 刘禅"></a></figure><figure><figcaption>S7：接受真实自动推荐，S8 诸葛亮2 标记为支援</figcaption><a href="season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-auto-recommended-S8-%E8%AF%B8%E8%91%9B%E4%BA%AE2.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-auto-recommended-S8-%E8%AF%B8%E8%91%9B%E4%BA%AE2.png" alt="S7：接受真实自动推荐，S8 诸葛亮2 标记为支援"></a></figure><figure><figcaption>S7：支援战法仍排除 S16 暗渡阴平</figcaption><a href="season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-blocks-S16-tactic-%E6%9A%97%E6%B8%A1%E9%98%B4%E5%B9%B3.png" alt="S7：支援战法仍排除 S16 暗渡阴平"></a></figure><figure><figcaption>S7：刷新后保留 S16 刘禅支援及手动添加的糜夫人</figcaption><a href="season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-confirmed-S16-support-after-reload.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-confirmed-S16-support-after-reload.png" alt="S7：刷新后保留 S16 刘禅支援及手动添加的糜夫人"></a></figure><figure><figcaption>S7：当前候选组中的关银屏不可重复作为支援</figcaption><a href="season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-excludes-offered-hero-%E5%85%B3%E9%93%B6%E5%B1%8F.png"><img loading="lazy" src="season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-excludes-offered-hero-%E5%85%B3%E9%93%B6%E5%B1%8F.png" alt="S7：当前候选组中的关银屏不可重复作为支援"></a></figure></div></section></html>
```
</details>

- Evidence: S1: S1 hero 曹操 remains searchable (local file: <code>~/.no-mistakes/evidence/01M22R620VSXEN2FBMT00G0KVV/season-matrix/seasonSelection-Season-sel-2f93a-iting-setup-or-round-inputs/S1-allows-boundary-hero-曹操.png</code>)
- Evidence: S2: cumulative availability includes S2 hero 贾诩 (local file: <code>~/.no-mistakes/evidence/01M22R620VSXEN2FBMT00G0KVV/season-matrix/seasonSelection-Season-sel-00c69-iting-setup-or-round-inputs/S2-allows-boundary-hero-贾诩.png</code>)
- Evidence: S3: independent, unowned S4 hero 于吉 is excluded (local file: <code>~/.no-mistakes/evidence/01M22R620VSXEN2FBMT00G0KVV/season-matrix/seasonSelection-Season-sel-72d38-iting-setup-or-round-inputs/S3-blocks-future-hero-于吉.png</code>)
- Evidence: S4: actual automatic recommendation accepts S8 诸葛亮2 as support (local file: <code>~/.no-mistakes/evidence/01M22R620VSXEN2FBMT00G0KVV/season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-auto-recommended-S8-诸葛亮2.png</code>)
- Evidence: S5: manually selected S16 刘禅 support survives reload (local file: <code>~/.no-mistakes/evidence/01M22R620VSXEN2FBMT00G0KVV/season-matrix/seasonSelection-Season-sel-0f535-es-owned-and-offered-heroes/S5-confirmed-S16-support-after-reload.png</code>)
- Evidence: S7: S16 support and shared-pool roster addition survive reload (local file: <code>~/.no-mistakes/evidence/01M22R620VSXEN2FBMT00G0KVV/season-matrix/seasonSelection-Season-sel-0c230-es-owned-and-offered-heroes/S7-confirmed-S16-support-after-reload.png</code>)
- Evidence: S4: S16 support tactic 暗渡阴平 remains unavailable (local file: <code>~/.no-mistakes/evidence/01M22R620VSXEN2FBMT00G0KVV/season-matrix/seasonSelection-Season-sel-e5971-es-owned-and-offered-heroes/S4-blocks-S16-tactic-暗渡阴平.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d24eaac7877e10edf01c1248174cd681c71c2a58","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 134e49843b31dfbda8dec72857f4673599021d42 45a5da888e1a336331165fb4db6fc0d793ef1e8b` against the approved intent and updated rule documentation.</code>
- <code>Installed worktree-local dependencies with `cd web &amp;&amp; pnpm install --frozen-lockfile --config.enableGlobalVirtualStore=false --store-dir &#34;$PWD/.pnpm-store&#34; --cache-dir &#34;$PWD/.pnpm-cache&#34;`. Initial `pnpm exec` attempts encountered automatic-reinstall configuration conflicts; subsequent tests used the installed local binaries.</code>
- <code>Ran baseline and final component tests: `cd web &amp;&amp; ./node_modules/.bin/vitest run src/components/game/__tests__/CurrentTeam.test.tsx`.</code>
- <code>Ran baseline browser tests: `cd web &amp;&amp; ./node_modules/.bin/playwright test tests/seasonSelection.spec.js --workers=1 --reporter=line --output=~/.no-mistakes/evidence/01M22R620VSXEN2FBMT00G0KVV/baseline-playwright`.</code>
- <code>Replayed the base commit&#39;s CurrentTeam through a temporary Vitest alias: `cd web &amp;&amp; ./node_modules/.bin/vitest run --config vitest.regression.config.mjs src/components/game/__tests__/CurrentTeam.test.tsx -t &#39;uses the cumulative&#39;`. The original component failed the S4/S5/S7 expectations as intended; the target component passed.</code>
- <code>Ran the strengthened browser matrix: `cd web &amp;&amp; ./node_modules/.bin/playwright test tests/seasonSelection.spec.js --workers=1 --reporter=line --output=~/.no-mistakes/evidence/01M22R620VSXEN2FBMT00G0KVV/season-matrix`. Exercised S1/S2/S3 cumulative boundaries, S4/S5/S7 complete recommendation pools, automatic acceptance, manual S16 support selection, owned/offered exclusions, unchanged tactic limits, shared roster editing, unrestricted setup/round inputs, and reload persistence.</code>
- <code>Captured actual pages with `page.screenshot({ path, fullPage: true, animations: &#39;disabled&#39; })`, inspected representative screenshots, and rendered the evidence gallery in Chromium while verifying every linked image decoded.</code>
- `Stopped the local Vite server and removed temporary regression fixtures, installed dependencies, and pnpm caches. No linters, static analysis, full suites, or other gate phases were run.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
